### PR TITLE
[DX-1786] (fix) Enforce eslint warnings, bandaid starkex module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "NODE_ENV=production rollup --config rollup.config.js",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts --max-warnings=0"
   },
   "repository": {
     "type": "git",

--- a/src/modules/apis/starkex/index.ts
+++ b/src/modules/apis/starkex/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { ImmutableX, Config } from '@imtbl/core-sdk';
 
 const imtblClient = new ImmutableX(Config.SANDBOX);


### PR DESCRIPTION
This PR ensures that we enforce ESLint warnings, similar to the original Core SDK. It also ignores a certain files ESLint complaints as it is a temporary solution - and is bloating other PRs.