### PR TITLE
[ID-409] changed withPassportError function to allow only error type as second params

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@rollup/plugin-typescript": "^11.0.0",
     "@swc/core": "^1.3.36",
     "@swc/jest": "^0.2.24",
+    "@types/axios": "^0.14.0",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.14.2",
     "eslint": "^8.34.0",
@@ -53,7 +54,6 @@
     "prettier": "2.8.4",
     "rollup": "^3.17.2",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5",
-    "@types/axios": "^0.14.0"
+    "typescript": "^4.9.5"
   }
 }

--- a/src/modules/passport/authManager.ts
+++ b/src/modules/passport/authManager.ts
@@ -38,7 +38,7 @@ export default class AuthManager {
 
   private mapOidcUserToDomainModel = (oidcUser: OidcUser): User => {
     const passport = oidcUser.profile?.passport as PassportMetadata;
-    return ({
+    return {
       idToken: oidcUser.id_token,
       accessToken: oidcUser.access_token,
       refreshToken: oidcUser.refresh_token,
@@ -47,25 +47,21 @@ export default class AuthManager {
         email: oidcUser.profile.email,
         nickname: oidcUser.profile.nickname,
       },
-      etherKey: passport?.ether_key || ""
-    });
+      etherKey: passport?.ether_key || '',
+    };
   };
 
   public async login(): Promise<User> {
     return withPassportError<User>(async () => {
       const oidcUser = await this.userManager.signinPopup();
       return this.mapOidcUserToDomainModel(oidcUser);
-    }, {
-      type: PassportErrorType.AUTHENTICATION_ERROR,
-    });
+    }, PassportErrorType.AUTHENTICATION_ERROR);
   }
 
   public async loginCallback(): Promise<void> {
     return withPassportError<void>(
       async () => this.userManager.signinPopupCallback(),
-      {
-        type: PassportErrorType.AUTHENTICATION_ERROR,
-      }
+      PassportErrorType.AUTHENTICATION_ERROR
     );
   }
 
@@ -76,14 +72,16 @@ export default class AuthManager {
         throw new Error('Failed to retrieve user');
       }
       return this.mapOidcUserToDomainModel(oidcUser);
-    }, {
-      type: PassportErrorType.NOT_LOGGED_IN_ERROR,
-    });
+    }, PassportErrorType.NOT_LOGGED_IN_ERROR);
   }
 
-  public async requestRefreshTokenAfterRegistration(jwt: string): Promise<User | null> {
+  public async requestRefreshTokenAfterRegistration(
+    jwt: string
+  ): Promise<User | null> {
     return withPassportError<User | null>(async () => {
-      const etherKey = await retryWithDelay(() => getUserEtherKeyFromMetadata(passportAuthDomain, jwt));
+      const etherKey = await retryWithDelay(() =>
+        getUserEtherKeyFromMetadata(passportAuthDomain, jwt)
+      );
       const updatedUser = await this.userManager.signinSilent();
       if (!updatedUser) {
         return null;
@@ -91,8 +89,6 @@ export default class AuthManager {
       const user = this.mapOidcUserToDomainModel(updatedUser);
       user.etherKey = etherKey;
       return user;
-    }, {
-      type: PassportErrorType.REFRESH_TOKEN_ERROR,
-    });
+    }, PassportErrorType.REFRESH_TOKEN_ERROR);
   }
 }

--- a/src/modules/passport/errors/passportError.test.ts
+++ b/src/modules/passport/errors/passportError.test.ts
@@ -14,9 +14,9 @@ describe('passportError', () => {
       anyFn.mockReturnValue(returnValue);
 
       await expect(
-        await withPassportError(anyFn, {
-          type: PassportErrorType.AUTHENTICATION_ERROR,
-        })
+        await withPassportError(anyFn, 
+          PassportErrorType.AUTHENTICATION_ERROR,
+        )
       ).toEqual(returnValue);
     });
 
@@ -25,9 +25,9 @@ describe('passportError', () => {
       errorFunction.mockRejectedValue(new Error('SOMETHINGWRONG'));
 
       await expect(
-        withPassportError(errorFunction, {
-          type: PassportErrorType.AUTHENTICATION_ERROR,
-        })
+        withPassportError(errorFunction, 
+          PassportErrorType.AUTHENTICATION_ERROR,
+        )
       ).rejects.toThrow(
         new PassportError(
           'AUTHENTICATION_ERROR: SOMETHINGWRONG',

--- a/src/modules/passport/errors/passportError.ts
+++ b/src/modules/passport/errors/passportError.ts
@@ -6,11 +6,6 @@ export enum PassportErrorType {
   REFRESH_TOKEN_ERROR = 'REFRESH_TOKEN_ERROR',
 }
 
-type ErrorType = {
-  type: PassportErrorType;
-  message?: string;
-};
-
 export class PassportError extends Error {
   public type: PassportErrorType;
   constructor(message: string, type: PassportErrorType) {
@@ -21,15 +16,14 @@ export class PassportError extends Error {
 
 export const withPassportError = async <T>(
   fn: () => Promise<T>,
-  customError: ErrorType
+  customErrorType: PassportErrorType
 ): Promise<T> => {
   try {
     return await fn();
   } catch (error) {
     const errorMessage =
-      customError.message ||
-      `${customError.type}: ${(error as Error).message}` ||
+      `${customErrorType}: ${(error as Error).message}` ||
       'UnknownError';
-    throw new PassportError(errorMessage, customError.type);
+    throw new PassportError(errorMessage, customErrorType);
   }
 }

--- a/src/modules/passport/magicAdapter.ts
+++ b/src/modules/passport/magicAdapter.ts
@@ -14,9 +14,7 @@ export default class MagicAdapter {
   constructor(network: Networks = 'mainnet') {
     this.magicClient = new Magic(magicApiKey, {
       network,
-      extensions: [
-        new OpenIdExtension(),
-      ]
+      extensions: [new OpenIdExtension()],
     });
   }
 
@@ -27,10 +25,9 @@ export default class MagicAdapter {
         providerId: magicProviderId,
       });
       return new ethers.providers.Web3Provider(
-        this.magicClient.rpcProvider as unknown as ethers.providers.ExternalProvider
+        this.magicClient
+          .rpcProvider as unknown as ethers.providers.ExternalProvider
       );
-    }, {
-      type: PassportErrorType.WALLET_CONNECTION_ERROR,
-    })
+    }, PassportErrorType.WALLET_CONNECTION_ERROR);
   }
 }

--- a/src/modules/passport/stark/getStarkSigner.ts
+++ b/src/modules/passport/stark/getStarkSigner.ts
@@ -6,11 +6,9 @@ import {
   StarkSigner,
 } from '@imtbl/core-sdk';
 
-export const getStarkSigner = async (
-  signer: Signer
-): Promise<StarkSigner> => {
+export const getStarkSigner = async (signer: Signer): Promise<StarkSigner> => {
   return withPassportError<StarkSigner>(async () => {
     const privateKey = await generateLegacyStarkPrivateKey(signer);
     return createStarkSigner(privateKey);
-  }, {type: PassportErrorType.WALLET_CONNECTION_ERROR})
+  }, PassportErrorType.WALLET_CONNECTION_ERROR);
 };


### PR DESCRIPTION
# Summary
It is an enhancement ticket around this discussion: 
https://imtbl.slack.com/archives/C0418BT9VV3/p1678169752133309

# Why the changes
### changed
* withPassportError function to allow only error type as second params

# Things worth calling out
![Screenshot 2023-03-10 at 10 29 23](https://user-images.githubusercontent.com/3668156/224184077-f956416e-f771-4d1c-a553-2df8dfe868cf.png)

