### PR TITLE
fix: remove loadUserInfo to avoid authentication error

### DIFF
--- a/src/modules/passport/authManager.ts
+++ b/src/modules/passport/authManager.ts
@@ -21,7 +21,6 @@ const getAuthConfiguration = ({ clientId, redirectUri }: AuthInput) => ({
     authorization_endpoint: `${passportAuthDomain}/authorize`,
     token_endpoint: `${passportAuthDomain}/oauth/token`,
   },
-  loadUserInfo: true,
 });
 
 export default class AuthManager {


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->
Remove `loadUserInfo` to avoid the error below. 

![Screen Shot 2023-03-09 at 2 36 58 pm](https://user-images.githubusercontent.com/107908828/224191669-4f5b3759-02f4-494a-bab9-fdff219f0d18.png)


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
