### PR TITLE
ID-436 Enabled confirmation for all transfers

### DIFF
--- a/src/modules/passport/workflows/transfer.ts
+++ b/src/modules/passport/workflows/transfer.ts
@@ -8,7 +8,7 @@ import {
 } from '@imtbl/core-sdk';
 import { PassportErrorType, withPassportError } from '../errors/passportError';
 import { convertToSignableToken } from '../../provider/signable-actions/utils';
-import { Transaction, TransactionTypes} from '../confirmation/types';
+import { TransactionTypes } from '../confirmation/types';
 import ConfirmationScreen from '../confirmation/confirmation';
 import { PassportConfiguration } from '../config';
 import { UserWithEtherKey } from '../types';


### PR DESCRIPTION
# Summary
This PR enables the confirmation screen for all single transfers, not just `ERC721`. 

# Why the changes
The confirmation screen now supports `ERC20` & `ETH` single transfers.