### PR TITLE
[Economy] add error handling and initialisation to SDK

### DIFF
--- a/packages/economy/packages/sdk/src/Economy.spec.ts
+++ b/packages/economy/packages/sdk/src/Economy.spec.ts
@@ -1,0 +1,50 @@
+import { CraftInput, craftStatuses } from './crafting';
+import { Economy } from './Economy';
+import { SDKError } from './Errors';
+
+jest.mock('./crafting', () => ({
+  craft: jest.fn(),
+}));
+
+describe('Economy Class', () => {
+  let economy: Economy;
+  const craftInput: CraftInput = { requiresWeb3: false, web3Assets: {} };
+
+  beforeEach(() => {
+    economy = new Economy();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should capture crafting errors', async () => {
+    const craftFn = jest
+      .requireMock('./crafting')
+      .craft.mockImplementation(async () => {
+        throw new Error('craft request has failed');
+      });
+
+    try {
+      await economy.craft(craftInput);
+    } catch (error) {
+      expect(error).toBeInstanceOf(SDKError);
+      expect((error as Error).message).toContain('craft request has failed');
+    }
+
+    expect(craftFn).toHaveBeenCalledWith(craftInput);
+  });
+
+  it('should return the craft status', async () => {
+    const craftFn = jest
+      .requireMock('./crafting')
+      .craft.mockImplementation(
+        async () =>
+          craftStatuses[Math.floor(Math.random() * craftStatuses.length)]
+      );
+
+    const status = await economy.craft(craftInput);
+    expect(status).toContain(status);
+    expect(craftFn).toHaveBeenCalledWith(craftInput);
+  });
+});

--- a/packages/economy/packages/sdk/src/Economy.ts
+++ b/packages/economy/packages/sdk/src/Economy.ts
@@ -1,14 +1,23 @@
 import { CraftInput, ICraftStatus, craft } from './crafting';
+import { withSDKError } from './Errors';
+import { SDK } from './SDK';
 
-export class Economy {
+export class Economy extends SDK {
+  /** Lifecycle method: Self invoked after class instanciation */
+  connect(): void {
+    this.log('mounted');
+  }
+
   /**
    * Given inputs for a recipe crafting
    * process the recipe by sending it to the backend service
    * @param input crafting recipe inputs
    * @returns crafting status
    */
+  @withSDKError({ type: 'CRAFTING_ERROR' })
   async craft(input: CraftInput): Promise<ICraftStatus> {
-    console.log('Economy->craft(input):', input);
-    return craft(input);
+    const status = await craft(input);
+
+    return status;
   }
 }

--- a/packages/economy/packages/sdk/src/Errors.ts
+++ b/packages/economy/packages/sdk/src/Errors.ts
@@ -1,0 +1,53 @@
+/**
+ * Types of SDK Errors
+ */
+export type ErrorType = 'CRAFTING_ERROR' | 'UNKNOWN_ERROR';
+
+/** SDK Error Payload */
+export type SDKErrorType = {
+  type: ErrorType;
+  message?: string;
+};
+
+/**
+ * SDK Error Class
+ */
+export class SDKError extends Error {
+  public type: ErrorType;
+  constructor(type: ErrorType, message: string) {
+    super(message);
+    this.type = type;
+  }
+}
+
+/**
+ * Decorator: Adds error handling to a class method
+ * @param sdkError
+ * @returns
+ */
+export function withSDKError(options: SDKErrorType) {
+  return function (
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    target: Object,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    const method = descriptor.value;
+
+    descriptor.value = async function (...args: unknown[]) {
+      try {
+        return await method.apply(this, args);
+      } catch (error) {
+        const params = `${args ? JSON.stringify(args, undefined, 2) : ''}`;
+        const errorMessage =
+          options.message ||
+          `Error in method ${target.constructor.name}.${propertyKey}: "${
+            (error as Error).message
+          }"\n called with: ${params}`;
+        throw new SDKError(options.type, errorMessage);
+      }
+    };
+
+    return descriptor;
+  };
+}

--- a/packages/economy/packages/sdk/src/SDK.spec.ts
+++ b/packages/economy/packages/sdk/src/SDK.spec.ts
@@ -1,0 +1,44 @@
+import { Configuration, SDK } from './SDK';
+
+export class SDKMock extends SDK {
+  constructor(config: Configuration) {
+    super(config);
+  }
+
+  connect(): void {
+    // ...
+  }
+}
+
+describe('SDK Class', () => {
+  describe('constructor', () => {
+    it('should instantiate with provided configuration', () => {
+      const sdk = new SDKMock({ env: 'production' });
+      expect(sdk.getConfig()).toEqual({ env: 'production' });
+    });
+
+    it('should call connect() method during instantiation', () => {
+      const connectMock = jest.fn();
+      class TestSDKMock extends SDKMock {
+        override connect() {
+          connectMock();
+        }
+      }
+
+      new TestSDKMock({ env: 'dev' });
+      expect(connectMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('log method', () => {
+    it('should log the arguments passed to it', () => {
+      const consoleLogFn = jest.spyOn(console, 'log');
+      const sdk = new SDKMock({ env: 'dev' });
+
+      sdk.log('test message');
+      expect(consoleLogFn).toHaveBeenCalledWith('SDKMock:', 'test message');
+
+      consoleLogFn.mockRestore();
+    });
+  });
+});

--- a/packages/economy/packages/sdk/src/SDK.ts
+++ b/packages/economy/packages/sdk/src/SDK.ts
@@ -1,0 +1,34 @@
+/** Standard SDK Configuration interface */
+export type Configuration = {
+  env: 'production' | 'dev';
+};
+
+const defaultConfig: Configuration = {
+  env: 'dev',
+};
+
+/**
+ * Base class from which all SDK classes inherit a common interface
+ * with default lifecycle implementations
+ */
+export abstract class SDK {
+  constructor(protected config = defaultConfig) {
+    this.config = config;
+    this.connect();
+  }
+
+  /**
+   * Lifecycle: Use to bootstrap initialisation
+   */
+  abstract connect(): void;
+
+  /** Utility: Use to print logs in console */
+  log(...args: unknown[]): void {
+    console.log(`${this.constructor.name}:`, ...args);
+  }
+
+  /** Utility: Getter to protected config object */
+  getConfig(): Configuration {
+    return this.config;
+  }
+}

--- a/packages/economy/packages/sdk/src/crafting/index.ts
+++ b/packages/economy/packages/sdk/src/crafting/index.ts
@@ -44,3 +44,12 @@ export async function craft(craftInput: CraftInput): Promise<ICraftStatus> {
 
   return 'COMPLETE';
 }
+
+/** List of valid craft status values */
+export const craftStatuses: ICraftStatus[] = [
+  'AWAITING_WEB3_INTERACTION',
+  'SUBMITTED',
+  'PENDING',
+  'COMPLETE',
+  'ERROR',
+];

--- a/packages/economy/packages/sdk/src/index.ts
+++ b/packages/economy/packages/sdk/src/index.ts
@@ -1,2 +1,3 @@
 export * from './Economy';
+export type { craftStatuses } from './crafting';
 export type { CraftInput, ICraftStatus } from './crafting';


### PR DESCRIPTION
# Summary
Add a base class for the Economy class to extend common lifecycle utils. Such as `connect`, `log`, error handling, and coming soon event handling.


# Why the changes
This is part of establishing a framework for Economy SDK as a way to have patterns to guide the consistent development of features.


# Things worth calling out
- SDK is a base class that abstracts the lifecycle methods and provides error-handling capabilities
- Errors is a bundle of error handling utils, specifically a decorator wrap class methods
- Unit tests were added to both SDK and Economy classes. No tests were added for the crafting function as is just a dummy.
