### PR TITLE
ID-497 Fixed some failing tests

### DIFF
--- a/packages/passport/src/imxProvider/passportImxProvider.test.ts
+++ b/packages/passport/src/imxProvider/passportImxProvider.test.ts
@@ -466,7 +466,6 @@ describe('PassportImxProvider', () => {
         {
           tokenId: '1',
           tokenAddress: 'token_address',
-          sender: '123',
           receiver: 'receiver_eth_address',
         },
       ];
@@ -526,7 +525,6 @@ describe('PassportImxProvider', () => {
                   token_address: transferRequest[0].tokenAddress,
                 },
               },
-              sender: transferRequest[0].sender,
               receiver: transferRequest[0].receiver,
             },
           ],

--- a/packages/passport/src/workflows/transfer.test.ts
+++ b/packages/passport/src/workflows/transfer.test.ts
@@ -202,7 +202,6 @@ describe('transfer', () => {
         tokenId: '1',
         tokenAddress: 'token_address',
         receiver: 'receiver_eth_address',
-        sender: '123',
       },
     ];
 
@@ -277,7 +276,6 @@ describe('transfer', () => {
                   token_address: transferRequest[0].tokenAddress,
                 },
               },
-              sender: transferRequest[0].sender,
               receiver: transferRequest[0].receiver,
             },
           ],

--- a/packages/passport/src/workflows/transfer.ts
+++ b/packages/passport/src/workflows/transfer.ts
@@ -4,6 +4,7 @@ import {
   GetSignableTransferRequest,
   GetSignableTransferRequestV1,
   NftTransferDetails,
+  SignableTransferDetails,
   StarkSigner,
   TransfersApi,
   UnsignedTransferRequest,
@@ -115,7 +116,7 @@ export async function batchNftTransfer({
     const ethAddress = user.etherKey;
 
     const signableRequests = request.map(
-      (nftTransfer): GetSignableTransferRequestV1 => {
+      (nftTransfer): SignableTransferDetails => {
         return {
           amount: '1',
           token: convertToSignableToken({
@@ -123,7 +124,6 @@ export async function batchNftTransfer({
             tokenId: nftTransfer.tokenId,
             tokenAddress: nftTransfer.tokenAddress,
           }),
-          sender: ethAddress,
           receiver: nftTransfer.receiver,
         };
       }

--- a/packages/provider/src/signable-actions/exchanges.test.ts
+++ b/packages/provider/src/signable-actions/exchanges.test.ts
@@ -1,7 +1,7 @@
 import { generateSigners, privateKey1, testConfig } from '../test/helpers';
 import { UnsignedExchangeTransferRequest, ExchangesApi } from '@imtbl/core-sdk';
 import { exchangeTransfer } from './exchanges';
-import { signRaw } from '@imtbl/toolkit';
+import { signRaw, convertToSignableToken } from '@imtbl/toolkit';
 
 jest.mock('@imtbl/core-sdk');
 jest.mock('@imtbl/toolkit');
@@ -54,6 +54,12 @@ describe('ExchangeTransfer', () => {
     test('should make the correct api requests with the correct params, and return the correct receipt', async () => {
       const signers = await generateSigners(privateKey1);
 
+      (convertToSignableToken as jest.Mock).mockReturnValue({
+        type: 'ETH',
+        data: {
+          decimals: 18,
+        },
+      });
       const response = await exchangeTransfer({
         signers,
         request: signableExchangeTransferRequest,

--- a/packages/provider/src/signable-actions/transfer.test.ts
+++ b/packages/provider/src/signable-actions/transfer.test.ts
@@ -5,7 +5,7 @@ import {
   NftTransferDetails,
 } from '@imtbl/core-sdk';
 import { transfer, batchTransfer } from './transfer';
-import { signRaw } from '@imtbl/toolkit';
+import { signRaw, convertToSignableToken } from '@imtbl/toolkit';
 
 jest.mock('@imtbl/core-sdk');
 jest.mock('@imtbl/toolkit');
@@ -58,6 +58,13 @@ describe('Transfer', () => {
     test('should make the correct api requests with the correct params, and return the correct receipt', async () => {
       const signers = await generateSigners(privateKey1);
 
+      (convertToSignableToken as jest.Mock).mockReturnValue({
+        type: 'ERC721',
+        data: {
+          token_address: signableTransferRequest.tokenAddress,
+          token_id: signableTransferRequest.tokenId,
+        },
+      });
       const response = await transfer({
         signers,
         request: signableTransferRequest,
@@ -150,6 +157,13 @@ describe('Transfer', () => {
     test('should make the correct api requests with the correct params, and return the correct receipt', async () => {
       const signers = await generateSigners(privateKey1);
 
+      (convertToSignableToken as jest.Mock).mockReturnValue({
+        type: 'ERC721',
+        data: {
+          token_address: signableTransferRequest[0].tokenAddress,
+          token_id: signableTransferRequest[0].tokenId,
+        },
+      });
       const response = await batchTransfer({
         signers,
         request: signableTransferRequest,


### PR DESCRIPTION
# Summary
This PR fixes some of the failing Passport tests & removes the redundant `sender` argument for `batchNftTransfer`

# Things worth calling out
There are more failing tests in `packages/passport/src/stark/getStarkSigner.test.ts` which will need to be resolved in a subsequent PR.
