### PR TITLE
[ID-566]Adjust the login and confirmation popup size

### DIFF
--- a/packages/passport/src/authManager.ts
+++ b/packages/passport/src/authManager.ts
@@ -64,7 +64,11 @@ export default class AuthManager {
 
   public async login(): Promise<User> {
     return withPassportError<User>(async () => {
-      const oidcUser = await this.userManager.signinPopup();
+      const popupWindowFeatures = { width: 400, height: 420 };
+      const oidcUser = await this.userManager.signinPopup({
+        popupWindowFeatures,
+      });
+
       return this.mapOidcUserToDomainModel(oidcUser);
     }, PassportErrorType.AUTHENTICATION_ERROR);
   }

--- a/packages/passport/src/confirmation/confirmation.ts
+++ b/packages/passport/src/confirmation/confirmation.ts
@@ -10,8 +10,8 @@ import { openPopupCenter } from './popup';
 import { PassportConfiguration } from '../config';
 
 const ConfirmationWindowTitle = 'Confirm this transaction';
-const ConfirmationWindowHeight = 600;
-const ConfirmationWindowWidth = 600;
+const ConfirmationWindowHeight = 380;
+const ConfirmationWindowWidth = 480;
 const ConfirmationWindowClosedPollingDuration = 1000;
 
 export default class ConfirmationScreen {
@@ -38,7 +38,8 @@ export default class ConfirmationScreen {
 
   startTransaction(
     accessToken: string,
-    transaction: Transaction
+    transaction: Transaction,
+    popupOptions?: { width: number; height: number }
   ): Promise<ConfirmationResult> {
     return new Promise((resolve, reject) => {
       const messageHandler = ({ data, origin }: MessageEvent) => {
@@ -73,8 +74,8 @@ export default class ConfirmationScreen {
       const confirmationWindow = openPopupCenter({
         url: `${this.config.passportDomain}/transaction-confirmation`,
         title: ConfirmationWindowTitle,
-        width: ConfirmationWindowWidth,
-        height: ConfirmationWindowHeight,
+        width: popupOptions?.width || ConfirmationWindowWidth,
+        height: popupOptions?.height || ConfirmationWindowHeight,
       });
 
       // https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128

--- a/packages/passport/src/confirmation/popup.test.ts
+++ b/packages/passport/src/confirmation/popup.test.ts
@@ -10,14 +10,10 @@ describe('openPopupCenter', () => {
     screen: {},
   };
   const mockWindow = {
-    screenLeft: 100,
-    screenTop: 200,
-    innerWidth: 1200,
-    innerHeight: 800,
-    screen: {
-      availWidth: 1920,
-      height: 1080,
-    },
+    screenX: 100,
+    screenY: 200,
+    outerWidth: 1200,
+    outerHeight: 800,
     open: jest.fn().mockReturnValue(mockPopup),
   } as unknown as Window;
 
@@ -45,10 +41,10 @@ describe('openPopupCenter', () => {
     );
     expect(mockPopup.focus).toHaveBeenCalledTimes(1);
     const screenArgs = (mockWindow.open as jest.Mock).mock.calls[0][2];
-    expect(screenArgs.includes('width=1280')).toBeTruthy();
-    expect(screenArgs.includes('height=960')).toBeTruthy();
-    expect(screenArgs.includes('left=420')).toBeTruthy();
-    expect(screenArgs.includes('top=360')).toBeTruthy();
+    expect(screenArgs.includes('width=800')).toBeTruthy();
+    expect(screenArgs.includes('height=600')).toBeTruthy();
+    expect(screenArgs.includes('left=300')).toBeTruthy();
+    expect(screenArgs.includes('top=300')).toBeTruthy();
   });
 
   it('should throw an error if the new window fails to open', () => {

--- a/packages/passport/src/confirmation/popup.ts
+++ b/packages/passport/src/confirmation/popup.ts
@@ -12,33 +12,21 @@ export const openPopupCenter = ({
   width,
   height,
 }: PopUpProps): Window => {
-  // Fixes dual-screen position                             Most browsers      Firefox
-  const dualScreenLeft =
-    window.screenLeft !== undefined ? window.screenLeft : window.screenX;
-  const dualScreenTop =
-    window.screenTop !== undefined ? window.screenTop : window.screenY;
-
-  const windowWidth = window.innerWidth
-    ? window.innerWidth
-    : document.documentElement.clientWidth
-    ? document.documentElement.clientWidth
-    : screen.width;
-  const windowHeight = window.innerHeight
-    ? window.innerHeight
-    : document.documentElement.clientHeight
-    ? document.documentElement.clientHeight
-    : screen.height;
-
-  const systemZoom = windowWidth / window.screen.availWidth;
-  const left = (windowWidth - width) / 2 / systemZoom + dualScreenLeft;
-  const top = (windowHeight - height) / 2 / systemZoom + dualScreenTop;
+  const left = Math.max(
+    0,
+    Math.round(window.screenX + (window.outerWidth - width) / 2)
+  );
+  const top = Math.max(
+    0,
+    Math.round(window.screenY + (window.outerHeight - height) / 2)
+  );
   const newWindow = window.open(
     url,
     title,
     `
       scrollbars=yes,
-      width=${width / systemZoom}, 
-      height=${height / systemZoom}, 
+      width=${width}, 
+      height=${height}, 
       top=${top}, 
       left=${left}
      `

--- a/packages/passport/src/workflows/transfer.ts
+++ b/packages/passport/src/workflows/transfer.ts
@@ -139,12 +139,14 @@ export async function batchNftTransfer({
     });
 
     const confirmationScreen = new ConfirmationScreen(passportConfig);
+    const popupWindowSize = { width: 480, height: 784 };
     const confirmationResult = await confirmationScreen.startTransaction(
       user.accessToken,
       {
         transactionType: TransactionTypes.CreateBatchTransfer,
         transactionData: getSignableTransferRequestV2,
-      }
+      },
+      popupWindowSize
     );
 
     if (!confirmationResult.confirmed) {


### PR DESCRIPTION
# Summary
* changed:
* login popup with predefined size
* confirmation popup size

Login Screen:
Login Popup
<img width="1264" alt="Screenshot 2023-04-18 at 13 16 45" src="https://user-images.githubusercontent.com/3668156/232662104-7c335fd7-44b7-4155-9bb8-238710135b83.png">


Confirmation Popup

https://user-images.githubusercontent.com/3668156/232662189-79c739b3-3bb6-40e7-a4fb-7ec92f335300.mov


Batch Transfer

https://user-images.githubusercontent.com/3668156/232662128-19e694df-4b4b-4e09-9e04-69bd56c970ca.mov


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
