### PR TITLE
[NO-CHANGELOG][NOJIRA] Add tokens to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 /packages/starkex @immutable/developer-experience
 /packages/config @immutable/developer-experience
 /packages/internal/toolkit @immutable/developer-experience
-/packages/internal/dex @immutable/imx-tokens
+/packages/internal/dex @immutable/tokens
 /packages/passport @immutable/passport
 /packages/provider @immutable/wallets
 /packages/checkout @immutable/wallets


### PR DESCRIPTION
# Summary

- Adds the tokens team as codeowners of the `dex` directory
- Removes ownership over the entire `internal` directory and assigns ownership to `internal/toolkit`
