### PR TITLE
Checkout | Update sample app to reflect refactored method params NO-CHANGELOG

### DIFF
--- a/packages/checkout/sdk-sample-app/src/components/switchNetwork/switchNetwork.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/switchNetwork/switchNetwork.tsx
@@ -23,7 +23,7 @@ function SwitchNetwork(props: SwitchNetworkProps) {
   async function getNetworkInfo() {
     if (provider) {
       try {
-        const info = await checkout.getNetworkInfo(provider);
+        const info = await checkout.getNetworkInfo({ provider });
         console.log(info);
       } catch (error: any) {
         console.log(error);

--- a/packages/checkout/widgets-sample-app/src/components/ui/connect/connect.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/connect/connect.tsx
@@ -19,13 +19,11 @@ function ConnectUI() {
         case ConnectEventType.SUCCESS: {
           const eventData = event.detail.data as ConnectionSuccess;
           console.log(eventData.providerPreference);
-          console.log(eventData.timestamp);
           break;
         }
         case ConnectEventType.FAILURE: {
           const eventData = event.detail.data as ConnectionFailed;
           console.log(eventData.reason);
-          console.log(eventData.timestamp);
           break;
         }
         default:

--- a/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/useConnectWidget.hook.ts
+++ b/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/useConnectWidget.hook.ts
@@ -18,7 +18,6 @@ export function useConnectWidget() {
         case ConnectEventType.SUCCESS: {
           const eventData = event.detail.data as ConnectionSuccess;
           console.log(eventData.providerPreference);
-          console.log(eventData.timestamp);
           setProviderPreference(eventData.providerPreference);
           setShowConnectWidget(false);
           break;
@@ -26,7 +25,6 @@ export function useConnectWidget() {
         case ConnectEventType.FAILURE: {
           const eventData = event.detail.data as ConnectionFailed;
           console.log(eventData.reason);
-          console.log(eventData.timestamp);
           setShowConnectWidget(false);
           break;
         }


### PR DESCRIPTION
# Summary
2 objects in Checkout were refactored recently:
1. getNetworkInfo() - Added object that takes in `provider` property
2. Success event object for connection widget - removed `timestamp` property

This PR is to reflect those changes in the checkout sample-app for sdk and widgets.


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
