### PR TITLE
DX-2050: Restrict releases to be done only from main branch [ NO-CHANGELOG ]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,10 @@ jobs:
     name: Publish Workflow
     runs-on: ubuntu-latest
     steps:
+      - name: Check Public Release Branch
+        if: contains(github.event.inputs.release_type, 'release') && (github.ref != 'refs/heads/main')
+        run: failure("Public releases should be only done from main branch, current branch ${{ github.ref }}")
+
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->
Public release to NPM should be done only from `main` branch. 

https://immutable.atlassian.net/browse/DX-2050

# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

We still need a solution for alpha release tags to exist in the history.
