### PR TITLE
[ID-641] change login popup size from w400 x h420 to w410 x h450 [ NO-CHANGELOG ]

### DIFF
--- a/packages/passport/src/authManager.ts
+++ b/packages/passport/src/authManager.ts
@@ -66,7 +66,7 @@ export default class AuthManager {
 
   public async login(): Promise<User> {
     return withPassportError<User>(async () => {
-      const popupWindowFeatures = { width: 400, height: 420 };
+      const popupWindowFeatures = { width: 410, height: 450 };
       const oidcUser = await this.userManager.signinPopup({
         popupWindowFeatures,
       });


### PR DESCRIPTION
# Summary
Change login popup size from w400 x h420 to w410 x h450


# Why the changes
This change is necessary to not show scroll bars in some cases for the login/signup


# Things worth calling out
@haydenfowler and @Jon-Alonso 
