### PR TITLE
Checkout | Move views into views folder NO-CHANGELOG

### DIFF
--- a/packages/checkout/widgets/src/widgets/connect/ConnectWidget.tsx
+++ b/packages/checkout/widgets/src/widgets/connect/ConnectWidget.tsx
@@ -21,10 +21,10 @@ import {
   viewReducer,
 } from '../../context/ViewContext';
 import { ConnectWidgetViews } from '../../context/ConnectViewContextTypes';
-import { ConnectWallet } from './components/connect-wallet/ConnectWallet';
-import { ConnectResult } from './components/connect-result/ConnectResult';
+import { ConnectWallet } from './views/ConnectWallet';
+import { ConnectResult } from './views/ConnectResult';
 import { SuccessView } from '../../components/Success/SuccessView';
-import { ReadyToConnect } from './components/ready-to-connect/ReadyToConnect';
+import { ReadyToConnect } from './views/ReadyToConnect';
 import { SwitchNetwork } from './views/SwitchNetwork';
 
 export interface ConnectWidgetProps {

--- a/packages/checkout/widgets/src/widgets/connect/components/WalletItem.tsx
+++ b/packages/checkout/widgets/src/widgets/connect/components/WalletItem.tsx
@@ -1,6 +1,6 @@
 import { ConnectionProviders, WalletInfo } from '@imtbl/checkout-sdk-web';
 import { MenuItem } from '@biom3/react';
-import { text } from '../../../../resources/text/textConfig';
+import { text } from '../../../resources/text/textConfig';
 
 export interface WalletProps {
   onWalletClick: (providerPreference: ConnectionProviders) => void;

--- a/packages/checkout/widgets/src/widgets/connect/components/WalletList.tsx
+++ b/packages/checkout/widgets/src/widgets/connect/components/WalletList.tsx
@@ -1,14 +1,14 @@
 import { Box } from '@biom3/react';
-import { useContext, useEffect, useState } from 'react';
-import { ViewActions, ViewContext } from '../../../../context/ViewContext';
-import { ConnectWidgetViews } from '../../../../context/ConnectViewContextTypes';
 import {
-  ConnectionProviders,
-  WalletFilter,
   WalletFilterTypes,
+  WalletFilter,
   WalletInfo,
+  ConnectionProviders,
 } from '@imtbl/checkout-sdk-web';
-import { ConnectActions, ConnectContext } from '../../context/ConnectContext';
+import { useContext, useState, useEffect } from 'react';
+import { ConnectWidgetViews } from '../../../context/ConnectViewContextTypes';
+import { ViewContext, ViewActions } from '../../../context/ViewContext';
+import { ConnectContext, ConnectActions } from '../context/ConnectContext';
 import { WalletItem } from './WalletItem';
 
 export interface WalletListProps {

--- a/packages/checkout/widgets/src/widgets/connect/views/ConnectResult.tsx
+++ b/packages/checkout/widgets/src/widgets/connect/views/ConnectResult.tsx
@@ -1,9 +1,9 @@
 import { useContext } from 'react';
-import { FooterLogo } from '../../../../components/Footer/FooterLogo';
-import { HeaderNavigation } from '../../../../components/Header/HeaderNavigation';
-import { SimpleLayout } from '../../../../components/SimpleLayout/SimpleLayout';
-import { ViewContext } from '../../../../context/ViewContext';
-import { ConnectWidgetViews } from '../../../../context/ConnectViewContextTypes';
+import { FooterLogo } from '../../../components/Footer/FooterLogo';
+import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
+import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
+import { ViewContext } from '../../../context/ViewContext';
+import { ConnectWidgetViews } from '../../../context/ConnectViewContextTypes';
 import { Body } from '@biom3/react';
 
 export const ConnectResult = () => {

--- a/packages/checkout/widgets/src/widgets/connect/views/ConnectWallet.tsx
+++ b/packages/checkout/widgets/src/widgets/connect/views/ConnectWallet.tsx
@@ -1,10 +1,10 @@
 import { Body, Box } from '@biom3/react';
-import { HeaderNavigation } from '../../../../components/Header/HeaderNavigation';
-import { SimpleLayout } from '../../../../components/SimpleLayout/SimpleLayout';
-import { FooterLogo } from '../../../../components/Footer/FooterLogo';
-import { WalletList } from '../wallet-list/WalletList';
-import { ConnectWidgetViews } from '../../../../context/ConnectViewContextTypes';
-import { text } from '../../../../resources/text/textConfig';
+import { FooterLogo } from '../../../components/Footer/FooterLogo';
+import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
+import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
+import { ConnectWidgetViews } from '../../../context/ConnectViewContextTypes';
+import { text } from '../../../resources/text/textConfig';
+import { WalletList } from '../components/WalletList';
 
 export const ConnectWallet = () => {
   const { header, body } = text.views[ConnectWidgetViews.CONNECT_WALLET];

--- a/packages/checkout/widgets/src/widgets/connect/views/OtherWallets.tsx
+++ b/packages/checkout/widgets/src/widgets/connect/views/OtherWallets.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Button } from '@biom3/react';
 import { ConnectionProviders } from '@imtbl/checkout-sdk-web';
-import { ButtonWrapperStyle } from '../../ConnectStyles';
-import { ConnectActions, ConnectContext } from '../../context/ConnectContext';
 import { useContext } from 'react';
-import { ViewActions, ViewContext } from '../../../../context/ViewContext';
-import { ConnectWidgetViews } from '../../../../context/ConnectViewContextTypes';
-import { SimpleLayout } from '../../../../components/SimpleLayout/SimpleLayout';
-import { HeaderNavigation } from '../../../../components/Header/HeaderNavigation';
-import { FooterLogo } from '../../../../components/Footer/FooterLogo';
+import { FooterLogo } from '../../../components/Footer/FooterLogo';
+import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
+import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
+import { ConnectWidgetViews } from '../../../context/ConnectViewContextTypes';
+import { ViewContext, ViewActions } from '../../../context/ViewContext';
+import { ButtonWrapperStyle } from '../ConnectStyles';
+import { ConnectContext, ConnectActions } from '../context/ConnectContext';
 
 export function OtherWallets() {
   const { connectState, connectDispatch } = useContext(ConnectContext);

--- a/packages/checkout/widgets/src/widgets/connect/views/ReadyToConnect.tsx
+++ b/packages/checkout/widgets/src/widgets/connect/views/ReadyToConnect.tsx
@@ -1,19 +1,19 @@
-import { HeaderNavigation } from '../../../../components/Header/HeaderNavigation';
-import { SimpleLayout } from '../../../../components/SimpleLayout/SimpleLayout';
-import { FooterButton } from '../../../../components/Footer/FooterButton';
-import { useCallback, useContext, useState } from 'react';
-import { ConnectActions, ConnectContext } from '../../context/ConnectContext';
-import { ViewActions, ViewContext } from '../../../../context/ViewContext';
+import { Web3Provider } from '@ethersproject/providers';
 import {
   ChainId,
   Checkout,
   ConnectionProviders,
 } from '@imtbl/checkout-sdk-web';
-import { ConnectWidgetViews } from '../../../../context/ConnectViewContextTypes';
-import { MetamaskConnectHero } from '../../../../components/Hero/MetamaskConnectHero';
-import { text } from '../../../../resources/text/textConfig';
-import { Web3Provider } from '@ethersproject/providers';
-import { SimpleTextBody } from '../../../../components/Body/SimpleTextBody';
+import { useContext, useState, useCallback } from 'react';
+import { SimpleTextBody } from '../../../components/Body/SimpleTextBody';
+import { FooterButton } from '../../../components/Footer/FooterButton';
+import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
+import { MetamaskConnectHero } from '../../../components/Hero/MetamaskConnectHero';
+import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
+import { ConnectWidgetViews } from '../../../context/ConnectViewContextTypes';
+import { ViewContext, ViewActions } from '../../../context/ViewContext';
+import { text } from '../../../resources/text/textConfig';
+import { ConnectContext, ConnectActions } from '../context/ConnectContext';
 
 export const ReadyToConnect = () => {
   const {

--- a/packages/checkout/widgets/src/widgets/connect/views/SwitchNetwork.tsx
+++ b/packages/checkout/widgets/src/widgets/connect/views/SwitchNetwork.tsx
@@ -1,14 +1,14 @@
+import { ChainId } from '@imtbl/checkout-sdk-web';
+import { useContext, useState } from 'react';
+import { SimpleTextBody } from '../../../components/Body/SimpleTextBody';
 import { FooterButton } from '../../../components/Footer/FooterButton';
 import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
-import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
-import { SimpleTextBody } from '../../../components/Body/SimpleTextBody';
-import { useContext, useState } from 'react';
-import { ConnectContext } from '../context/ConnectContext';
-import { ChainId } from '@imtbl/checkout-sdk-web';
-import { ViewActions, ViewContext } from '../../../context/ViewContext';
-import { ConnectWidgetViews } from '../../../context/ConnectViewContextTypes';
 import { ImmutableNetworkHero } from '../../../components/Hero/ImmutableNetworkHero';
+import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
+import { ConnectWidgetViews } from '../../../context/ConnectViewContextTypes';
+import { ViewContext, ViewActions } from '../../../context/ViewContext';
 import { text } from '../../../resources/text/textConfig';
+import { ConnectContext } from '../context/ConnectContext';
 
 export const SwitchNetwork = () => {
   const { viewDispatch } = useContext(ViewContext);


### PR DESCRIPTION
# Summary
Views should live inside the `views` folder instead of `components` since they are considered views rather than reusable components. The `components` folder should be used for individual reusable components that can be used inside views rather than entire views.

This change was already made in WT-1254 for the SwitchNetwork view and this PR is just moving the rest of the views across.
