### PR TITLE
NOJIRA: Export PassportModuleConfiguration [NO-CHANGELOG]

### DIFF
--- a/packages/passport/src/index.ts
+++ b/packages/passport/src/index.ts
@@ -1,5 +1,5 @@
 import { PassportError } from './errors/passportError';
 import { Passport } from './Passport';
-import { PassportConfiguration } from './config';
+import { PassportModuleConfiguration } from './types';
 
-export { PassportConfiguration, Passport, PassportError };
+export { Passport, PassportError, PassportModuleConfiguration };


### PR DESCRIPTION
# Summary
We're currently exporting the `PassportConfiguration`, which is used internally, rather than the `PassportModuleConfiguration`, which is what the Passport constructor accepts.
