### PR TITLE
DX-2036: Disable warnings as errors until linting is fully rolled out. [NO-CHANGELOG]

### DIFF
--- a/lint-ci.sh
+++ b/lint-ci.sh
@@ -2,4 +2,4 @@
 
 files=$(git diff --name-only --diff-filter=ACMRTUXB $(git rev-parse HEAD^1) | grep  -E '(.js$|.ts$|.tsx$)')
 
-[[ -z $files ]] || eslint $files --ext .ts,.jsx,.tsx --max-warnings=0 --no-error-on-unmatched-pattern
+[[ -z $files ]] || eslint $files --ext .ts,.jsx,.tsx --no-error-on-unmatched-pattern


### PR DESCRIPTION
# Summary
 
Disable treating linter warning as errors until linting is fully rolled out.
