### PR TITLE
[DX-2036][NO-CHANGELOG] Lint all files that have changed in a PR

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,11 @@
 {
     "root": true,
     "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "project": "./tsconfig.json",
+      "tsconfigRootDir": ".",
+      "sourceType": "module"
+    },
     "plugins": ["@typescript-eslint"]
 }
   

--- a/lint-ci.sh
+++ b/lint-ci.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
-files=$(git diff --name-only --diff-filter=ACMRTUXB $(git rev-parse HEAD^1) | grep  -E '(.js$|.ts$|.tsx$)')
+# if GITHUB_BASE_REF is set, use it. Otherwise, use origin/main
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+base=${GITHUB_BASE_REF:-main}
 
-[[ -z $files ]] || eslint $files --ext .ts,.jsx,.tsx --no-error-on-unmatched-pattern
+files=$(git diff --name-only --diff-filter=ACMRTUXB origin/$base)
+
+tolint=()
+for f in $files; do
+  #   match js,.js,.jsx,.ts,.tsx
+  if [[ $f =~ \.[tj]sx?$ ]]; then
+    tolint+=($f)
+  fi
+done
+
+[[ -z $tolint ]] || eslint $tolint --no-error-on-unmatched-pattern


### PR DESCRIPTION
# Summary
Previously, `yarn lint:ci` was only linting files that have changed in the latest commit of a PR. 
This PR ensures that all changed files are linted.

# Why the changes


# Things worth calling out
