### PR TITLE
ID-712-provider-module-prod [NO-CHANGELOG]

### DIFF
--- a/sdk/module-release.json
+++ b/sdk/module-release.json
@@ -9,7 +9,7 @@
         "config": "prod",
         "immutablex_client": "prod",
         "passport": "prod",
-        "provider": "alpha",
+        "provider": "prod",
         "checkout_sdk": "alpha",
         "checkout_widgets": "alpha"
     }


### PR DESCRIPTION
# Summary
This PR sets the `Provider` module to `prod`, so that it's included in NPM releases.