### PR TITLE
Checkout | Add lodash debounce to unblock quote fetch [NO-CHANGELOG]

### DIFF
--- a/packages/checkout/widgets-lib/package.json
+++ b/packages/checkout/widgets-lib/package.json
@@ -22,6 +22,7 @@
     "@imtbl/config": "0.0.0",
     "@imtbl/cryptofiat": "0.0.0",
     "ethers": "^5.7.2",
+    "lodash.debounce": "^4.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.0"

--- a/packages/checkout/widgets-lib/src/widgets/swap/constants.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/constants.ts
@@ -1,0 +1,2 @@
+export const TEXT_DEBOUNCE_TIME = 500;
+export const SELECT_DEBOUNCE_TIME = 50;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,6 +2742,7 @@ __metadata:
     ethers: ^5.7.2
     jest: ^29.4.3
     local-cypress: ^1.2.6
+    lodash.debounce: ^4.0.8
     react: ^18.2.0
     react-dom: ^18.2.0
     react-router-dom: ^6.11.0


### PR DESCRIPTION
# Summary
Adding lodash.debounce package so we can use the debounce function only. This keeps bundle size small as we don't import anything else except debounce from lodash.

Refactors the debounce logic and cleans up the From and To components. This helps out a lot with only fetching a quote when we want to. Example below:


https://github.com/immutable/ts-immutable-sdk/assets/24286603/77e79ae4-3fc9-4057-be71-43e0af8168d3



# Why the changes
Need to fix our debounce logic in branch `feature/WT-1327-Swap-Interaction-1`


# Things worth calling out

