### PR TITLE
[DX-2128] [NO-CHANGELOG] Remove prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,0 @@
-dist
-build
-coverage

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,0 @@
-{
-  "singleQuote": true,
-  "semi": true
-}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.2.0",
     "node-gyp": "^9.3.1",
-    "prettier": "^2.8.7",
     "release-it": "^15.10.1",
     "syncpack": "^9.8.4",
     "wsrun": "^5.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25331,7 +25331,6 @@ __metadata:
     husky: ^8.0.3
     lint-staged: ^13.2.0
     node-gyp: ^9.3.1
-    prettier: ^2.8.7
     release-it: ^15.10.1
     syncpack: ^9.8.4
     wsrun: ^5.2.4


### PR DESCRIPTION
# Summary
Prettier is no longer needed we are now using eslint for code style and formatting which is conflicting with the prettier config



# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
