### PR TITLE
POC - Checkout wraps provider [NO-CHANGELOG]

### DIFF
--- a/packages/checkout/sdk-sample-app/src/components/CheckConnection.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/CheckConnection.tsx
@@ -3,7 +3,7 @@ import {
   Checkout,
   ConnectionProviders,
 } from '@imtbl/checkout-sdk';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import LoadingButton from './LoadingButton';
 import { Web3Provider } from '@ethersproject/providers';
 import { SuccessMessage, ErrorMessage, WarningMessage } from './messages';
@@ -21,7 +21,7 @@ export default function CheckConnection(props: CheckConnectionProps) {
   const [error, setError] = useState<any>(null);
   const [loading, setLoading] = useState<boolean>(false);
 
-  async function checkMyConnection() {
+  const checkMyConnection = useCallback(async () => {
     if (!checkout) {
       console.error('missing checkout, please connect frist');
       return;
@@ -30,9 +30,7 @@ export default function CheckConnection(props: CheckConnectionProps) {
     setError(null);
     setLoading(true);
     try {
-      const resp = await checkout.checkIsWalletConnected({
-        providerPreference: ConnectionProviders.METAMASK,
-      });
+      const resp = await checkout.checkIsWalletConnected();
       setResult(resp);
       setLoading(false);
     } catch (err: any) {
@@ -43,7 +41,7 @@ export default function CheckConnection(props: CheckConnectionProps) {
       console.log(err.data);
       console.log(err.stack);
     }
-  }
+  },[checkout, provider]);
 
   useEffect(() => {
     // reset state wehn checkout changes from environment switch

--- a/packages/checkout/sdk-sample-app/src/components/Connect.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/Connect.tsx
@@ -1,4 +1,4 @@
-import { Checkout, ConnectionProviders } from '@imtbl/checkout-sdk';
+import { Checkout, ConnectionProviders, NetworkInfo } from '@imtbl/checkout-sdk';
 import { Web3Provider } from '@ethersproject/providers';
 import LoadingButton from './LoadingButton';
 import { useEffect, useMemo, useState } from 'react';
@@ -6,26 +6,27 @@ import { SuccessMessage, ErrorMessage } from './messages';
 import { Environment } from '@imtbl/config';
 
 interface ConnectProps {
-  checkout: Checkout;
-  setProvider: (provider: Web3Provider) => void;
+  checkout: Checkout  | undefined;
 }
 
 export default function Connect(props: ConnectProps) {
-  const { setProvider, checkout } = props;
+  const { checkout } = props;
 
-  const [result, setResult] = useState<Web3Provider>();
+  const [result, setResult] = useState<NetworkInfo>();
   const [error, setError] = useState<any>(null);
   const [loading, setLoading] = useState<boolean>(false);
 
   async function connectClick() {
+    if(!checkout) {
+      console.error('missing checkout, create provider and connect first')
+      return;
+    } 
+
     setError(null);
     setLoading(true);
     try {
-      const resp = await checkout.connect({
-        providerPreference: ConnectionProviders.METAMASK,
-      });
-      setProvider(resp.provider);
-      setResult(resp.provider);
+      const resp = await checkout.connect();
+      setResult(resp.network);
       setLoading(false);
     } catch (err: any) {
       setError(err);

--- a/packages/checkout/sdk-sample-app/src/components/GetAllBalances.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/GetAllBalances.tsx
@@ -32,7 +32,6 @@ export default function GetAllBalances(props: BalanceProps) {
     const walletAddress = await provider.getSigner().getAddress();
     try {
       const resp = await checkout.getAllBalances({
-        provider,
         walletAddress: walletAddress,
         chainId: ChainId.ETHEREUM,
       });

--- a/packages/checkout/sdk-sample-app/src/components/GetBalance.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/GetBalance.tsx
@@ -39,7 +39,6 @@ export default function GetBalance(props: BalanceProps) {
     const walletAddress = await provider.getSigner().getAddress();
     try {
       const resp = await checkout.getBalance({
-        provider,
         walletAddress,
       });
       setResultNative(resp);
@@ -70,7 +69,6 @@ export default function GetBalance(props: BalanceProps) {
     const walletAddress = await provider.getSigner().getAddress();
     try {
       const resp = await checkout.getBalance({
-        provider,
         walletAddress,
         contractAddress,
       });

--- a/packages/checkout/sdk-sample-app/src/components/SwitchNetwork.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/SwitchNetwork.tsx
@@ -62,7 +62,7 @@ export default function SwitchNetwork(props: SwitchNetworkProps) {
     setLoading(true);
 
     try {
-      const resp = await checkout.switchNetwork({ provider, chainId });
+      const resp = await checkout.switchNetwork({ chainId });
       setProvider(resp.provider);
       setResult(resp.network);
       setLoading(false);
@@ -90,7 +90,7 @@ export default function SwitchNetwork(props: SwitchNetworkProps) {
     setLoadingNetInfo(true);
 
     try {
-      const resp = await checkout.getNetworkInfo({ provider });
+      const resp = await checkout.getNetworkInfo();
       setResultNetInfo(resp);
       setLoadingNetInfo(false);
     } catch (err: any) {

--- a/packages/checkout/sdk-sample-app/src/pages/ConnectWidget.tsx
+++ b/packages/checkout/sdk-sample-app/src/pages/ConnectWidget.tsx
@@ -5,17 +5,20 @@ import { Web3Provider } from '@ethersproject/providers';
 import GetAllBalances from '../components/GetAllBalances';
 import CheckConnection from '../components/CheckConnection';
 import GetAllowList from '../components/GetAllowList';
-import { Body, Divider, Heading, Toggle } from '@biom3/react';
+import { Body, Button, Divider, Heading, Toggle } from '@biom3/react';
 import GetBalance from '../components/GetBalance';
-import { Checkout } from '@imtbl/checkout-sdk';
+import { Checkout, ConnectionProviders } from '@imtbl/checkout-sdk';
 import { Environment } from '@imtbl/config';
 
 export default function ConnectWidget() {
   const [environment, setEnvironment] = useState(Environment.PRODUCTION);
-  const checkout = useMemo(() => {
-    return new Checkout({ baseConfig: { environment: environment } });
-  }, [environment]);
   const [provider, setProvider] = useState<Web3Provider>();
+  
+  const checkout = useMemo(() => {
+    if(!provider) return;
+    return new Checkout({ baseConfig: { environment: environment } }, provider);
+  }, [environment, provider]);
+  
 
   function toggleEnvironment() {
     if (environment === Environment.PRODUCTION) {
@@ -23,6 +26,11 @@ export default function ConnectWidget() {
     } else {
       setEnvironment(Environment.PRODUCTION);
     }
+  }
+
+  const handleMetaMask = async () => {
+    const providerResult = await Checkout.createProvider({providerPreference: ConnectionProviders.METAMASK});
+    setProvider(providerResult.provider)
   }
 
   return (
@@ -49,6 +57,16 @@ export default function ConnectWidget() {
         onChange={toggleEnvironment}
       />
 
+    <Divider
+        sx={{
+          marginTop: 'base.spacing.x6',
+          marginBottom: 'base.spacing.x2',
+        }}
+      >
+        Create Provider
+      </Divider>
+      <Button onClick={handleMetaMask}>Create MetaMask provider</Button>
+
       <Divider
         sx={{
           marginTop: 'base.spacing.x6',
@@ -57,7 +75,7 @@ export default function ConnectWidget() {
       >
         Connect
       </Divider>
-      <Connect checkout={checkout} setProvider={setProvider} />
+      <Connect checkout={checkout} />
 
       <Divider
         sx={{

--- a/packages/checkout/sdk/src/connect/connect.ts
+++ b/packages/checkout/sdk/src/connect/connect.ts
@@ -3,7 +3,6 @@ import detectEthereumProvider from '@metamask/detect-provider';
 import { Web3Provider, ExternalProvider } from '@ethersproject/providers';
 import {
   ConnectionProviders,
-  ConnectParams,
   WalletAction,
   CheckConnectionResult,
 } from '../types';
@@ -25,7 +24,7 @@ async function getMetaMaskProvider(): Promise<Web3Provider> {
   return new Web3Provider(provider);
 }
 
-async function getWalletProviderForPreference(
+export async function getWalletProviderForPreference(
   providerPreference: ConnectionProviders,
 ): Promise<Web3Provider> {
   let web3Provider: Web3Provider | null = null;
@@ -44,15 +43,13 @@ async function getWalletProviderForPreference(
 }
 
 export async function checkIsWalletConnected(
-  providerPreference: ConnectionProviders,
+  provider: Web3Provider,
 ): Promise<CheckConnectionResult> {
-  const provider = await getWalletProviderForPreference(providerPreference);
-
   if (!provider.provider?.request) {
     throw new CheckoutError(
       'Incompatible provider',
       CheckoutErrorType.PROVIDER_REQUEST_MISSING_ERROR,
-      { details: `Unsupported provider for ${providerPreference}` },
+      { details: 'Unsupported provider' },
     );
   }
 
@@ -80,23 +77,19 @@ export async function checkIsWalletConnected(
 }
 
 export async function connectWalletProvider(
-  params: ConnectParams,
+  provider: Web3Provider,
 ): Promise<Web3Provider> {
-  const web3Provider = await getWalletProviderForPreference(
-    params.providerPreference,
-  );
-
   await withCheckoutError<void>(
     async () => {
-      if (!web3Provider || !web3Provider?.provider?.request) {
+      if (!provider || !provider?.provider?.request) {
         throw new CheckoutError(
           'Incompatible provider',
           CheckoutErrorType.PROVIDER_REQUEST_MISSING_ERROR,
-          { details: `Unsupported provider for ${params.providerPreference}` },
+          { details: 'Unsupported provider' },
         );
       }
       // this makes the request to the wallet to connect i.e request eth accounts ('eth_requestAccounts')
-      await web3Provider.provider.request({
+      await provider.provider.request({
         method: WalletAction.CONNECT,
         params: [],
       });
@@ -104,5 +97,5 @@ export async function connectWalletProvider(
     { type: CheckoutErrorType.USER_REJECTED_REQUEST_ERROR },
   );
 
-  return web3Provider;
+  return provider;
 }

--- a/packages/checkout/sdk/src/errors/checkoutError.ts
+++ b/packages/checkout/sdk/src/errors/checkoutError.ts
@@ -2,6 +2,7 @@
  * The different types of errors that can be returned by the checkout process.
  */
 export enum CheckoutErrorType {
+  CHECKOUT_CONSTRUCTION_ERROR = 'CHECKOUT_CONSTRUCTION_ERROR',
   PROVIDER_PREFERENCE_ERROR = 'PROVIDER_PREFERENCE_ERROR',
   CONNECT_PROVIDER_ERROR = 'CONNECT_PROVIDER_ERROR',
   GET_BALANCE_ERROR = 'GET_BALANCE_ERROR',

--- a/packages/checkout/sdk/src/network/network.ts
+++ b/packages/checkout/sdk/src/network/network.ts
@@ -9,10 +9,8 @@ import {
   NetworkInfo,
   SwitchNetworkResult,
   WalletAction,
-  ConnectionProviders,
   NetworkMap,
 } from '../types';
-import { connectWalletProvider } from '../connect/connect';
 import networkMasterList from './network_master_list.json';
 import { CheckoutConfiguration } from '../config';
 
@@ -86,7 +84,6 @@ export async function getNetworkInfo(
 
 export async function switchWalletNetwork(
   config: CheckoutConfiguration,
-  providerPreference: ConnectionProviders,
   provider: Web3Provider,
   chainId: ChainId,
 ): Promise<SwitchNetworkResult> {
@@ -129,8 +126,7 @@ export async function switchWalletNetwork(
       );
     }
   }
-  currentProvider = await connectWalletProvider({ providerPreference });
-
+  currentProvider = new Web3Provider(currentProvider.provider);
   if ((await currentProvider.getNetwork()).chainId !== chainId) {
     // user didn't actually switch
     throw new CheckoutError(

--- a/packages/checkout/sdk/src/transaction/transaction.ts
+++ b/packages/checkout/sdk/src/transaction/transaction.ts
@@ -1,22 +1,21 @@
+import { Web3Provider } from '@ethersproject/providers';
 import { CheckoutErrorType, withCheckoutError } from '../errors';
 import {
-  SendTransactionParams,
   SendTransactionResult,
+  Transaction,
 } from '../types/transaction';
 
 export const sendTransaction = async (
-  params: SendTransactionParams,
-): Promise<SendTransactionResult> => {
-  const { provider, transaction } = params;
-  return await withCheckoutError<SendTransactionResult>(
-    async () => {
-      const transactionResponse = await provider
-        .getSigner()
-        .sendTransaction(transaction);
-      return {
-        transactionResponse,
-      };
-    },
-    { type: CheckoutErrorType.TRANSACTION_ERROR },
-  );
-};
+  provider: Web3Provider,
+  transaction: Transaction,
+): Promise<SendTransactionResult> => await withCheckoutError<SendTransactionResult>(
+  async () => {
+    const transactionResponse = await provider
+      .getSigner()
+      .sendTransaction(transaction);
+    return {
+      transactionResponse,
+    };
+  },
+  { type: CheckoutErrorType.TRANSACTION_ERROR },
+);

--- a/packages/checkout/sdk/src/types/balances.ts
+++ b/packages/checkout/sdk/src/types/balances.ts
@@ -1,4 +1,3 @@
-import { Web3Provider } from '@ethersproject/providers';
 import { BigNumber } from 'ethers';
 import { ChainId } from './chainId';
 import { TokenInfo } from './tokenInfo';
@@ -10,7 +9,6 @@ import { TokenInfo } from './tokenInfo';
  * @property {string | undefined} contractAddress - The contract address of the token.
  */
 export interface GetBalanceParams {
-  provider: Web3Provider;
   walletAddress: string;
   contractAddress?: string;
 }
@@ -34,7 +32,6 @@ export interface GetBalanceResult {
  * @property {ChainId} chainId - The ID of the network.
  */
 export interface GetAllBalancesParams {
-  provider: Web3Provider;
   walletAddress: string;
   chainId: ChainId;
 }

--- a/packages/checkout/sdk/src/types/connect.ts
+++ b/packages/checkout/sdk/src/types/connect.ts
@@ -1,5 +1,4 @@
 import { Web3Provider } from '@ethersproject/providers';
-
 import { NetworkInfo } from './networkInfo';
 
 /**
@@ -7,6 +6,14 @@ import { NetworkInfo } from './networkInfo';
  */
 export enum ConnectionProviders {
   METAMASK = 'metamask',
+}
+
+export interface CreateProviderParams {
+  providerPreference: ConnectionProviders
+}
+
+export interface CreateProviderResult {
+  provider: Web3Provider;
 }
 
 /**
@@ -23,7 +30,6 @@ export type ConnectParams = {
  * @property {NetworkInfo} network - Information about the connected network.
  */
 export interface ConnectResult {
-  provider: Web3Provider;
   network: NetworkInfo;
 }
 
@@ -32,7 +38,7 @@ export interface ConnectResult {
  * @property {ConnectionProviders} providerPreference - The preferred provider to use to check the connection status to th Web3 network.
  */
 export interface CheckConnectionParams {
-  providerPreference: ConnectionProviders;
+  provider: Web3Provider;
 }
 
 /**

--- a/packages/checkout/sdk/src/types/network.ts
+++ b/packages/checkout/sdk/src/types/network.ts
@@ -130,7 +130,7 @@ NetworkDetails
  * @property {ChainId} chainId - The ID of the network to switch to.
  */
 export interface SwitchNetworkParams {
-  provider: Web3Provider;
+  // provider: Web3Provider;
   chainId: ChainId;
 }
 
@@ -148,7 +148,7 @@ export interface SwitchNetworkResult {
  * @property {Web3Provider} provider - The provider to connect to the network.
  */
 export interface GetNetworkParams {
-  provider: Web3Provider;
+  // provider: Web3Provider;
 }
 
 /**

--- a/packages/checkout/sdk/src/types/transaction.ts
+++ b/packages/checkout/sdk/src/types/transaction.ts
@@ -1,4 +1,4 @@
-import { TransactionResponse, Web3Provider } from '@ethersproject/providers';
+import { TransactionResponse } from '@ethersproject/providers';
 
 /**
  * Interface representing the parameters for {@link Checkout.sendTransaction}.
@@ -6,7 +6,6 @@ import { TransactionResponse, Web3Provider } from '@ethersproject/providers';
  * @property {Transaction} transaction - The transaction to send.
  */
 export interface SendTransactionParams {
-  provider: Web3Provider;
   transaction: Transaction;
 }
 


### PR DESCRIPTION
# Summary

Refactor the checkout sdk Checkout class so that it takes a provider at constructor time and keeps it on the checkout object. When switching network, the inner provider is re-wrapped in a web3 and updated on the checkout object.

All methods now don't need a provider input, they just use the provider saved on the checkout object.

This is the method where the Checkout class 'wraps' the provider.
Allows for DevEx of:

Pass in an already created Web3Provider
`const checkout = new Checkout(config, provider)`

OR create one from providerPreference

`const providerResult = await Checkout.createProvider({providerPreference: 'metamask'});`
`const checkout = new Checkout(config, providerResult.provider);`



# Why the changes



# Things worth calling out

