### PR TITLE
ID-710 Fixed tests not running in Webstorm [NO-CHANGELOG]

### DIFF
--- a/packages/internal/guardian/rollup.config.js
+++ b/packages/internal/guardian/rollup.config.js
@@ -1,7 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import json from '@rollup/plugin-json';
-import commonjs from "@rollup/plugin-commonjs";
 
 export default {
   input: './src/index.ts',
@@ -10,8 +9,7 @@ export default {
   },
   plugins: [
     json(),
-    commonjs(),
-    nodeResolve( { browser: true }),
+    resolve({ browser: true }),
     typescript({
       exclude: ['**/ABIs/*', '**/*.test.*', '**/utils/testUtils.ts'],
     }),


### PR DESCRIPTION
# Summary
Previously the guardian `dist/index.js` file contained an import statement (`import globalAxios from 'axios';`), which meant that any tests that consumed guardian would not run correctly through Webstorm, and therefore could not be debugged:

```
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /Users/haydenfowler/Code/ts-immutable-sdk/node_modules/axios/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){import axios from './lib/axios.js';
                                                                                      ^^^^^^

    SyntaxError: Cannot use import statement outside a module

    > 1 | import globalAxios from 'axios';
        | ^
      2 |
      3 | /* tslint:disable */
      4 | /* eslint-disable */

      at Runtime.createScriptFromCode (../../node_modules/jest-runtime/build/index.js:1728:14)
      at Object.<anonymous> (../internal/guardian/dist/index.js:1:1)
      at Object.<anonymous> (src/workflows/transfer.ts:14:1)
      at Object.<anonymous> (src/imxProvider/passportImxProvider.ts:24:1)
      at Object.<anonymous> (src/Passport.ts:6:1)
      at Object.<anonymous> (src/Passport.test.ts:5:1)
      at TestScheduler.scheduleTests (../../node_modules/react-scripts/node_modules/@jest/core/build/TestScheduler.js:333:13)
      at runJest (../../node_modules/react-scripts/node_modules/@jest/core/build/runJest.js:404:19)
      at _run10000 (../../node_modules/react-scripts/node_modules/@jest/core/build/cli/index.js:320:7)
      at runCLI (../../node_modules/react-scripts/node_modules/@jest/core/build/cli/index.js:173:3)
```

This PR adds the `resolve` rollup plugin to ensure that the import statement is not included in the compiled code. More context here: https://github.com/axios/axios/issues/1259