### PR TITLE
TEST - Increase memory limit on publish action [NO-CHANGELOG]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ on:
         default: none
       dry_run:
         type: boolean
-        description: '(Optional) Dry run'
+        description: "(Optional) Dry run"
         required: false
         default: false
 
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Increase memory limit"
-          env:
-            NODE_OPTIONS: "--max_old_space_size=4096"
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
       - name: Check Public Release Branch
         if: contains(github.event.inputs.release_type, 'release') && (github.ref != 'refs/heads/main')
         run: failure("Public releases should be only done from main branch, current branch ${{ github.ref }}")


### PR DESCRIPTION
# Summary
Github Action for Publishing 'alpha' releases is failing with an error

`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

Testing increasing the memory allocation for the job as per this issue: https://github.com/actions/runner-images/issues/70


# Why the changes
alpha releases are failing with a heap out of memory issue


# Things worth calling out
