### PR TITLE
Use addresses from devnet for gas estimate tokens NO-CHANGELOG

### DIFF
--- a/packages/checkout/sdk/src/gasEstimate/gas_estimate_tokens.json
+++ b/packages/checkout/sdk/src/gasEstimate/gas_estimate_tokens.json
@@ -5,8 +5,8 @@
       "fromAddress": "0xd1da7e9b2Ce1a4024DaD52b3D37F4c5c91a525C1"
     },
     "swapAddresses": {
-      "inAddress": "0x741185AEFC3E539c1F42c1d6eeE8bFf1c89D70FE",
-      "outAddress": "0xaC953a0d7B67Fae17c87abf79f09D0f818AC66A2"
+      "inAddress": "0xFEa9FF93DC0C6DC73F8Be009Fe7a22Bb9dcE8A2d",
+      "outAddress": "0x8AC26EfCbf5D700b37A27aA00E6934e6904e7B8e"
     }
   }
 }


### PR DESCRIPTION
# Summary
We were using Sepolia addresses but on devnet for TopUpView, so the fee was showing as $-.-- for swap. This patches to show the fees using devnet addresses
![Screenshot 2023-06-21 at 12 22 51 pm](https://github.com/immutable/ts-immutable-sdk/assets/122326421/4401ac4d-1447-4148-97fe-75021512cf69)

