### PR TITLE
ID-786 Added gitleaks config to ignore tests [NO-CHANGELOG]

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,6 @@
 title = "Unified SDK gitleaks config"
 
 [whitelist]
-# As of v4, gitleaks only matches against filename, not path in the
-# files directive.  Leaving content for backwards compatibility.
-files = [
-  "(.*?)(jpg|gif|doc|pdf|bin)$",
-  ".gitleaks.toml",
-  "^.+\\.(t|j)sx?$"
+exactMatch = [
+  '0x7EEC32793414aAb720a90073607733d9e7B0ecD0' # Ethereum address used in Passport unit tests
 ]


### PR DESCRIPTION
# Summary
The [Gitleaks action failed](https://github.com/immutable/ts-immutable-sdk/actions/runs/5352404702/jobs/9707282566) against [this branch](https://github.com/immutable/ts-immutable-sdk/compare/feature/ID-694-zkevm-provider) due to [Passport.int.test.ts](https://github.com/immutable/ts-immutable-sdk/blob/6cfb0ffe03a123eecf69bc2cfb51b576ad6bcdf4/packages/passport/src/Passport.int.test.ts#L35) containing an etherKey.

This PR adds a `.gitleaks.toml` and ignores test files and some other files that may cause issues (images, PDFs, docs, bin files).

Example of a successful run with this config [here](https://github.com/immutable/ts-immutable-sdk/actions/runs/5352492990/jobs/9707466694).