### PR TITLE
[ID-839]Passing the etherAddress to confirmation screen

### DIFF
--- a/packages/passport/src/confirmation/confirmation.test.ts
+++ b/packages/passport/src/confirmation/confirmation.test.ts
@@ -15,6 +15,7 @@ const mockNewWindow = {
 const mockedOpen = jest.fn().mockReturnValue(mockNewWindow);
 const addEventListenerMock = jest.fn();
 const removeEventListenerMock = jest.fn();
+const mockEtherAddress = '0x1234';
 
 describe('confirmation', () => {
   beforeEach(() => {
@@ -64,11 +65,12 @@ describe('confirmation', () => {
       const transactionId = 'transactionId123';
       const res = await confirmationScreen.startGuardianTransaction(
         transactionId,
+        mockEtherAddress,
       );
       confirmationScreen.loading();
 
       expect(res.confirmed).toEqual(false);
-      expect(mockNewWindow.location.href).toEqual('https://passport.sandbox.immutable.com/transaction-confirmation/transaction.html?transactionId=transactionId123&chainType=starkex');
+      expect(mockNewWindow.location.href).toEqual('https://passport.sandbox.immutable.com/transaction-confirmation/transaction.html?transactionId=transactionId123&imxEtherAddress=0x1234&chainType=starkex');
     });
   });
 

--- a/packages/passport/src/confirmation/confirmation.ts
+++ b/packages/passport/src/confirmation/confirmation.ts
@@ -95,6 +95,7 @@ export default class ConfirmationScreen {
 
   startGuardianTransaction(
     transactionId: string,
+    imxEtherAddress: string,
   ): Promise<ConfirmationResult> {
     return new Promise((resolve, reject) => {
       const messageHandler = ({ data, origin }: MessageEvent) => {
@@ -126,7 +127,7 @@ export default class ConfirmationScreen {
         return;
       }
       // eslint-disable-next-line max-len
-      this.confirmationWindow.location.href = `${this.config.passportDomain}/transaction-confirmation/transaction.html?transactionId=${transactionId}&chainType=starkex`;
+      this.confirmationWindow.location.href = `${this.config.passportDomain}/transaction-confirmation/transaction.html?transactionId=${transactionId}&imxEtherAddress=${imxEtherAddress}&chainType=starkex`;
       // https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128
       const timer = setInterval(() => {
         if (this.confirmationWindow?.closed) {

--- a/packages/passport/src/starkEx/guardian.test.ts
+++ b/packages/passport/src/starkEx/guardian.test.ts
@@ -19,6 +19,7 @@ describe('guardian', () => {
     }));
   });
   const mockAccessToken = 'eyJh1234';
+  const mockEtherAddress = '0x1234';
   const mockConfirmationScreen = new ConfirmationScreen({} as any);
   const mockImxPublicApiDomain = 'https://api.example.com';
 
@@ -31,6 +32,7 @@ describe('guardian', () => {
         accessToken: mockAccessToken,
         imxPublicApiDomain: mockImxPublicApiDomain,
         confirmationScreen: mockConfirmationScreen,
+        imxEtherAddress: mockEtherAddress,
       });
       await guardianClient.validate({ payloadHash: 'hash' });
       expect(mockConfirmationScreen.startGuardianTransaction).toBeCalledTimes(0);
@@ -42,6 +44,8 @@ describe('guardian', () => {
         accessToken: mockAccessToken,
         imxPublicApiDomain: mockImxPublicApiDomain,
         confirmationScreen: mockConfirmationScreen,
+        imxEtherAddress: mockEtherAddress,
+
       });
       await guardianClient.validate({ payloadHash: 'hash' });
 
@@ -57,10 +61,11 @@ describe('guardian', () => {
         accessToken: mockAccessToken,
         imxPublicApiDomain: mockImxPublicApiDomain,
         confirmationScreen: mockConfirmationScreen,
+        imxEtherAddress: mockEtherAddress,
       });
       await guardianClient.validate({ payloadHash: 'hash' });
 
-      expect(mockConfirmationScreen.startGuardianTransaction).toHaveBeenCalledWith('hash');
+      expect(mockConfirmationScreen.startGuardianTransaction).toHaveBeenCalledWith('hash', mockEtherAddress);
     });
 
     it('should throw error if user did not confirm the transaction', async () => {
@@ -73,6 +78,7 @@ describe('guardian', () => {
         accessToken: mockAccessToken,
         imxPublicApiDomain: mockImxPublicApiDomain,
         confirmationScreen: mockConfirmationScreen,
+        imxEtherAddress: mockEtherAddress,
       });
       expect(guardianClient.validate({ payloadHash: 'hash' })).rejects.toThrow('Transaction rejected by user');
     });

--- a/packages/passport/src/starkEx/guardian.ts
+++ b/packages/passport/src/starkEx/guardian.ts
@@ -6,6 +6,7 @@ export type GuardianClientParams = {
   accessToken: string;
   imxPublicApiDomain: string;
   confirmationScreen: ConfirmationScreen;
+  imxEtherAddress: string;
 };
 
 export type GuardianValidateParams = {
@@ -18,7 +19,11 @@ export default class GuardianClient {
 
   private confirmationScreen: ConfirmationScreen;
 
-  constructor({ imxPublicApiDomain, accessToken, confirmationScreen }: GuardianClientParams) {
+  private imxEtherAddress: string;
+
+  constructor({
+    imxPublicApiDomain, accessToken, confirmationScreen, imxEtherAddress,
+  }: GuardianClientParams) {
     this.confirmationScreen = confirmationScreen;
     this.transactionAPI = new guardian.TransactionsApi(
       new guardian.Configuration({
@@ -26,6 +31,7 @@ export default class GuardianClient {
         basePath: imxPublicApiDomain,
       }),
     );
+    this.imxEtherAddress = imxEtherAddress;
   }
 
   public async validate({ popupWindowSize, payloadHash }: GuardianValidateParams) {
@@ -54,6 +60,7 @@ export default class GuardianClient {
     if (confirmationRequired) {
       const confirmationResult = await this.confirmationScreen.startGuardianTransaction(
         payloadHash,
+        this.imxEtherAddress,
       );
 
       if (!confirmationResult.confirmed) {

--- a/packages/passport/src/starkEx/passportImxProvider.ts
+++ b/packages/passport/src/starkEx/passportImxProvider.ts
@@ -66,6 +66,7 @@ export class PassportImxProvider implements IMXProvider {
       imxPublicApiDomain,
       accessToken: user.accessToken,
       confirmationScreen,
+      imxEtherAddress: user.imx.ethAddress,
     });
   }
 


### PR DESCRIPTION
# Summary
To Passing the etherAddress to confirmation screen.

# Why the changes
**The Persist JWT contains an issue:**
If User Login through GameA using UserA and does some workflows, which will save persistent JWT to localStorage using UserA
Then User switch the User to UserB, but because the persisted JWT in the confirmation screen is still UserA. It would be an issue to call the evaluation because the JWT belongs to UserA (edited) 

**Solution**:
1. send etherAddress from SDK to the confirmation screen,
2. then compare the etherAddress with the token’s key; log in again if it is not the same. login again.


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
