### PR TITLE
ID-836 Updated PassportMR basePath [NO-CHANGELOG]

### DIFF
--- a/packages/internal/generated-clients/src/config/config.ts
+++ b/packages/internal/generated-clients/src/config/config.ts
@@ -67,7 +67,7 @@ export const multiRollupConfig = {
       basePath: 'https://order-book-mr.imtbl.com',
     }),
     passport: createConfig({
-      basePath: 'https://api.immutable.com/passport-mr',
+      basePath: 'https://api.immutable.com',
     }),
   }),
   getSandbox: (): MultiRollupAPIConfiguration => ({
@@ -78,7 +78,7 @@ export const multiRollupConfig = {
       basePath: 'https://order-book-mr.sandbox.imtbl.com',
     }),
     passport: createConfig({
-      basePath: 'https://api.sandbox.immutable.com/passport-mr',
+      basePath: 'https://api.sandbox.immutable.com',
     }),
   }),
 };


### PR DESCRIPTION
# Summary
This PR updates the `generated-clients` Passport `basePath`


# Why the changes
The `basePath` included `passport-mr`, but this is appended with each route. This meant that attempting to use the passport client would result in an invalid URL, e.g `https://api.sandbox.immutable.com/passport-mr/passport-mr/v1/counterfactual-address`