### PR TITLE
Fix: module not found issue[NO-CHANGELOG ]

### DIFF
--- a/packages/internal/bridge/sdk/package.json
+++ b/packages/internal/bridge/sdk/package.json
@@ -35,7 +35,6 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "module": "dist/module.js",
   "private": true,
   "repository": "immutable/ts-immutable-sdk.git",
   "scripts": {

--- a/packages/internal/dex/sdk/package.json
+++ b/packages/internal/dex/sdk/package.json
@@ -37,7 +37,6 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "module": "dist/module.js",
   "private": true,
   "repository": "immutable/ts-immutable-sdk.git",
   "scripts": {


### PR DESCRIPTION
# Summary
When testing locally with the local packed SDK(or [alpha.2](https://github.com/immutable/ts-immutable-sdk/releases/tag/0.1.9-alpha.2) build), it will have the following issue:
```
Module not found: Can't resolve '@imtbl/bridge-sdk'
```

That is because, from the built js file, it failed to build those two modules.

<img width="1229" alt="Screenshot_2023-06-28_at_10_51_00" src="https://github.com/immutable/ts-immutable-sdk/assets/3668156/95ba7140-e915-48ed-8095-dcbcdf6ffe2e">

The root cause is that it doesn't have a "dist/module.js" file defined in the package json.
So removing it from the config will resolve the issue.

# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
