### PR TITLE
NOJIRA: Skip naughty test [NO-CHANGELOG]

### DIFF
--- a/packages/checkout/sdk/package.json
+++ b/packages/checkout/sdk/package.json
@@ -43,7 +43,7 @@
     "lint": "eslint ./src --ext .ts,.jsx,.tsx --max-warnings=0",
     "lint:fix": "eslint ./src --ext .ts,.jsx,.tsx --max-warnings=0 --fix",
     "start": "parcel watch",
-    "test": "jest test --detectOpenHandles",
+    "test": "jest test",
     "test:coverage": "jest --coverage",
     "test:watch": "jest test --watch",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Skipping this one innocent-looking test causes the tests to complete in 2mins rather than 10mins

Before

![Screen Shot 2023-06-30 at 2 22 13 pm](https://github.com/immutable/ts-immutable-sdk/assets/101608096/2304f095-7c23-4943-8117-d0545ba45f96)

After

![Screen Shot 2023-06-30 at 2 20 10 pm](https://github.com/immutable/ts-immutable-sdk/assets/101608096/1d49607c-72c4-46ac-8979-a9ff051537b0)

I think its related to the fact that `createExchangeInstance` does a real network call.

Suggest we leave this test skipped for now, until the team can implement a proper fix.