### PR TITLE
ID-872 Improve `eth_requestAccounts` implementation

### DIFF
--- a/packages/passport/src/zkEvm/rpcMethods/index.ts
+++ b/packages/passport/src/zkEvm/rpcMethods/index.ts
@@ -1,2 +1,1 @@
-export * from './eth_requestAccounts';
 export * from './eth_sendTransaction';

--- a/packages/passport/src/zkEvm/userRegistration/createCounterfactualAddress.test.ts
+++ b/packages/passport/src/zkEvm/userRegistration/createCounterfactualAddress.test.ts
@@ -2,8 +2,8 @@ import { Web3Provider } from '@ethersproject/providers';
 import { signRaw } from '@imtbl/toolkit';
 import { MultiRollupApiClients } from '@imtbl/generated-clients';
 import { createCounterfactualAddress } from './createCounterfactualAddress';
-import AuthManager from '../authManager';
-import { mockUser, mockUserZkEvm } from '../test/mocks';
+import AuthManager from '../../authManager';
+import { mockUser, mockUserZkEvm } from '../../test/mocks';
 
 jest.mock('@ethersproject/providers');
 jest.mock('@imtbl/toolkit');

--- a/packages/passport/src/zkEvm/userRegistration/createCounterfactualAddress.ts
+++ b/packages/passport/src/zkEvm/userRegistration/createCounterfactualAddress.ts
@@ -1,9 +1,9 @@
 import { ExternalProvider, Web3Provider } from '@ethersproject/providers';
 import { MultiRollupApiClients } from '@imtbl/generated-clients';
 import { signRaw } from '@imtbl/toolkit';
-import { UserZkEvm } from '../types';
-import AuthManager from '../authManager';
-import { JsonRpcError, RpcErrorCode } from './JsonRpcError';
+import { UserZkEvm } from '../../types';
+import AuthManager from '../../authManager';
+import { JsonRpcError, RpcErrorCode } from '../JsonRpcError';
 
 export type CreateCounterfactualAddressInput = {
   authManager: AuthManager;

--- a/packages/passport/src/zkEvm/userRegistration/index.ts
+++ b/packages/passport/src/zkEvm/userRegistration/index.ts
@@ -1,0 +1,2 @@
+export * from './createCounterfactualAddress';
+export * from './registerZkEvmUser';

--- a/packages/passport/src/zkEvm/userRegistration/registerZkEvmUser.ts
+++ b/packages/passport/src/zkEvm/userRegistration/registerZkEvmUser.ts
@@ -1,30 +1,29 @@
 import { MultiRollupApiClients } from '@imtbl/generated-clients';
 import { ExternalProvider } from '@ethersproject/providers';
-import AuthManager from '../../authManager';
-import MagicAdapter from '../../magicAdapter';
-import { PassportConfiguration } from '../../config';
-import { createCounterfactualAddress } from '../createCounterfactualAddress';
+import { createCounterfactualAddress } from './createCounterfactualAddress';
 import { UserZkEvm } from '../../types';
+import AuthManager from '../../authManager';
+import { PassportConfiguration } from '../../config';
+import MagicAdapter from '../../magicAdapter';
 
-type EthRequestAccountsInput = {
+type RegisterZkEvmUserInput = {
   authManager: AuthManager;
   config: PassportConfiguration;
   magicAdapter: MagicAdapter;
   multiRollupApiClients: MultiRollupApiClients;
 };
 
-type EthRequestAccountsOutput = {
+type RegisterZkEvmUserOutput = {
   user: UserZkEvm;
   magicProvider: ExternalProvider;
-  result: string[];
 };
 
-export const ethRequestAccounts = async ({
+export const registerZkEvmUser = async ({
   authManager,
   config,
   magicAdapter,
   multiRollupApiClients,
-}: EthRequestAccountsInput): Promise<EthRequestAccountsOutput> => {
+}: RegisterZkEvmUserInput): Promise<RegisterZkEvmUserOutput> => {
   const user = await authManager.getUser() || await authManager.login();
   if (!user.idToken) {
     throw new Error('User is missing idToken');
@@ -45,14 +44,12 @@ export const ethRequestAccounts = async ({
 
     return {
       user: userZkevm,
-      result: [userZkevm.zkEvm.ethAddress],
       magicProvider,
     };
   }
 
   return {
     user: user as UserZkEvm,
-    result: [user.zkEvm.ethAddress],
     magicProvider,
   };
 };

--- a/packages/passport/src/zkEvm/zkEvmProvider.test.ts
+++ b/packages/passport/src/zkEvm/zkEvmProvider.test.ts
@@ -1,43 +1,74 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { ZkEvmProviderInput, ZkEvmProvider } from './zkEvmProvider';
+import { registerZkEvmUser } from './userRegistration';
 
 jest.mock('@ethersproject/providers');
 jest.mock('./relayerAdapter');
+jest.mock('./userRegistration');
 
 describe('ZkEvmProvider', () => {
-  const sendMock = jest.fn();
-  const passthroughMethods = [
-    ['eth_getStorageAt', '0x'],
-    ['eth_getBalance', '0x1'],
-    ['eth_gasPrice', '0x2'],
-    ['eth_estimateGas', '0x3'],
-  ];
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-
-    (JsonRpcProvider as unknown as jest.Mock).mockImplementation(() => ({
-      send: sendMock,
-    }));
-  });
-
-  it.each(passthroughMethods)('should passthrough %s to the jsonRpcProvider', async (method, returnValue) => {
-    sendMock.mockResolvedValueOnce(returnValue);
-
+  const getProvider = () => {
     const constructorParameters = {
       config: {},
     } as Partial<ZkEvmProviderInput>;
 
-    const provider = new ZkEvmProvider(constructorParameters as ZkEvmProviderInput);
+    return new ZkEvmProvider(constructorParameters as ZkEvmProviderInput);
+  };
 
-    // NOTE: params are static since we are only testing the call is
-    // forwarded with whatever parameters it's called with. Might not match
-    // the actual parameters for a specific method.
-    const providerParams = { method, params: [] };
-    const result = await provider.request(providerParams);
+  describe('passthrough methods', () => {
+    const sendMock = jest.fn();
+    const passthroughMethods = [
+      ['eth_getStorageAt', '0x'],
+      ['eth_getBalance', '0x1'],
+      ['eth_gasPrice', '0x2'],
+      ['eth_estimateGas', '0x3'],
+    ];
 
-    expect(sendMock).toBeCalledTimes(1);
-    expect(sendMock).toBeCalledWith(providerParams.method, providerParams.params);
-    expect(result).toBe(returnValue);
+    beforeEach(() => {
+      jest.resetAllMocks();
+
+      (JsonRpcProvider as unknown as jest.Mock).mockImplementation(() => ({
+        send: sendMock,
+      }));
+    });
+
+    it.each(passthroughMethods)('should passthrough %s to the jsonRpcProvider', async (method, returnValue) => {
+      sendMock.mockResolvedValueOnce(returnValue);
+
+      const provider = getProvider();
+
+      // NOTE: params are static since we are only testing the call is
+      // forwarded with whatever parameters it's called with. Might not match
+      // the actual parameters for a specific method.
+      const providerParams = { method, params: [] };
+      const result = await provider.request(providerParams);
+
+      expect(sendMock).toBeCalledTimes(1);
+      expect(sendMock).toBeCalledWith(providerParams.method, providerParams.params);
+      expect(result).toBe(returnValue);
+    });
+  });
+
+  describe('eth_requestAccounts', () => {
+    it('should return the ethAddress if already logged in', async () => {
+      const mockUser = {
+        zkEvm: {
+          ethAddress: '0x123',
+        },
+      };
+      const mockMagicProvider = {};
+      (registerZkEvmUser as jest.Mock).mockResolvedValue({
+        user: mockUser,
+        magicProvider: mockMagicProvider,
+      });
+      const provider = getProvider();
+
+      const resultOne = await provider.request({ method: 'eth_requestAccounts', params: [] });
+      const resultTwo = await provider.request({ method: 'eth_requestAccounts', params: [] });
+
+      expect(resultOne).toEqual([mockUser.zkEvm.ethAddress]);
+      expect(resultTwo).toEqual([mockUser.zkEvm.ethAddress]);
+      expect(registerZkEvmUser).toBeCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
# Summary
This PR improves upon the `eth_requestAccounts` method by no longer re-authenticating or re-initialising the Magic wallet when the `eth_requestAccounts` method is called subsequent times. This now matches the Metamask implementation. In addition, the `eth_requestAccounts` logic & `createCounterfactualAddress` logic has been moved to `zkevm/userRegistration`.
