### PR TITLE
[NO-CHANGELOG] Patch for provider injection validation check

### DIFF
--- a/packages/checkout/sdk/src/provider/validateProvider.ts
+++ b/packages/checkout/sdk/src/provider/validateProvider.ts
@@ -12,7 +12,7 @@ import { getUnderlyingChainId } from './getUnderlyingProvider';
 export function isWeb3Provider(
   web3Provider: Web3Provider,
 ): boolean {
-  if (web3Provider && web3Provider instanceof Web3Provider && web3Provider.provider?.request) {
+  if (web3Provider && web3Provider.provider?.request && typeof web3Provider.provider.request === 'function') {
     return true;
   }
   return false;


### PR DESCRIPTION
# Summary

The validator was failing when we inject the provider. removing the instanceof check fixes the issue, replaced it with a type check on the request function instead.
