### PR TITLE
Remove fetch-depth 0

### DIFF
--- a/.github/workflows/build-lint-typecheck-test.yaml
+++ b/.github/workflows/build-lint-typecheck-test.yaml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
This is only required when we need the entire history of every branch and commit. Nothing i can see in this action requires that, so lets remove it.

See here for more info https://github.com/actions/checkout