### PR TITLE
NOJIRA Updated sample-app dev zkEvmRpcUrl [NO-CHANGELOG]

### DIFF
--- a/packages/passport/sdk-sample-app/src/context/ImmutableProvider.tsx
+++ b/packages/passport/sdk-sample-app/src/context/ImmutableProvider.tsx
@@ -87,7 +87,7 @@ const getPassportConfig = (environment: EnvironmentNames): PassportModuleConfigu
               immutableXConfig: getCoreSdkConfig(EnvironmentNames.DEV),
             },
           }),
-          zkEvmRpcUrl: 'https://rpc.testnet.immutable.com',
+          zkEvmRpcUrl: 'https://rpc.dev.immutable.com',
           zkEvmChainId: 'eip155:13433',
           relayerUrl: 'https://api.dev.immutable.com/relayer-mr',
           indexerMrBasePath: 'https://api.dev.immutable.com',


### PR DESCRIPTION
# Summary
This PR corrects the `zkEvmRpcUrl` for the `dev` environment of the passport-sdk-sample-app.


# Why the changes
It was previously updated to `rpc.testnet.immutable.com`, which is the sandbox environment. We're using the "internal" dev address here because no external address exists for dev. Users will need to be connected to the VPN to access dev.