### PR TITLE
fix: Resolve game bridge calling init before Unreal game has connected.

### DIFF
--- a/packages/game-bridge/src/index.ts
+++ b/packages/game-bridge/src/index.ts
@@ -46,7 +46,7 @@ declare function UnityPostMessage(message: string): void;
 
 const waitForUOjectBinding = (data: object) => {
   const interval = setInterval(() => {
-    if (typeof window.ue !== 'undefined' && window.ue.jsconnector !== 'undefined') {
+    if (typeof window.ue !== 'undefined' && typeof window.ue.jsconnector !== 'undefined') {
       clearInterval(interval);
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       callbackToGame(data);


### PR DESCRIPTION
# Summary
Adds a setInterval-based wait loop to handle the case where the game bridge finished loading before the Unreal game can bind its connector object to the browser session.


# Why the changes
Resolves an intermittent initialisation issue.


# Things worth calling out
