### PR TITLE
[NOJIRA][NO-CHANGELOG] Disable the major release type from the publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ on:
           - none
           - patch
           - minor
-          - major
+          # - major
         required: false
         default: none
       dry_run:


### PR DESCRIPTION
# Summary

Temporarily disable major releases until there is a stable release to prevent someone from releasing 1.0.0.

# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
