### PR TITLE
[NO-CHANGELOG] feat: pass environment on initialisation of passport in game bridge

### DIFF
--- a/packages/game-bridge/src/index.ts
+++ b/packages/game-bridge/src/index.ts
@@ -87,7 +87,7 @@ window.callFunction = async (jsonData: string) => { // eslint-disable-line no-un
         if (!passportClient) {
           const passportConfig = {
             baseConfig: new config.ImmutableConfiguration({
-              environment: config.Environment.SANDBOX,
+              environment: request.environment,
             }),
             clientId: request.clientId,
             audience,

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -70,7 +70,7 @@ export class Passport {
     return this.passportImxProviderFactory.getProviderWithDeviceFlow(deviceCode, interval, timeoutMs);
   }
 
-  getPKCEAuthorizationUrl(): string {
+  public getPKCEAuthorizationUrl(): string {
     return this.authManager.getPKCEAuthorizationUrl();
   }
 


### PR DESCRIPTION
# Summary
Allow the developer to pass in the environment when initialising Passport for the Game Bridge.


# Why the changes
Previously, it was hardcoded to Sandbox.


# Things worth calling out
N/A
