### PR TITLE
[NO-CHANGELOG] fix: Remove additional version bump used during testing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,11 +69,6 @@ jobs:
           ./.github/scripts/version-up.sh --${{github.event.inputs.release_type }} --$upgrade_type --apply $revision_upgrade
         shell: bash
 
-      - name: Workout next version string
-        run: |
-          ./.github/scripts/version-up.sh --release --patch --apply
-        shell: bash        
-
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
# Summary

Fixing a bug in the publish workflow that unintentionally bumps the next version tag twice.

This was added accidentally while working on [DX-2297](https://immutable.atlassian.net/browse/DX-2297)

# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


[DX-2297]: https://immutable.atlassian.net/browse/DX-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ