### PR TITLE
[NO-CHANGELOG] Fix broken link, add link to zkEVM API reference

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -11,7 +11,10 @@
 
 See our [developer documentation](https://docs.immutable.com) for information on building on Immutable.
 
-See our [API reference](https://docs.immutable.com/reference) for more information on our APIs.
+See our rollup API references for more information on our APIs.
+
+- [Immutable X API Reference](https://docs.immutable.com/x/reference)
+- [Immutable zkEVM API Reference](https://docs.immutable.com/zkevm/reference)
 
 ### Examples
 
@@ -20,7 +23,7 @@ See our [API reference](https://docs.immutable.com/reference) for more informati
 ## Installation
 
 ```sh
-npm install @imtbl/sdk --save
+npm install @imtbl/sdk
 # or
 yarn add @imtbl/sdk
 ```


### PR DESCRIPTION
# Summary

[DX-2300](https://immutable.atlassian.net/browse/DX-2300)

API Reference link on npm is broken. Fixed the link to the X API reference, added a link to the zkEVM reference

# Why the changes
<!--- State the reason/context for the change. -->

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


[DX-2300]: https://immutable.atlassian.net/browse/DX-2300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ