### PR TITLE
[NO-CHANGELOG][GPR-106] Primary revenue widget add passport provider and init from query params

### DIFF
--- a/packages/checkout/widgets-lib/src/global.d.ts
+++ b/packages/checkout/widgets-lib/src/global.d.ts
@@ -9,6 +9,7 @@ import {
   ImtblTransitionExampleProps,
   ImtblInnerWidgetExampleProps,
   ImtblOuterWidgetExampleProps,
+  ImtblPrimaryRevenueProps,
 } from '@imtbl/checkout-widgets';
 
 declare global {

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWebComponent.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWebComponent.tsx
@@ -7,8 +7,16 @@ import {
 } from '../../components/ConnectLoader/ConnectLoader';
 import { ImmutableWebComponent } from '../ImmutableWebComponent';
 import { ConnectTargetLayer, getL1ChainId, getL2ChainId } from '../../lib';
+import {
+  isValidAddress,
+  isValidAmount,
+} from '../../lib/validations/widgetValidators';
 
 export class ImmutablePrimaryRevenue extends ImmutableWebComponent {
+  amount = '';
+
+  fromContractAddress = '';
+
   constructor() {
     console.log('ImmutablePrimaryRevenue constructor'); // eslint-disable-line no-console
     super();
@@ -16,12 +24,25 @@ export class ImmutablePrimaryRevenue extends ImmutableWebComponent {
 
   connectedCallback() {
     super.connectedCallback();
-    // TODO: initialise widget inputs
+
+    this.amount = this.getAttribute('amount') ?? '';
+    this.fromContractAddress = this.getAttribute('fromContractAddress')?.toLowerCase() ?? '';
+
     this.renderWidget();
   }
 
   validateInputs(): void {
-    // TODO: validate widget inputs
+    if (!isValidAmount(this.amount)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "amount" widget input');
+      this.amount = '';
+    }
+
+    if (!isValidAddress(this.fromContractAddress)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "fromContractAddress" widget input');
+      this.fromContractAddress = '';
+    }
   }
 
   renderWidget() {
@@ -44,11 +65,12 @@ export class ImmutablePrimaryRevenue extends ImmutableWebComponent {
         <ConnectLoader
           widgetConfig={this.widgetConfig!}
           params={connectLoaderParams}
-          closeEvent={() => {
-          }}
+          closeEvent={() => {}}
         >
           <PrimaryRevenueWidget
             config={this.widgetConfig!}
+            amount={this.amount}
+            fromContractAddress={this.fromContractAddress}
           />
         </ConnectLoader>
       </React.StrictMode>,

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWebView.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWebView.tsx
@@ -5,9 +5,12 @@ import { config, passport } from '@imtbl/sdk';
 import { WidgetTheme } from '../../lib';
 import { ImmutableWebComponent } from '../ImmutableWebComponent';
 
-const usePassportInstance = () => {
+const passportlink =  "http://localhost:3001/primary-revenue?clientId=XuGsHvMqMJrb73diq1fCswWwn4AYhcM6&redirectUri=http://localhost:3001/primary-revenue&logoutRedirectUri=http://localhost:3001/primary-revenue&audience=platform_api&scope=openid%20offline_access%20email%20transact&environment=sandbox"; // eslint-disable-line
+
+const useParams = () => {
   const urlParams = new URLSearchParams(window.location.search);
 
+  const login = urlParams.get('login') as string;
   const clientId = urlParams.get('clientId') as string;
   const redirectUri = urlParams.get('redirectUri') as string;
   const logoutRedirectUri = urlParams.get('logoutRedirectUri') as string;
@@ -17,6 +20,31 @@ const usePassportInstance = () => {
     sandbox: config.Environment.SANDBOX,
     production: config.Environment.PRODUCTION,
   }[urlParams.get('environment') || 'sandbox'];
+  const amount = urlParams.get('amount') as string;
+  const fromContractAddress = urlParams.get('fromContractAddress') as string;
+
+  return {
+    login,
+    clientId,
+    redirectUri,
+    logoutRedirectUri,
+    audience,
+    scope,
+    environment,
+    amount,
+    fromContractAddress,
+  };
+};
+
+const usePassportInstance = () => {
+  const {
+    clientId,
+    redirectUri,
+    logoutRedirectUri,
+    audience,
+    scope,
+    environment,
+  } = useParams();
 
   if (!clientId || !redirectUri || !logoutRedirectUri || !audience || !scope) {
     return null;
@@ -37,6 +65,9 @@ const usePassportInstance = () => {
 };
 
 function PrimaryRevenueWebView() {
+  const params = useParams();
+  const { login, amount, fromContractAddress } = params;
+
   useEffect(() => {
     const passportInstance = usePassportInstance();
     if (!passportInstance) return;
@@ -46,25 +77,51 @@ function PrimaryRevenueWebView() {
     );
     primaryRevenueElement?.addPassportOption(passportInstance as any);
 
-    const urlParams = new URLSearchParams(window.location.search);
-    const login = urlParams.get('login') as string;
     if (login) {
       passportInstance.loginCallback();
     }
-  }, []);
+  }, [login]);
+
+  const handleRedirect = (withPassport: boolean) => (e: any) => {
+    e.preventDefault();
+    const origin = new URL(window.location.href);
+    const destination = new URL(passportlink);
+
+    destination.searchParams.forEach((value, key) => {
+      if (withPassport) {
+        origin.searchParams.set(key, value);
+      } else {
+        origin.searchParams.delete(key);
+      }
+    });
+
+    window.location.href = origin.toString();
+  };
 
   const widgetConfig = {
     theme: WidgetTheme.LIGHT,
     environment: Environment.SANDBOX,
   };
-  const testLink = 'http://localhost:3001/primary-revenue?clientId=XuGsHvMqMJrb73diq1fCswWwn4AYhcM6&redirectUri=http://localhost:3001/primary-revenue&logoutRedirectUri=http://localhost:3001/primary-revenue&audience=platform_api&scope=openid%20offline_access%20email%20transact&environment=sandbox'; // eslint-disable-line max-len
+
   return (
     <>
-      <imtbl-primary-revenue widgetConfig={JSON.stringify(widgetConfig)} />
+      <imtbl-primary-revenue
+        widgetConfig={JSON.stringify(widgetConfig)}
+        amount={amount}
+        fromContractAddress={fromContractAddress}
+      />
       <br />
-      <h1><a href={testLink}>Passport On</a></h1>
+      <h1>
+        <a href="#" onClick={handleRedirect(true)}>
+          Passport On
+        </a>
+      </h1>
       <br />
-      <h1><a href="/primary-revenue">Passport Off</a></h1>
+      <h1>
+        <a href="#" onClick={handleRedirect(false)}>
+          Passport Off
+        </a>
+      </h1>
     </>
   );
 }

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWidget.tsx
@@ -27,10 +27,12 @@ import { TopUpView } from '../../views/top-up/TopUpView';
 
 export interface PrimaryRevenueWidgetProps {
   config: StrongCheckoutWidgetsConfig;
+  amount: string;
+  fromContractAddress: string;
 }
 
 export function PrimaryRevenueWidget(props: PrimaryRevenueWidgetProps) {
-  const { config } = props;
+  const { config, amount, fromContractAddress } = props;
   const loadingText = text.views[SharedViews.LOADING_VIEW].text;
 
   const { theme } = config;
@@ -79,18 +81,15 @@ export function PrimaryRevenueWidget(props: PrimaryRevenueWidgetProps) {
     const { formattedBalance } = await checkout.getBalance({
       provider,
       walletAddress,
-      // FIXME: get erc20 address from props
-      contractAddress: '0x21b51ec6fb7654b7e59e832f9e9687f29df94fb8',
+      contractAddress: fromContractAddress,
     });
 
-    const balance = Number(formattedBalance);
+    const balance = parseFloat(formattedBalance);
+    const requiredAmounts = parseFloat(amount);
+    console.log('🚀 ~ file:  ~ balance:', balance, requiredAmounts);
 
-    // FIXME: get amount from props
-    // const amount = 0.0001;
-    const amount = 10000000;
-
-    return balance > amount;
-  }, [checkout, provider]);
+    return balance > requiredAmounts;
+  }, [checkout, provider, amount, fromContractAddress]);
 
   useEffect(() => {
     if (!checkout || !provider) return;

--- a/packages/checkout/widgets/src/definitions/global.ts
+++ b/packages/checkout/widgets/src/definitions/global.ts
@@ -125,4 +125,6 @@ export interface ImtblPrimaryRevenueProps
   HTMLElement
   > {
   widgetConfig?: string;
+  amount?: string;
+  fromContractAddress?: string;
 }


### PR DESCRIPTION
# Summary
- Init widget from query params
  - amount, fromContractAddress (erc20)
- Add passport instance to web view component, to demo connecting a passport wallet


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
