### PR TITLE
feat: [WT-1554] Implementation for calculating routing options availability

### DIFF
--- a/packages/checkout/sdk/src/config/config.ts
+++ b/packages/checkout/sdk/src/config/config.ts
@@ -6,6 +6,9 @@ import {
   PRODUCTION_CHAIN_ID_NETWORK_MAP,
   SANDBOX_CHAIN_ID_NETWORK_MAP,
   ChainId,
+  DEFAULT_ON_RAMP_ENABLED,
+  DEFAULT_SWAP_ENABLED,
+  DEFAULT_BRIDGE_ENABLED,
 } from '../types';
 import { RemoteConfigFetcher } from './remoteConfigFetcher';
 
@@ -53,6 +56,12 @@ export class CheckoutConfiguration {
 
   readonly isProduction: boolean;
 
+  readonly isOnRampEnabled: boolean;
+
+  readonly isSwapEnabled: boolean;
+
+  readonly isBridgeEnabled: boolean;
+
   readonly remote: RemoteConfigFetcher;
 
   readonly environment: Environment;
@@ -70,6 +79,9 @@ export class CheckoutConfiguration {
 
     // Developer mode will super set any environment configuration
     this.isProduction = !this.isDevelopment && this.environment === Environment.PRODUCTION;
+    this.isOnRampEnabled = config.isOnRampEnabled ?? DEFAULT_ON_RAMP_ENABLED;
+    this.isSwapEnabled = config.isSwapEnabled ?? DEFAULT_SWAP_ENABLED;
+    this.isBridgeEnabled = config.isBridgeEnabled ?? DEFAULT_BRIDGE_ENABLED;
 
     this.networkMap = networkMap(
       this.isProduction,

--- a/packages/checkout/sdk/src/smartCheckout/routing/geoBlocking.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/geoBlocking.ts
@@ -1,0 +1,3 @@
+export const isOnRampGeoBlocked = async (): Promise<boolean> => true;
+
+export const isSwapGeoBlocked = async (): Promise<boolean> => true;

--- a/packages/checkout/sdk/src/smartCheckout/routing/index.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/index.ts
@@ -1,0 +1,1 @@
+export * from './routingOptions';

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingOptions.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingOptions.test.ts
@@ -1,0 +1,135 @@
+import { Web3Provider } from '@ethersproject/providers';
+import { Environment } from '@imtbl/config';
+import { routingOptionsAvailable } from './routingOptions';
+import { CheckoutConfiguration } from '../../config';
+import * as geoBlocking from './geoBlocking';
+import { DEFAULT_BRIDGE_ENABLED, DEFAULT_ON_RAMP_ENABLED, DEFAULT_SWAP_ENABLED } from '../../types';
+
+jest.mock('./geoBlocking', () => ({
+  isOnRampGeoBlocked: jest.fn().mockResolvedValue(false),
+  isSwapGeoBlocked: jest.fn().mockResolvedValue(false),
+}));
+
+describe('routingOptions', () => {
+  let mockProvider: Web3Provider;
+  let config: CheckoutConfiguration;
+
+  beforeEach(() => {
+    mockProvider = {
+      getSigner: jest.fn().mockReturnValue({
+        getAddress: jest.fn().mockResolvedValue('0xADDRESS'),
+      }),
+    } as unknown as Web3Provider;
+
+    config = new CheckoutConfiguration({
+      baseConfig: { environment: Environment.SANDBOX },
+    });
+
+    // Default to no geo-blocking
+    (geoBlocking.isOnRampGeoBlocked as jest.Mock).mockResolvedValue(false);
+    (geoBlocking.isSwapGeoBlocked as jest.Mock).mockResolvedValue(false);
+  });
+
+  it('should return default routing options if no routing availability overrides configured', async () => {
+    const routingOptions = await routingOptionsAvailable(config, mockProvider);
+    expect(routingOptions).toEqual({
+      onRamp: DEFAULT_ON_RAMP_ENABLED,
+      swap: DEFAULT_SWAP_ENABLED,
+      bridge: DEFAULT_BRIDGE_ENABLED,
+    });
+  });
+
+  it('should return default routing options if no geo-blocking', async () => {
+    (geoBlocking.isOnRampGeoBlocked as jest.Mock).mockResolvedValue(false);
+    (geoBlocking.isSwapGeoBlocked as jest.Mock).mockResolvedValue(false);
+
+    const routingOptions = await routingOptionsAvailable(config, mockProvider);
+    expect(routingOptions).toEqual({
+      onRamp: DEFAULT_ON_RAMP_ENABLED,
+      swap: DEFAULT_SWAP_ENABLED,
+      bridge: DEFAULT_BRIDGE_ENABLED,
+    });
+  });
+
+  it('should return configured routing availability overrides if provided', async () => {
+    const configWithOptions = new CheckoutConfiguration({
+      baseConfig: { environment: Environment.SANDBOX },
+      isBridgeEnabled: false,
+      isOnRampEnabled: false,
+      isSwapEnabled: false,
+    });
+
+    const routingOptions = await routingOptionsAvailable(configWithOptions, mockProvider);
+    expect(routingOptions).toEqual({
+      onRamp: false,
+      swap: false,
+      bridge: false,
+    });
+  });
+
+  it('should disable onRamp options if OnRamp is geo-blocked', async () => {
+    (geoBlocking.isOnRampGeoBlocked as jest.Mock).mockResolvedValue(true);
+
+    const routingOptions = await routingOptionsAvailable(config, mockProvider);
+    expect(routingOptions.onRamp).toEqual(false);
+  });
+
+  it('should disable OnRamp options if OnRamp geo-blocked checks are rejected', async () => {
+    (geoBlocking.isOnRampGeoBlocked as jest.Mock).mockRejectedValue({ error: '404' });
+
+    const routingOptions = await routingOptionsAvailable(config, mockProvider);
+    expect(routingOptions.onRamp).toEqual(false);
+  });
+
+  it('should disable Swap options if Swap is geo-blocked', async () => {
+    (geoBlocking.isSwapGeoBlocked as jest.Mock).mockResolvedValue(true);
+
+    const routingOptions = await routingOptionsAvailable(config, mockProvider);
+    expect(routingOptions.swap).toEqual(false);
+  });
+
+  it('should disable Swap options if Swap geo-blocked checks are rejected', async () => {
+    (geoBlocking.isSwapGeoBlocked as jest.Mock).mockRejectedValue({ error: '404' });
+
+    const routingOptions = await routingOptionsAvailable(config, mockProvider);
+    expect(routingOptions.swap).toEqual(false);
+  });
+
+  it('should disable both options if OnRamp and Bridge is geo-blocked', async () => {
+    (geoBlocking.isOnRampGeoBlocked as jest.Mock).mockResolvedValue(true);
+    (geoBlocking.isSwapGeoBlocked as jest.Mock).mockResolvedValue(true);
+
+    const routingOptions = await routingOptionsAvailable(config, mockProvider);
+    expect(routingOptions.onRamp).toEqual(false);
+    expect(routingOptions.swap).toEqual(false);
+  });
+
+  it('should disable both options if OnRamp and Bridge geo-blocked checks are rejected', async () => {
+    (geoBlocking.isOnRampGeoBlocked as jest.Mock).mockRejectedValue({ error: '404' });
+    (geoBlocking.isSwapGeoBlocked as jest.Mock).mockRejectedValue({ error: '404' });
+
+    const routingOptions = await routingOptionsAvailable(config, mockProvider);
+    expect(routingOptions.onRamp).toEqual(false);
+    expect(routingOptions.swap).toEqual(false);
+  });
+
+  it('should disable Bridge options if Passport provider', async () => {
+    const mockPassportProvider = {
+      provider: {
+        isPassport: true,
+      },
+    } as unknown as Web3Provider;
+
+    const routingOptions = await routingOptionsAvailable(config, mockPassportProvider);
+    expect(routingOptions.bridge).toEqual(false);
+  });
+
+  it('should enable Bridge options if non-Passport provider', async () => {
+    const mockPassportProvider = {
+      provider: {},
+    } as unknown as Web3Provider;
+
+    const routingOptions = await routingOptionsAvailable(config, mockPassportProvider);
+    expect(routingOptions.bridge).toEqual(true);
+  });
+});

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingOptions.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingOptions.ts
@@ -1,0 +1,51 @@
+import { Web3Provider } from '@ethersproject/providers';
+import { CheckoutConfiguration } from '../../config';
+import { RoutingOptionsAvailable } from '../../types';
+import { isOnRampGeoBlocked, isSwapGeoBlocked } from './geoBlocking';
+
+const isPassportProvider = (provider: Web3Provider) => (provider.provider as any)?.isPassport === true ?? false;
+
+type GeoBlockingCheck = {
+  id: 'onRamp' | 'swap';
+  promise: Promise<boolean>;
+};
+
+/**
+ * Determines which routing options are available.
+ */
+export const routingOptionsAvailable = async (
+  config: CheckoutConfiguration,
+  provider: Web3Provider,
+) : Promise<RoutingOptionsAvailable> => {
+  const availableRoutingOptions = {
+    onRamp: config.isOnRampEnabled,
+    swap: config.isSwapEnabled,
+    bridge: config.isBridgeEnabled,
+  };
+
+  // Geo-blocking checks
+  const geoBlockingChecks: GeoBlockingCheck[] = [];
+  if (availableRoutingOptions.onRamp) {
+    geoBlockingChecks.push({ id: 'onRamp', promise: isOnRampGeoBlocked() });
+  }
+  if (availableRoutingOptions.swap) {
+    geoBlockingChecks.push({ id: 'swap', promise: isSwapGeoBlocked() });
+  }
+
+  if (geoBlockingChecks.length > 0) {
+    const promises = geoBlockingChecks.map((geoBlockingCheck) => geoBlockingCheck.promise);
+    const geoBlockingStatus = await Promise.allSettled(promises);
+
+    geoBlockingStatus.forEach((result, index) => {
+      const statusId = geoBlockingChecks[index].id;
+      availableRoutingOptions[statusId] = availableRoutingOptions[statusId]
+        && result.status === 'fulfilled'
+        && !result.value;
+    });
+  }
+
+  // Bridge not available if passport provider
+  availableRoutingOptions.bridge = availableRoutingOptions.bridge && !isPassportProvider(provider);
+
+  return availableRoutingOptions;
+};

--- a/packages/checkout/sdk/src/types/config.ts
+++ b/packages/checkout/sdk/src/types/config.ts
@@ -4,7 +4,11 @@ import { TokenInfo } from './tokenInfo';
 import { ChainId } from './chains';
 
 export interface CheckoutOverrides {}
-export interface CheckoutModuleConfiguration extends ModuleConfiguration<CheckoutOverrides> {}
+export interface CheckoutModuleConfiguration extends ModuleConfiguration<CheckoutOverrides> {
+  isOnRampEnabled?: boolean,
+  isSwapEnabled?: boolean,
+  isBridgeEnabled?: boolean,
+}
 
 /**
  * A type representing various remotely defined configurations which are

--- a/packages/checkout/sdk/src/types/constants.ts
+++ b/packages/checkout/sdk/src/types/constants.ts
@@ -18,6 +18,21 @@ export const CHECKOUT_API_BASE_URL = {
   [Environment.PRODUCTION]: 'https://checkout-api.immutable.com',
 };
 
+/**
+ * Smart Checkout routing default onramp enabled flag
+ */
+export const DEFAULT_ON_RAMP_ENABLED = true;
+
+/**
+ * Smart Checkout routing default swap enabled flag
+ */
+export const DEFAULT_SWAP_ENABLED = true;
+
+/**
+ * Smart Checkout routing default bridge enabled flag
+ */
+export const DEFAULT_BRIDGE_ENABLED = true;
+
 export const BLOCKSCOUT_CHAIN_URL_MAP: { [key: string]: string } = {
   [ChainId.IMTBL_ZKEVM_TESTNET]: 'https://explorer.testnet.immutable.com',
 };

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -207,3 +207,13 @@ export type BalanceDelta = {
   balance: BigNumber;
   formattedBalance: string;
 };
+
+/**
+ * A type representing the Smart Checkout routing options available for a user
+ * if they are configured and enabled (not geo-blocked etc.)
+ */
+export type RoutingOptionsAvailable = {
+  onRamp?: boolean;
+  swap?: boolean;
+  bridge?: boolean;
+};


### PR DESCRIPTION
# Summary
https://immutable.atlassian.net/browse/WT-1554

[ ] - Pull down PR
[ ] - Run through ACs

# Why the changes
SmartCheckout needs to determine if specific routing options are available based on configuration, providers, and geo-blocking constraints.


# Things worth calling out
CheckoutModule configuration now supports an optional `routing` flags as external facing configuration the customer can override to enable/disable Smart Checkout routing options.
 isOnRampEnabled?: boolean,
 isSwapEnabled?: boolean,
 isBridgeEnabled?: boolean,
