### PR TITLE
Primary Revenut Widget - Update widget to handle the updated /sign en…

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWebComponent.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWebComponent.tsx
@@ -8,14 +8,10 @@ import {
 import { ImmutableWebComponent } from '../ImmutableWebComponent';
 import { ConnectTargetLayer, getL1ChainId, getL2ChainId } from '../../lib';
 import {
-  isValidAddress,
   isValidAmount,
 } from '../../lib/validations/widgetValidators';
 
 export class ImmutablePrimaryRevenue extends ImmutableWebComponent {
-  // @deprecated
-  fromContractAddress = '';
-
   amount = '';
 
   envId = '';
@@ -36,8 +32,6 @@ export class ImmutablePrimaryRevenue extends ImmutableWebComponent {
     this.envId = this.getAttribute('envId') ?? '';
     this.fromCurrency = this.getAttribute('fromCurrency') ?? '';
     this.items = JSON.parse(this.getAttribute('items') ?? '');
-    // @deprecated
-    this.fromContractAddress = this.getAttribute('fromContractAddress')?.toLowerCase() ?? '';
     this.renderWidget();
   }
 
@@ -64,13 +58,6 @@ export class ImmutablePrimaryRevenue extends ImmutableWebComponent {
       // eslint-disable-next-line no-console
       console.warn('[IMTBL]: invalid "fromCurrency" widget input');
       this.fromCurrency = '';
-    }
-
-    // @deprecated
-    if (!isValidAddress(this.fromContractAddress)) {
-      // eslint-disable-next-line no-console
-      console.warn('[IMTBL]: invalid "fromContractAddress" widget input');
-      this.fromContractAddress = '';
     }
   }
 
@@ -99,11 +86,8 @@ export class ImmutablePrimaryRevenue extends ImmutableWebComponent {
           <PrimaryRevenueWidget
             config={this.widgetConfig!}
             amount={this.amount}
-            envId={this.envId}
             fromCurrency={this.fromCurrency}
             items={this.items}
-            // deprecated
-            fromContractAddress={this.fromContractAddress}
           />
         </ConnectLoader>
       </React.StrictMode>,

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWebView.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWebView.tsx
@@ -17,28 +17,16 @@ const defaultPassportConfig = {
 
 const defaultItems: Item[] = [
   {
-    id: '60',
+    productId: 'P0001',
     qty: 1,
-    price: '0.5',
-    name: 'Poliwag',
-    image: 'https://pokemon-nfts.s3.ap-southeast-2.amazonaws.com/images/60.png',
-    description: 'Poliwag',
   },
   {
-    id: '61',
+    productId: 'P0002',
     qty: 1,
-    price: '1',
-    name: 'Poliwhirl',
-    image: 'https://pokemon-nfts.s3.ap-southeast-2.amazonaws.com/images/61.png',
-    description: 'Poliwhirl',
   },
   {
-    id: '62',
+    productId: 'P0003',
     qty: 1,
-    price: '2',
-    name: 'Poliwrath',
-    image: 'https://pokemon-nfts.s3.ap-southeast-2.amazonaws.com/images/62.png',
-    description: 'Poliwrath',
   },
 ];
 
@@ -49,15 +37,12 @@ const useParams = () => {
   const amount = urlParams.get('amount') as string;
   const envId = urlParams.get('envId') as string;
   const fromCurrency = urlParams.get('fromCurrency') as string;
-  // @deprecated
-  const fromContractAddress = urlParams.get('fromContractAddress') as string;
 
   return {
     login,
     amount,
     envId,
     fromCurrency,
-    fromContractAddress,
   };
 };
 
@@ -92,7 +77,7 @@ const usePassportInstance = (passportConfig: any) => {
 function PrimaryRevenueWebView() {
   const params = useParams();
   const {
-    login, amount, envId, fromCurrency, fromContractAddress,
+    login, amount, envId, fromCurrency,
   } = params;
   const [passportOn, setPassportOn] = useState(false);
   const [passportConfig, setPassportConfig] = useState(
@@ -179,8 +164,6 @@ function PrimaryRevenueWebView() {
         envId={envId}
         fromCurrency={fromCurrency}
         items={items}
-        // @deprecated
-        fromContractAddress={fromContractAddress}
       />
       <br />
       <h3>Passport Config</h3>

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/hooks/useSignOrder.ts
@@ -25,27 +25,19 @@ type SignDataType = {
 };
 
 type Input = {
-  amount: string;
-  fromContractAddress: string;
-  fromCollectionAddress: string;
   items: {
-    id: string;
-    name: string;
-    price: string;
+    productId: string;
     qty: number;
-    image: string;
   }[];
   fromCurrency?: string;
-  paymentMethod?: string;
-  envId?: string;
+  paymentType?: string;
   provider: Web3Provider | undefined;
 };
 
 export const useSignOrder = ({
   items,
-  amount,
-  fromContractAddress,
-  fromCollectionAddress,
+  fromCurrency,
+  paymentType,
   provider,
 }: Input) => {
   const [signData, setSignData] = useState<SignDataType | undefined>();
@@ -87,14 +79,16 @@ export const useSignOrder = ({
 
   const sign = useCallback(async (): Promise<void> => {
     const data = {
-      amount: Number(amount),
       recipient_address: recipientAddress,
-      erc20_contract_address: fromContractAddress,
-      items: items.map((item) => ({
-        collection_address: fromCollectionAddress,
-        token_id: item.id,
+      currency: fromCurrency,
+      payment_type: paymentType,
+      products: items.map((item) => ({
+        product_id: item.productId,
+        quantity: item.qty,
       })),
     };
+
+    console.log('@@@ data', data);
 
     try {
       const response = await fetch(
@@ -117,9 +111,8 @@ export const useSignOrder = ({
     }
   }, [
     items,
-    amount,
-    fromCollectionAddress,
-    fromContractAddress,
+    fromCurrency,
+    paymentType,
     recipientAddress,
   ]);
 

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/views/PaymentMethods.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/views/PaymentMethods.tsx
@@ -18,10 +18,11 @@ import {
 
 export interface PaymentMethodsProps {
   checkBalances: () => Promise<boolean>;
+  setPaymentType: (type: 'fiat' | 'crypto' | undefined) => void;
 }
 
 export function PaymentMethods(props: PaymentMethodsProps) {
-  const { checkBalances } = props;
+  const { checkBalances, setPaymentType } = props;
   const { header } = text.views[PrimaryRevenueWidgetViews.PAYMENT_METHODS];
   const { viewDispatch, viewState } = useContext(ViewContext);
 
@@ -35,6 +36,10 @@ export function PaymentMethods(props: PaymentMethodsProps) {
 
   const handleOptionClick = useCallback(
     async (type: PrimaryRevenueWidgetViews) => {
+      setPaymentType(
+        type === PrimaryRevenueWidgetViews.PAY_WITH_CRYPTO ? 'crypto' : 'fiat',
+      );
+
       try {
         viewDispatch({
           payload: {
@@ -55,9 +60,7 @@ export function PaymentMethods(props: PaymentMethodsProps) {
               type: ViewActions.UPDATE_VIEW,
               view: {
                 type: SharedViews.TOP_UP_VIEW,
-                data: {
-
-                },
+                data: {},
                 bridgeData: {
                   fromAmount: amount,
                   fromContractAddress,


### PR DESCRIPTION
# Summary
Updated and refactored the widget to handle the updated `/sign `endpoint.

From this:
```
    const signRequestBody= {
      amount: Number(amount),
      recipient_address: recipientAddress,
      erc20_contract_address: fromContractAddress,
      items: items.map((item) => ({
        collection_address: fromCollectionAddress,
        token_id: item.id,
      })),
```

to 

```
 const newSignRequestBody = {
      recipient_address: recipientAddress,
      currency: fromCurrency,
      payment_type: paymentType,
      products: items.map((item) => ({
        product_id: item.productId,
        quantity: item.qty,
      })),
    };
```

# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
