### PR TITLE
[WT-1658] feat: Apply allowlist to smart checkout route calculator

### DIFF
--- a/packages/checkout/sdk/src/smartCheckout/allowList/allowListCheck.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/allowList/allowListCheck.test.ts
@@ -1,0 +1,395 @@
+import { Environment } from '@imtbl/config';
+import { BigNumber } from 'ethers';
+import { CheckoutConfiguration } from '../../config';
+import {
+  allowListCheck, allowListCheckForBridge, allowListCheckForOnRamp, allowListCheckForSwap,
+} from './allowListCheck';
+import {
+  BridgeConfig,
+  ChainId,
+  DexConfig,
+  IMX_ADDRESS_ZKEVM,
+  OnRampConfig, OnRampProvider,
+  OnRampProviderConfig,
+} from '../../types';
+import { TokenBalanceResult } from '../routing/types';
+import { RemoteConfigFetcher } from '../../config/remoteConfigFetcher';
+
+jest.mock('../../config/remoteConfigFetcher');
+
+describe('allowListCheck', () => {
+  let config: CheckoutConfiguration;
+  let dexConfig: DexConfig;
+  let bridgeConfig: BridgeConfig;
+  let onRampConfig: OnRampConfig;
+  let balances: Map<ChainId, TokenBalanceResult>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (RemoteConfigFetcher as unknown as jest.Mock).mockReturnValue({
+      getConfig: jest.fn().mockImplementation((key) => {
+        let remoteConfig: any;
+        // eslint-disable-next-line default-case
+        switch (key) {
+          case 'bridge':
+            remoteConfig = bridgeConfig;
+            break;
+          case 'dex':
+            remoteConfig = dexConfig;
+            break;
+          case 'onramp':
+            remoteConfig = onRampConfig;
+            break;
+        }
+        return remoteConfig;
+      }),
+    });
+
+    config = new CheckoutConfiguration({
+      baseConfig: { environment: Environment.SANDBOX },
+    });
+
+    dexConfig = {
+      tokens: [{
+        address: IMX_ADDRESS_ZKEVM,
+        decimals: 18,
+        symbol: 'IMX',
+        name: 'IMX',
+      }],
+    };
+    bridgeConfig = {
+      tokens: [{
+        decimals: 18,
+        symbol: 'ETH',
+        name: 'Ethereum',
+      }],
+    };
+    onRampConfig = {
+      [OnRampProvider.TRANSAK]: {
+        publishableApiKey: '',
+        tokens: [{
+          address: IMX_ADDRESS_ZKEVM,
+          decimals: 18,
+          symbol: 'IMX',
+          name: 'IMX',
+        }],
+        fees: {},
+      } as OnRampProviderConfig,
+    };
+    balances = new Map<ChainId, TokenBalanceResult>([
+      [ChainId.IMTBL_ZKEVM_TESTNET, {
+        success: true,
+        balances: [
+          {
+            balance: BigNumber.from(10),
+            formattedBalance: '10',
+            token: {
+              address: IMX_ADDRESS_ZKEVM,
+              decimals: 18,
+              symbol: 'IMX',
+              name: 'IMX',
+            },
+          },
+          {
+            balance: BigNumber.from(10),
+            formattedBalance: '10',
+            token: {
+              name: 'Ethereum',
+              symbol: 'ETH',
+              decimals: 18,
+            },
+          },
+        ],
+      }],
+      [ChainId.SEPOLIA, {
+        success: true,
+        balances: [
+          {
+            balance: BigNumber.from(10),
+            formattedBalance: '10',
+            token: {
+              name: 'Ethereum',
+              symbol: 'ETH',
+              decimals: 18,
+            },
+          },
+        ],
+      }],
+    ]);
+  });
+
+  describe('allowListCheck', () => {
+    it('should return all route option allowlists when options enabled', async () => {
+      const availableRoutingOptions = { swap: true, bridge: true, onRamp: true };
+
+      const allowList = await allowListCheck(config, balances, availableRoutingOptions);
+      expect(allowList).toEqual({
+        swap: [{
+          address: IMX_ADDRESS_ZKEVM,
+          decimals: 18,
+          symbol: 'IMX',
+          name: 'IMX',
+        }],
+        bridge: [{
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        }],
+        onRamp: {
+          [OnRampProvider.TRANSAK]: [{
+            address: IMX_ADDRESS_ZKEVM,
+            decimals: 18,
+            symbol: 'IMX',
+            name: 'IMX',
+          }],
+        },
+      });
+    });
+
+    it('should return only bridge allowlist when bridge option enabled', async () => {
+      const availableRoutingOptions = { swap: false, bridge: true, onRamp: false };
+
+      const allowList = await allowListCheck(config, balances, availableRoutingOptions);
+      expect(allowList).toEqual({
+        bridge: [{
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        }],
+        onRamp: {},
+        swap: [],
+      });
+    });
+
+    it('should return only swap allowlist when swap option enabled', async () => {
+      const availableRoutingOptions = { swap: true, bridge: false, onRamp: false };
+
+      const allowList = await allowListCheck(config, balances, availableRoutingOptions);
+      expect(allowList).toEqual({
+        bridge: [],
+        onRamp: {},
+        swap: [{
+          address: IMX_ADDRESS_ZKEVM,
+          decimals: 18,
+          symbol: 'IMX',
+          name: 'IMX',
+        }],
+      });
+    });
+
+    it('should return only onRamp allowlist when onRamp option enabled', async () => {
+      const availableRoutingOptions = { swap: false, bridge: false, onRamp: true };
+
+      const allowList = await allowListCheck(config, balances, availableRoutingOptions);
+      expect(allowList).toEqual({
+        bridge: [],
+        onRamp: {
+          [OnRampProvider.TRANSAK]: [{
+            address: IMX_ADDRESS_ZKEVM,
+            decimals: 18,
+            symbol: 'IMX',
+            name: 'IMX',
+          }],
+        },
+        swap: [],
+      });
+    });
+
+    it('should return no allowlist tokens when all options disabled', async () => {
+      const availableRoutingOptions = { swap: false, bridge: false, onRamp: false };
+
+      const allowList = await allowListCheck(config, balances, availableRoutingOptions);
+      expect(allowList).toEqual({
+        bridge: [],
+        onRamp: {},
+        swap: [],
+      });
+    });
+  });
+
+  describe('allowListCheckForBridge', () => {
+    it('should return bridge allowlist', async () => {
+      const result = await allowListCheckForBridge(config, balances, { bridge: true });
+      expect(result).toEqual([{
+        decimals: 18,
+        symbol: 'ETH',
+        name: 'Ethereum',
+      }]);
+    });
+
+    it('should return bridge allowlist with ERC20 and Native', async () => {
+      balances = new Map<ChainId, TokenBalanceResult>([
+        [ChainId.SEPOLIA, {
+          success: true,
+          balances: [
+            {
+              balance: BigNumber.from(10),
+              formattedBalance: '10',
+              token: {
+                address: '0x0000000',
+                decimals: 18,
+                symbol: 'MEGA',
+                name: 'Mega',
+              },
+            },
+            {
+              balance: BigNumber.from(10),
+              formattedBalance: '10',
+              token: {
+                name: 'Ethereum',
+                symbol: 'ETH',
+                decimals: 18,
+              },
+            },
+          ],
+        }],
+      ]);
+
+      bridgeConfig = {
+        tokens: [{
+          address: '0x0000000',
+          decimals: 18,
+          symbol: 'MEGA',
+          name: 'Mega',
+        },
+        {
+          decimals: 18,
+          symbol: 'ETH',
+          name: 'Ethereum',
+        }],
+      };
+
+      const result = await allowListCheckForBridge(config, balances, { bridge: true });
+      expect(result).toEqual([{
+        address: '0x0000000',
+        decimals: 18,
+        symbol: 'MEGA',
+        name: 'Mega',
+      },
+      {
+        decimals: 18,
+        symbol: 'ETH',
+        name: 'Ethereum',
+      }]);
+    });
+
+    it('should return an empty array if bridge option is disabled', async () => {
+      const result = await allowListCheckForBridge(config, balances, { bridge: false });
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array if there are no balances', async () => {
+      const result = await allowListCheckForBridge(config, new Map(), { bridge: true });
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array if bridge allowlist is empty', async () => {
+      bridgeConfig = {
+        tokens: [],
+      };
+
+      const result = await allowListCheckForBridge(config, balances, { bridge: true });
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array if allowlist tokens have no balance', async () => {
+      bridgeConfig = {
+        tokens: [{
+          address: '0x0000000',
+          decimals: 18,
+          symbol: 'MEGA',
+          name: 'Mega',
+        }],
+      };
+
+      const result = await allowListCheckForBridge(config, balances, { bridge: true });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('allowListCheckForSwap', () => {
+    it('should return swap allowlist', async () => {
+      const result = await allowListCheckForSwap(config, balances, { swap: true });
+      expect(result).toEqual([{
+        address: IMX_ADDRESS_ZKEVM,
+        decimals: 18,
+        symbol: 'IMX',
+        name: 'IMX',
+      }]);
+    });
+
+    it('should return an empty array if swap option is disabled', async () => {
+      const result = await allowListCheckForSwap(config, balances, { swap: false });
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array if there are no balances', async () => {
+      const result = await allowListCheckForSwap(config, new Map(), { bridge: true });
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array if swap allowlist is empty', async () => {
+      dexConfig = {
+        tokens: [],
+      };
+
+      const result = await allowListCheckForSwap(config, balances, { swap: true });
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array if allowlist tokens have no balance', async () => {
+      dexConfig = {
+        tokens: [{
+          address: '0x0000000',
+          decimals: 18,
+          symbol: 'MEGA',
+          name: 'Mega',
+        }],
+      };
+
+      const result = await allowListCheckForSwap(config, balances, { swap: true });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('allowListCheckForOnRamp', () => {
+    it('should return onRamp allowlist', async () => {
+      const result = await allowListCheckForOnRamp(config, { onRamp: true });
+      expect(result).toEqual({
+        [OnRampProvider.TRANSAK]: [{
+          address: IMX_ADDRESS_ZKEVM,
+          decimals: 18,
+          symbol: 'IMX',
+          name: 'IMX',
+        }],
+      });
+    });
+
+    it('should return an empty object if onRamp option is disabled', async () => {
+      const result = await allowListCheckForOnRamp(config, { onRamp: false });
+      expect(result).toEqual({});
+    });
+
+    it('should return an empty object if no onRamp providers configured', async () => {
+      onRampConfig = {};
+
+      const result = await allowListCheckForOnRamp(config, { onRamp: true });
+      expect(result).toEqual({});
+    });
+
+    it('should return an empty array if onRamp allowlist is empty', async () => {
+      onRampConfig = {
+        [OnRampProvider.TRANSAK]: {
+          publishableApiKey: '',
+          tokens: [],
+          fees: {},
+        } as OnRampProviderConfig,
+      };
+
+      const result = await allowListCheckForOnRamp(config, { onRamp: true });
+      expect(result).toEqual({
+        [OnRampProvider.TRANSAK]: [],
+      });
+    });
+  });
+});

--- a/packages/checkout/sdk/src/smartCheckout/allowList/allowListCheck.ts
+++ b/packages/checkout/sdk/src/smartCheckout/allowList/allowListCheck.ts
@@ -1,0 +1,84 @@
+import { CheckoutConfiguration, getL1ChainId, getL2ChainId } from '../../config';
+import {
+  BridgeConfig,
+  DexConfig, OnRampConfig,
+  RoutingOptionsAvailable,
+  TokenInfo,
+} from '../../types';
+import { TokenBalanceResult, TokenBalances } from '../routing/types';
+import { OnRampTokensAllowList, RoutingTokensAllowList } from './types';
+
+const filterTokens = (allowedTokens: TokenInfo[], balances: TokenBalanceResult | undefined) => {
+  if (balances && balances.success) {
+    return allowedTokens.filter((token) => {
+      if ('address' in token) {
+        return balances.balances.find((balance) => balance.token.address === token.address && balance.balance.gt(0));
+      }
+      return balances.balances.find((balance) => !('address' in balance.token) && balance.balance.gt(0));
+    });
+  }
+
+  return [];
+};
+
+export const allowListCheckForOnRamp = async (
+  config: CheckoutConfiguration,
+  availableRoutingOptions: RoutingOptionsAvailable,
+) : Promise<OnRampTokensAllowList> => {
+  if (availableRoutingOptions.onRamp) {
+    const onRampOptions = await config.remote.getConfig('onramp') as OnRampConfig;
+    const onRampAllowList: OnRampTokensAllowList = {};
+    Object.entries(onRampOptions)
+      .forEach(([onRampProvider, onRampProviderConfig]) => {
+        // Allowed list per onRamp provider
+        onRampAllowList[onRampProvider] = onRampProviderConfig.tokens ?? [];
+      });
+    return onRampAllowList;
+  }
+
+  return {};
+};
+
+export const allowListCheckForBridge = async (
+  config: CheckoutConfiguration,
+  tokenBalances: TokenBalances,
+  availableRoutingOptions: RoutingOptionsAvailable,
+) : Promise<TokenInfo[]> => {
+  if (availableRoutingOptions.bridge) {
+    const allowedTokens = ((await config.remote.getConfig('bridge')) as BridgeConfig)?.tokens ?? [];
+    const balances = tokenBalances.get(getL1ChainId(config));
+    return filterTokens(allowedTokens, balances);
+  }
+
+  return [];
+};
+
+export const allowListCheckForSwap = async (
+  config: CheckoutConfiguration,
+  tokenBalances: TokenBalances,
+  availableRoutingOptions: RoutingOptionsAvailable,
+) : Promise<TokenInfo[]> => {
+  if (availableRoutingOptions.swap) {
+    const allowedTokens = ((await config.remote.getConfig('dex')) as DexConfig)?.tokens ?? [];
+    const balances = tokenBalances.get(getL2ChainId(config));
+    return filterTokens(allowedTokens, balances);
+  }
+
+  return [];
+};
+
+/**
+ * Checks the user balances against the route option allowlists.
+ */
+export const allowListCheck = async (
+  config: CheckoutConfiguration,
+  tokenBalances: TokenBalances,
+  availableRoutingOptions: RoutingOptionsAvailable,
+) : Promise<RoutingTokensAllowList> => {
+  const tokenAllowList: RoutingTokensAllowList = {};
+  tokenAllowList.swap = await allowListCheckForSwap(config, tokenBalances, availableRoutingOptions);
+  tokenAllowList.bridge = await allowListCheckForBridge(config, tokenBalances, availableRoutingOptions);
+  tokenAllowList.onRamp = await allowListCheckForOnRamp(config, availableRoutingOptions);
+
+  return tokenAllowList;
+};

--- a/packages/checkout/sdk/src/smartCheckout/allowList/index.ts
+++ b/packages/checkout/sdk/src/smartCheckout/allowList/index.ts
@@ -1,0 +1,1 @@
+export * from './allowListCheck';

--- a/packages/checkout/sdk/src/smartCheckout/allowList/types.ts
+++ b/packages/checkout/sdk/src/smartCheckout/allowList/types.ts
@@ -1,0 +1,9 @@
+import { TokenInfo } from '../../types';
+
+export type OnRampTokensAllowList = { [key: string]: TokenInfo[] };
+
+export type RoutingTokensAllowList = {
+  'bridge'?: TokenInfo[],
+  'swap'?: TokenInfo[],
+  'onRamp'?: OnRampTokensAllowList,
+};

--- a/packages/checkout/sdk/src/smartCheckout/routing/bridge/bridgeRoute.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/bridge/bridgeRoute.test.ts
@@ -20,11 +20,13 @@ import { estimateGasForBridgeApproval } from './estimateApprovalGas';
 import { bridgeGasEstimate } from './bridgeGasEstimate';
 import { INDEXER_ETH_ROOT_CONTRACT_ADDRESS } from './constants';
 import { CheckoutErrorType } from '../../../errors';
+import { allowListCheckForBridge } from '../../allowList/allowListCheck';
 
 jest.mock('../../../gasEstimate');
 jest.mock('../../../instance');
 jest.mock('./estimateApprovalGas');
 jest.mock('./bridgeGasEstimate');
+jest.mock('../../allowList/allowListCheck');
 
 describe('bridgeRoute', () => {
   const config = new CheckoutConfiguration({
@@ -84,6 +86,13 @@ describe('bridgeRoute', () => {
         });
 
         (estimateGasForBridgeApproval as jest.Mock).mockResolvedValue(BigNumber.from(0));
+        (allowListCheckForBridge as jest.Mock).mockResolvedValue([
+          {
+            name: 'Ethereum',
+            symbol: 'ETH',
+            decimals: 18,
+          },
+        ]);
       });
 
       it('should return the bridge route if user has enough Ethereum & gas on L1', async () => {
@@ -218,6 +227,51 @@ describe('bridgeRoute', () => {
 
         expect(route).toBeUndefined();
       });
+
+      it('should not return bridge route if Ethereum is not on bridge allowlist', async () => {
+        const balances = new Map<ChainId, TokenBalanceResult>([
+          [ChainId.SEPOLIA, {
+            success: true,
+            balances: [
+              {
+                balance: BigNumber.from(20),
+                formattedBalance: '20',
+                token: {
+                  name: 'Immutable X',
+                  symbol: 'IMX',
+                  decimals: 18,
+                  address: '0xIMX',
+                },
+              },
+              {
+                balance: BigNumber.from(12),
+                formattedBalance: '12',
+                token: {
+                  name: 'Ethereum',
+                  symbol: 'ETH',
+                  decimals: 18,
+                },
+              },
+            ],
+          }],
+        ]);
+        (allowListCheckForBridge as jest.Mock).mockResolvedValue([]);
+
+        const route = await bridgeRoute(
+          config,
+          readonlyProviders,
+          '0xADDRESS',
+          {
+            bridge: true,
+          },
+          balanceRequirement,
+          balances,
+          feeEstimates,
+        );
+
+        expect(allowListCheckForBridge).toHaveBeenCalledTimes(1);
+        expect(route).toEqual(undefined);
+      });
     });
 
     describe('Bridge non-ETH ERC20', () => {
@@ -263,6 +317,14 @@ describe('bridgeRoute', () => {
         });
 
         (estimateGasForBridgeApproval as jest.Mock).mockResolvedValue(BigNumber.from(1));
+        (allowListCheckForBridge as jest.Mock).mockResolvedValue([
+          {
+            address: '0xROOT_ADDRESS',
+            name: '0xERC20',
+            symbol: '0xERC20',
+            decimals: 18,
+          },
+        ]);
       });
 
       it('should return the bridge route if user has enough ERC20 & gas on L1', async () => {
@@ -462,6 +524,51 @@ describe('bridgeRoute', () => {
 
         expect(route).toBeUndefined();
       });
+
+      it('should not return bridge route if ERC20 is not on bridge allowlist', async () => {
+        const balances = new Map<ChainId, TokenBalanceResult>([
+          [ChainId.SEPOLIA, {
+            success: true,
+            balances: [
+              {
+                balance: BigNumber.from(10),
+                formattedBalance: '10',
+                token: {
+                  name: 'Ethereum',
+                  symbol: 'ETH',
+                  decimals: 18,
+                },
+              },
+              {
+                balance: BigNumber.from(11),
+                formattedBalance: '11',
+                token: {
+                  name: '0xERC20',
+                  symbol: '0xERC20',
+                  decimals: 18,
+                  address: '0xROOT_ADDRESS',
+                },
+              },
+            ],
+          }],
+        ]);
+        (allowListCheckForBridge as jest.Mock).mockResolvedValue([]);
+
+        const route = await bridgeRoute(
+          config,
+          readonlyProviders,
+          '0xADDRESS',
+          {
+            bridge: true,
+          },
+          balanceRequirement,
+          balances,
+          feeEstimates,
+        );
+
+        expect(allowListCheckForBridge).toHaveBeenCalledTimes(1);
+        expect(route).toEqual(undefined);
+      });
     });
 
     it('should return undefined if no balance on layer 1', async () => {
@@ -518,7 +625,7 @@ describe('bridgeRoute', () => {
       expect(route).toBeUndefined();
     });
 
-    it('should throw error if no token balance result for L1', async () => {
+    it('should return undefined if no token balance result for L1', async () => {
       const balanceRequirement: BalanceRequirement = {
         type: ItemType.ERC20,
         sufficient: false,
@@ -557,31 +664,22 @@ describe('bridgeRoute', () => {
         }],
       ]);
 
-      let type;
-      let data;
+      const route = await bridgeRoute(
+        config,
+        readonlyProviders,
+        '0xADDRESS',
+        {
+          bridge: true,
+        },
+        balanceRequirement,
+        balances,
+        feeEstimates,
+      );
 
-      try {
-        await bridgeRoute(
-          config,
-          readonlyProviders,
-          '0xADDRESS',
-          {
-            bridge: true,
-          },
-          balanceRequirement,
-          balances,
-          feeEstimates,
-        );
-      } catch (err: any) {
-        type = err.type;
-        data = err.data;
-      }
-
-      expect(type).toEqual(CheckoutErrorType.GET_BALANCE_ERROR);
-      expect(data).toEqual({ chainId: ChainId.SEPOLIA.toString() });
+      expect(route).toEqual(undefined);
     });
 
-    it('should throw error if token balance returned unsuccessful on L1', async () => {
+    it('should return undefined if token balance returned unsuccessful on L1', async () => {
       const balanceRequirement: BalanceRequirement = {
         type: ItemType.ERC20,
         sufficient: false,
@@ -620,28 +718,19 @@ describe('bridgeRoute', () => {
         }],
       ]);
 
-      let type;
-      let data;
+      const route = await bridgeRoute(
+        config,
+        readonlyProviders,
+        '0xADDRESS',
+        {
+          bridge: true,
+        },
+        balanceRequirement,
+        balances,
+        feeEstimates,
+      );
 
-      try {
-        await bridgeRoute(
-          config,
-          readonlyProviders,
-          '0xADDRESS',
-          {
-            bridge: true,
-          },
-          balanceRequirement,
-          balances,
-          feeEstimates,
-        );
-      } catch (err: any) {
-        type = err.type;
-        data = err.data;
-      }
-
-      expect(type).toEqual(CheckoutErrorType.GET_BALANCE_ERROR);
-      expect(data).toEqual({ chainId: ChainId.SEPOLIA.toString() });
+      expect(route).toEqual(undefined);
     });
 
     it('should throw error if readonly providers missing L1', async () => {

--- a/packages/checkout/sdk/src/smartCheckout/routing/geoBlocking.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/geoBlocking.ts
@@ -1,3 +1,3 @@
-export const isOnRampGeoBlocked = async (): Promise<boolean> => true;
+export const isOnRampGeoBlocked = async (): Promise<boolean> => false;
 
-export const isSwapGeoBlocked = async (): Promise<boolean> => true;
+export const isSwapGeoBlocked = async (): Promise<boolean> => false;

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
@@ -52,8 +52,6 @@ export const routingCalculator = async (
     availableRoutingOptions,
   );
 
-  // Get allowed tokens?
-
   // Bridge and swap fee cache
   const feeEstimates = new Map<FundingRouteType, BigNumber>();
 

--- a/packages/checkout/sdk/src/smartCheckout/routing/types.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/types.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers';
-import { GetBalanceResult, TokenInfo } from '../../types';
+import { ChainId, GetBalanceResult, TokenInfo } from '../../types';
 import { CheckoutError } from '../../errors';
 
 export type RoutingCalculatorResult = {
@@ -47,3 +47,5 @@ export type TokenBalanceResult = {
   balances: GetBalanceResult[],
   error?: CheckoutError,
 };
+
+export type TokenBalances = Map<ChainId, TokenBalanceResult>;

--- a/packages/checkout/sdk/src/types/config.ts
+++ b/packages/checkout/sdk/src/types/config.ts
@@ -21,6 +21,7 @@ export interface CheckoutModuleConfiguration extends ModuleConfiguration<Checkou
 export type RemoteConfiguration = {
   dex: DexConfig;
   onramp: OnRampConfig;
+  bridge: BridgeConfig;
   allowedNetworks: AllowedNetworkConfig[];
   gasEstimateTokens?: GasEstimateTokenConfig;
 };
@@ -67,6 +68,14 @@ export type OnRampConfig = {
  */
 export type DexConfig = {
   overrides?: ExchangeOverrides;
+  tokens?: TokenInfo[];
+};
+
+/**
+ * A type representing the configuration for the Bridge.
+ * @property {TokenInfo[] | undefined} tokens - An array of tokens compatible with the Bridge.
+ */
+export type BridgeConfig = {
   tokens?: TokenInfo[];
 };
 


### PR DESCRIPTION
# Summary
AllowListCheck implementations check the available options (bridge, onRamp, swap) and validate the token balances against the configured allowlists.


# Why the changes
For Smart Checkout route calculation we need to determine what tokens are allowed when performing bridging, swapping and on ramp.
[WT-1658](https://immutable.atlassian.net/browse/WT-1658)

# Notes
This is part 1 of 2 PRs for allowlist.
[PR 2](https://github.com/immutable/ts-immutable-sdk/pull/874)


[WT-1658]: https://immutable.atlassian.net/browse/WT-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ