### PR TITLE
chore: Prevent the build from running out of memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ If your package isn't part of the dependency tree for the main SDK, then you mig
 yarn wsrun -p @imtbl/your_project --recursive --stages build
 ```
 
+If you run out of memory, set NODE_OPTIONS to limit Node's use of memory (this assumes you have about 16GB of memory):
+
+```sh
+export NODE_OPTIONS=--max-old-space-size=14366
+```
+
 ### Linting
 
 #### ESLint Tooling

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@biom3/design-tokens": "0.2.4-beta"
   },
   "scripts": {
-    "build": "wsrun -y 4 -p @imtbl/sdk -p @imtbl/checkout-widgets-lib -e -r --serial build && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
-    "build:onlysdk": "wsrun -y 4 --stages build && yarn syncpack:format",
+    "build": "NODE_OPTIONS=--max-old-space-size=14366 wsrun -y 4 -p @imtbl/sdk -p @imtbl/checkout-widgets-lib -e -r --serial build && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
+    "build:onlysdk": "NODE_OPTIONS=--max-old-space-size=14366 wsrun -y 4 --stages build && yarn syncpack:format",
     "docs:build": "typedoc",
     "docs:serve": "http-server ./docs --cors -p 8080 -c-1",
     "lint": "wsrun --exclude-missing -e lint --no-error-on-unmatched-pattern",


### PR DESCRIPTION
# Summary

The build was running out of memory.
This PR limits Node's use of memory to a max of 14GB. 

It also adds a note to README.md.

# Why the changes
There were a few reports of builds running out memory.

# Things worth calling out
No code changes.

# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
