### PR TITLE
feat: [WT-1660] Smart Checkout onRamp route calculator implementation

### DIFF
--- a/packages/checkout/sdk/src/smartCheckout/routing/onRamp/index.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/onRamp/index.ts
@@ -1,0 +1,1 @@
+export * from './onRampRoute';

--- a/packages/checkout/sdk/src/smartCheckout/routing/onRamp/onRampRoute.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/onRamp/onRampRoute.test.ts
@@ -1,0 +1,172 @@
+import { BigNumber } from 'ethers';
+import { Environment } from '@imtbl/config';
+import { CheckoutConfiguration } from '../../../config';
+import {
+  ChainId,
+  FundingRouteType,
+  ItemType,
+  OnRampProvider,
+} from '../../../types';
+import { allowListCheckForOnRamp } from '../../allowList';
+import { onRampRoute } from './onRampRoute';
+import { BalanceERC20Requirement, BalanceERC721Requirement } from '../../balanceCheck/types';
+
+jest.mock('../../allowList/allowListCheck');
+
+describe('onRampRoute', () => {
+  const config = new CheckoutConfiguration({
+    baseConfig: { environment: Environment.SANDBOX },
+  });
+
+  beforeEach(() => {
+    (allowListCheckForOnRamp as jest.Mock).mockResolvedValue({
+      [OnRampProvider.TRANSAK]: [
+        {
+          address: '0x65AA7a21B0f3ce9B478aAC3408fE75b423939b1F',
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        },
+      ],
+    });
+  });
+
+  it('should return the onRamp route if the ERC20 balance requirement is in the allowlist', async () => {
+    const balanceRequirement: BalanceERC20Requirement = {
+      type: ItemType.ERC20,
+      required: {
+        balance: BigNumber.from(10),
+        formattedBalance: '10',
+        token: {
+          address: '0x65AA7a21B0f3ce9B478aAC3408fE75b423939b1F',
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        },
+      },
+      sufficient: false,
+      current: {
+        balance: BigNumber.from(0),
+        formattedBalance: '0',
+        token: {
+          address: '0x65AA7a21B0f3ce9B478aAC3408fE75b423939b1F',
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        },
+      },
+      delta: {
+        balance: BigNumber.from(10),
+        formattedBalance: '10',
+      },
+    } as BalanceERC20Requirement;
+
+    const route = await onRampRoute(
+      config,
+      {
+        onRamp: true,
+      },
+      balanceRequirement,
+    );
+
+    expect(route)
+      .toEqual({
+        type: FundingRouteType.ONRAMP,
+        chainId: ChainId.IMTBL_ZKEVM_TESTNET,
+        asset: {
+          balance: BigNumber.from(10),
+          formattedBalance: '10',
+          token: {
+            address: '0x65AA7a21B0f3ce9B478aAC3408fE75b423939b1F',
+            name: 'Ethereum',
+            symbol: 'ETH',
+            decimals: 18,
+          },
+        },
+      });
+  });
+
+  it('should return undefined if the ERC20 balance requirement is not in the allowlist', async () => {
+    const balanceRequirement: BalanceERC20Requirement = {
+      type: ItemType.ERC20,
+      required: {
+        balance: BigNumber.from(10),
+        formattedBalance: '10',
+        token: {
+          address: '0x65AA7a21B0f3ce9B478aAC3408fE75b423939b1F',
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        },
+      },
+      sufficient: false,
+      current: {
+        balance: BigNumber.from(0),
+        formattedBalance: '0',
+        token: {
+          address: '0x65AA7a21B0f3ce9B478aAC3408fE75b423939b1F',
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        },
+      },
+      delta: {
+        balance: BigNumber.from(10),
+        formattedBalance: '10',
+      },
+    } as BalanceERC20Requirement;
+
+    (allowListCheckForOnRamp as jest.Mock).mockResolvedValue({
+      [OnRampProvider.TRANSAK]: [],
+    });
+
+    const route = await onRampRoute(
+      config,
+      {
+        onRamp: true,
+      },
+      balanceRequirement,
+    );
+
+    expect(route).toBeUndefined();
+  });
+
+  it('should return undefined if the balance requirement is an ERC721', async () => {
+    const balanceRequirement: BalanceERC721Requirement = {
+      type: ItemType.ERC721,
+      required: {
+        type: ItemType.ERC721,
+        balance: BigNumber.from(1),
+        formattedBalance: '1',
+        id: '1',
+        contractAddress: '0xADDRESS',
+      },
+      sufficient: false,
+      current: {
+        type: ItemType.ERC721,
+        balance: BigNumber.from(0),
+        formattedBalance: '0',
+        id: '1',
+        contractAddress: '0xADDRESS',
+      },
+      delta: {
+        balance: BigNumber.from(1),
+        formattedBalance: '1',
+      },
+    } as BalanceERC721Requirement;
+
+    (allowListCheckForOnRamp as jest.Mock).mockResolvedValue({
+      [OnRampProvider.TRANSAK]: [],
+    });
+
+    const route = await onRampRoute(
+      config,
+      {
+        onRamp: true,
+      },
+      balanceRequirement,
+    );
+
+    expect(route).toBeUndefined();
+  });
+});

--- a/packages/checkout/sdk/src/smartCheckout/routing/onRamp/onRampRoute.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/onRamp/onRampRoute.ts
@@ -1,0 +1,35 @@
+import { CheckoutConfiguration, getL2ChainId } from '../../../config';
+import { FundingRouteType, ItemType, RoutingOptionsAvailable } from '../../../types';
+import { BalanceRequirement } from '../../balanceCheck/types';
+import { FundingRouteStep } from '../types';
+import { allowListCheckForOnRamp } from '../../allowList';
+
+export const onRampRoute = async (
+  config: CheckoutConfiguration,
+  availableRoutingOptions: RoutingOptionsAvailable,
+  balanceRequirement: BalanceRequirement,
+): Promise<FundingRouteStep | undefined> => {
+  if (balanceRequirement.type !== ItemType.ERC20 && balanceRequirement.type !== ItemType.NATIVE) return undefined;
+  const requiredBalance = balanceRequirement.required;
+
+  let hasAllowList = false;
+  const onRampProvidersAllowList = await allowListCheckForOnRamp(config, availableRoutingOptions);
+  Object.values(onRampProvidersAllowList).forEach((onRampAllowList) => {
+    if (onRampAllowList.length > 0 && !hasAllowList) {
+      hasAllowList = !!onRampAllowList.find((token) => token.address === requiredBalance.token?.address);
+    }
+  });
+  if (!hasAllowList) return undefined;
+
+  return {
+    type: FundingRouteType.ONRAMP,
+    chainId: getL2ChainId(config),
+    asset: {
+      balance: requiredBalance.balance,
+      formattedBalance: requiredBalance.formattedBalance,
+      token: {
+        ...requiredBalance.token,
+      },
+    },
+  };
+};


### PR DESCRIPTION
# Summary
Adds the OnRamp Route to Smart Checkout.

[WT-1660](https://immutable.atlassian.net/browse/WT-1660)
The onRamp route does the following

- Checks that there is only a single token as a requirement
- Checks the balance requirement type is ERC20 or NATIVE
- Checks the balance requirement is on the onRamp allowlist

# Demo
In this demo I am adding a requirement for NATIVE IMX.
Smart checkout is then checking that this is on the allowlist and returning the onRamp route.

https://github.com/immutable/ts-immutable-sdk/assets/1617003/5dcc0f63-949e-49ae-81fd-3b89c00f93a9



[WT-1660]: https://immutable.atlassian.net/browse/WT-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ