### PR TITLE
fix: Prevent accessing the global window object when instantiating Passport

### DIFF
--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -1,4 +1,5 @@
 import {
+  InMemoryWebStorage,
   User as OidcUser,
   UserManager,
   UserManagerSettings,
@@ -31,6 +32,9 @@ const getAuthConfiguration = ({
   oidcConfiguration,
   authenticationDomain,
 }: PassportConfiguration): UserManagerSettings => {
+  const store = typeof window !== 'undefined' ? window.localStorage : new InMemoryWebStorage();
+  const userStore = new WebStorageStateStore({ store });
+
   const baseConfiguration: UserManagerSettings = {
     authority: authenticationDomain,
     redirect_uri: oidcConfiguration.redirectUri,
@@ -48,7 +52,7 @@ const getAuthConfiguration = ({
     mergeClaims: true,
     loadUserInfo: true,
     scope: oidcConfiguration.scope,
-    userStore: new WebStorageStateStore({ store: window.localStorage }),
+    userStore,
   };
 
   if (oidcConfiguration.audience) {


### PR DESCRIPTION
# Summary
Prevent accessing the global window object when instantiating authManager as this may be declared serverside


# Why the changes
Checkout's sample application uses nextJS and instantiates Passport on the serverside. We should delay accessing the `window` object until it's necessary to avoid breaking these kind of implementations

