### PR TITLE
feat: [WT-1730] Implementation of no options for routing calculator

### DIFF
--- a/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.test.ts
@@ -12,7 +12,7 @@ import { bridgeRoute } from './bridge/bridgeRoute';
 import {
   ChainId, FundingRouteType, IMX_ADDRESS_ZKEVM, ItemType,
 } from '../../types';
-import { BalanceERC20Requirement, BalanceRequirement } from '../balanceCheck/types';
+import { BalanceCheckResult, BalanceERC20Requirement, BalanceRequirement } from '../balanceCheck/types';
 import { createReadOnlyProviders } from '../../readOnlyProviders/readOnlyProvider';
 import { CheckoutError, CheckoutErrorType } from '../../errors';
 import { swapRoute } from './swap/swapRoute';
@@ -151,6 +151,59 @@ describe('routingCalculator', () => {
     config = new CheckoutConfiguration({
       baseConfig: { environment: Environment.SANDBOX },
     });
+  });
+
+  it('should return no options if no routing options are available', async () => {
+    const availableRoutingOptions = {
+      onRamp: false,
+      swap: false,
+      bridge: false,
+    };
+
+    const balanceRequirements = {} as BalanceCheckResult;
+    (createReadOnlyProviders as jest.Mock).mockResolvedValue(new Map([
+      [ChainId.SEPOLIA, {} as JsonRpcProvider],
+      [ChainId.IMTBL_ZKEVM_TESTNET, {} as JsonRpcProvider],
+    ]));
+
+    const routingOptions = await routingCalculator(
+      config,
+      '0x123',
+      balanceRequirements,
+      availableRoutingOptions,
+    );
+    expect(routingOptions)
+      .toEqual({
+        response: {
+          type: RouteCalculatorType.NO_OPTIONS,
+          message: 'No options available',
+        },
+        fundingRoutes: [],
+      });
+  });
+
+  it('should return no options if no routing options are defined', async () => {
+    const availableRoutingOptions = {};
+    const balanceRequirements = {} as BalanceCheckResult;
+    (createReadOnlyProviders as jest.Mock).mockResolvedValue(new Map([
+      [ChainId.SEPOLIA, {} as JsonRpcProvider],
+      [ChainId.IMTBL_ZKEVM_TESTNET, {} as JsonRpcProvider],
+    ]));
+
+    const routingOptions = await routingCalculator(
+      config,
+      '0x123',
+      balanceRequirements,
+      availableRoutingOptions,
+    );
+    expect(routingOptions)
+      .toEqual({
+        response: {
+          type: RouteCalculatorType.NO_OPTIONS,
+          message: 'No options available',
+        },
+        fundingRoutes: [],
+      });
   });
 
   it('should return bridge funding step', async () => {

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
@@ -23,6 +23,10 @@ import { swapRoute } from './swap/swapRoute';
 import { allowListCheck } from '../allowList';
 import { onRampRoute } from './onRamp';
 
+const hasAvailableRoutingOptions = (availableRoutingOptions: RoutingOptionsAvailable) => (
+  availableRoutingOptions.bridge || availableRoutingOptions.swap || availableRoutingOptions.onRamp
+);
+
 export const getInsufficientRequirement = (
   balanceRequirements: BalanceCheckResult,
 ): BalanceRequirement | undefined => {
@@ -98,6 +102,16 @@ export const routingCalculator = async (
   balanceRequirements: BalanceCheckResult,
   availableRoutingOptions: RoutingOptionsAvailable,
 ): Promise<RoutingCalculatorResult> => {
+  if (!hasAvailableRoutingOptions(availableRoutingOptions)) {
+    return {
+      response: {
+        type: RouteCalculatorType.NO_OPTIONS,
+        message: 'No options available',
+      },
+      fundingRoutes: [],
+    };
+  }
+
   let readOnlyProviders;
   try {
     readOnlyProviders = await createReadOnlyProviders(config);


### PR DESCRIPTION
# Summary
Smart Checkout route calculator should handle the `NO_OPTIONS` condition when all available routing options have been disabled.
[WT-1730](https://immutable.atlassian.net/browse/WT-1730)


# Before submitting the PR, please consider the following:
- [ ] Pull down PR
- [ ] Run through ACs

[WT-1730]: https://immutable.atlassian.net/browse/WT-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ