### PR TITLE
[NO-CHANGELOG][GPR-209]: Select smart checkout funding routes

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/PrimaryRevenueWidget.tsx
@@ -17,7 +17,9 @@ import {
 } from '../../context/view-context/ViewContext';
 import { ConnectLoaderContext } from '../../context/connect-loader-context/ConnectLoaderContext';
 
-import { PrimaryRevenueWidgetViews } from '../../context/view-context/PrimaryRevenueViewContextTypes';
+import {
+  PrimaryRevenueWidgetViews,
+} from '../../context/view-context/PrimaryRevenueViewContextTypes';
 import { Item } from './types';
 import { widgetTheme } from '../../lib/theme';
 import { SharedContextProvider } from './context/SharedContextProvider';
@@ -51,10 +53,7 @@ export function PrimaryRevenueWidget(props: PrimaryRevenueWidgetProps) {
   const biomeTheme = useMemo(() => widgetTheme(theme), [theme]);
 
   const [viewState, viewDispatch] = useReducer(viewReducer, initialViewState);
-  const viewReducerValues = useMemo(
-    () => ({ viewState, viewDispatch }),
-    [viewState, viewDispatch],
-  );
+  const viewReducerValues = useMemo(() => ({ viewState, viewDispatch }), [viewState, viewDispatch]);
 
   const onMount = useCallback(() => {
     if (!checkout || !provider) return;

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/FundingRouteMenuItem/FundingRouteMenuItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/FundingRouteMenuItem/FundingRouteMenuItem.tsx
@@ -1,0 +1,35 @@
+import { ETH_TOKEN_IMAGE_URL, Heading, MenuItem } from '@biom3/react';
+
+export interface FundingRouteMenuItemProps {
+  onClick: () => void;
+  fundingRoute: any;
+  toggleVisible?: boolean;
+  selected?: boolean;
+}
+export function FundingRouteMenuItem({
+  onClick, fundingRoute, toggleVisible, selected,
+}: FundingRouteMenuItemProps) {
+  return (
+    <MenuItem
+      testId="funding-route-menu-item"
+      onClick={onClick}
+      selected={selected}
+      size="small"
+    >
+      {toggleVisible && <MenuItem.IntentIcon icon="ChevronExpand" />}
+      <MenuItem.FramedImage imageUrl={ETH_TOKEN_IMAGE_URL} />
+      <MenuItem.PriceDisplay
+        use={<Heading size="xSmall" />}
+        price="0.0252565"
+        fiatAmount="USD $2.49"
+        currencyImageUrl={ETH_TOKEN_IMAGE_URL}
+      />
+      <MenuItem.Label>
+        { fundingRoute.steps[0].asset.token.symbol}
+      </MenuItem.Label>
+      <MenuItem.Caption>
+        Fees - USD $0.10
+      </MenuItem.Caption>
+    </MenuItem>
+  );
+}

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/FundingRouteSelect/FundingRouteSelect.cy.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/FundingRouteSelect/FundingRouteSelect.cy.tsx
@@ -1,0 +1,134 @@
+import { BiomeCombinedProviders } from '@biom3/react';
+import { mount } from 'cypress/react18';
+import { cy, describe } from 'local-cypress';
+import { ChainId } from '@imtbl/checkout-sdk';
+import { BigNumber } from 'ethers';
+import { cySmartGet } from '../../../../lib/testUtils';
+import { FundingRouteSelect } from './FundingRouteSelect';
+
+describe('FundingRouteSelect View', () => {
+  beforeEach(() => {
+    cy.viewport('ipad-2');
+  });
+
+  describe('single option available', () => {
+    const fundingRoutes = [
+      {
+        priority: 1,
+        steps: [{
+          type: 'BRIDGE',
+          chainId: ChainId.SEPOLIA,
+          asset: {
+            balance: BigNumber.from(1),
+            formattedBalance: '1',
+            token: {
+              name: 'ETH',
+              symbol: 'ETH',
+              decimals: 18,
+            },
+          },
+        }],
+      },
+    ];
+    beforeEach(() => {
+      mount(
+        <BiomeCombinedProviders>
+          <FundingRouteSelect fundingRoutes={fundingRoutes} />
+        </BiomeCombinedProviders>,
+      );
+    });
+    it('should display first option, without chevron', () => {
+      cySmartGet('funding-route-menu-item').should('exist');
+      cySmartGet('funding-route-menu-item').should('contain.text', 'ETH');
+
+      cySmartGet('funding-route-menu-item__intentIcon').should('not.exist');
+    });
+
+    it('clicking should not open bottom sheet', () => {
+      cySmartGet('funding-route-menu-item').click();
+
+      cySmartGet('bottomSheet').should('not.exist');
+    });
+  });
+
+  describe('multiple options available', () => {
+    const fundingRoutes = [
+      {
+        priority: 1,
+        steps: [{
+          type: 'BRIDGE',
+          chainId: ChainId.SEPOLIA,
+          asset: {
+            balance: BigNumber.from(1),
+            formattedBalance: '1',
+            token: {
+              name: 'ETH',
+              symbol: 'ETH',
+              decimals: 18,
+            },
+          },
+        }],
+      },
+      {
+        priority: 2,
+        steps: [{
+          type: 'SWAP',
+          chainId: ChainId.IMTBL_ZKEVM_TESTNET,
+          asset: {
+            balance: BigNumber.from(10),
+            formattedBalance: '10',
+            token: {
+              name: 'ERC20',
+              symbol: 'USDC',
+              decimals: 18,
+              address: '0xERC20_2',
+            },
+          },
+        }],
+      },
+    ];
+    beforeEach(() => {
+      mount(
+        <BiomeCombinedProviders>
+          <FundingRouteSelect fundingRoutes={fundingRoutes} />
+        </BiomeCombinedProviders>,
+      );
+    });
+    it('should display first option, with chevron', () => {
+      cySmartGet('funding-route-menu-item').should('exist');
+      cySmartGet('funding-route-menu-item').should('contain.text', 'ETH');
+
+      cySmartGet('funding-route-menu-item__intentIcon').should('exist');
+    });
+
+    it('clicking should open bottom sheet', () => {
+      cySmartGet('funding-route-menu-item').click();
+
+      cySmartGet('bottomSheet').should('exist');
+    });
+
+    it('selecting an item inside the bottom sheet should change selected option', () => {
+      cySmartGet('funding-route-menu-item').should('contain.text', 'ETH');
+      cySmartGet('funding-route-menu-item').click();
+
+      cySmartGet('bottomSheet').should('exist');
+      cySmartGet('bottomSheet').find('[data-testId="funding-route-menu-item"]').should('have.length', 2);
+      cySmartGet('bottomSheet').find('[data-testId="funding-route-menu-item"]')
+        .eq(0).should('have.class', 'selected');
+      cySmartGet('bottomSheet').find('[data-testId="funding-route-menu-item"]')
+        .eq(1).should('not.have.class', 'selected');
+      cySmartGet('bottomSheet').find('[data-testId="funding-route-menu-item"]')
+        .eq(1).click();
+
+      cySmartGet('bottomSheet').should('not.exist');
+
+      cySmartGet('funding-route-menu-item').should('contain.text', 'USDC');
+
+      cySmartGet('funding-route-menu-item').click();
+      cySmartGet('bottomSheet').find('[data-testId="funding-route-menu-item"]')
+        .eq(0).should('not.have.class', 'selected');
+      cySmartGet('bottomSheet').find('[data-testId="funding-route-menu-item"]')
+        .eq(1).should('have.class', 'selected');
+    });
+  });
+});

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/FundingRouteSelect/FundingRouteSelect.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/FundingRouteSelect/FundingRouteSelect.tsx
@@ -1,11 +1,95 @@
-import { Box } from '@biom3/react';
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
-export function FundingRouteSelect() {
+import {
+  Body, Box,
+  Button, Heading, Select,
+} from '@biom3/react';
+import { useState } from 'react';
+import { FooterLogo } from '../../../../components/Footer/FooterLogo';
+import { HeaderNavigation } from '../../../../components/Header/HeaderNavigation';
+import { SimpleLayout } from '../../../../components/SimpleLayout/SimpleLayout';
+import { FundingRouteDrawer } from '../FundingRouteSelectDrawer/FundingRouteDrawer';
+import { FundingRouteMenuItem } from '../FundingRouteMenuItem/FundingRouteMenuItem';
+import { PurchaseMenuItem } from '../PurchaseMenuItem/PurchaseMenuItem';
+
+type FundingRouteSelectProps = {
+  fundingRoutes: any[];
+};
+
+export function FundingRouteSelect({ fundingRoutes }: FundingRouteSelectProps) {
+  const [smartCheckoutDrawerVisible, setSmartCheckoutDrawerVisible] = useState(false);
+  const [activeFundingRouteIndex, setActiveFundingRouteIndex] = useState(0);
+
+  const onClickContinue = () => {
+    console.log('@@@ onClickContinue');
+  };
+
+  const closeBottomSheet = (selectedFundingRouteIndex: number) => {
+    setActiveFundingRouteIndex(selectedFundingRouteIndex);
+    setSmartCheckoutDrawerVisible(false);
+  };
+
+  const onSmartCheckoutDropdownClick = () => {
+    console.log('@@@@@ onSmartCheckoutDropdownClickevent');
+    setSmartCheckoutDrawerVisible(true);
+  };
+
   return (
-    <Box testId="funding-route-select">
-      <p>
-        hello world from FundingRouteSelect
-      </p>
-    </Box>
+    <SimpleLayout
+      testId="funding-route-select"
+      header={<HeaderNavigation onCloseButtonClick={() => {}} />}
+      footer={<FooterLogo />}
+    >
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          paddingX: 'base.spacing.x2',
+          paddingY: 'base.spacing.x8',
+          rowGap: 'base.spacing.x4',
+          height: '100%',
+        }}
+      >
+        <Heading size="small">
+          Pay with your
+        </Heading>
+
+        {fundingRoutes.length === 0
+          ? (
+            <Heading size="small">
+              No funding routes available
+            </Heading>
+          )
+          : (
+            <FundingRouteMenuItem
+              data-testid="funding-route-select-selected-route"
+              onClick={fundingRoutes.length > 1 ? onSmartCheckoutDropdownClick : () => {}}
+              fundingRoute={fundingRoutes[activeFundingRouteIndex]}
+              selected
+              toggleVisible={fundingRoutes.length > 1}
+            />
+          ) }
+
+        {/* TODO add purchase data here */}
+        <PurchaseMenuItem />
+
+        <Button sx={{ mt: 'auto' }} variant="primary" onClick={onClickContinue}>
+          {/* {options.continue.text} */}
+          continue
+        </Button>
+        <Button variant="tertiary">
+          {/* {options.payWithCard.text} */}
+          pay with card
+        </Button>
+      </Box>
+      <FundingRouteDrawer
+        visible={smartCheckoutDrawerVisible}
+        onCloseBottomSheet={closeBottomSheet}
+        fundingRoutes={fundingRoutes}
+        activeFundingRouteIndex={activeFundingRouteIndex}
+      />
+    </SimpleLayout>
   );
 }

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/FundingRouteSelectDrawer/FundingRouteDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/FundingRouteSelectDrawer/FundingRouteDrawer.tsx
@@ -1,11 +1,44 @@
-import { Box } from '@biom3/react';
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
-export function FundingRouteDrawer() {
+import {
+  BottomSheet,
+} from '@biom3/react';
+import { FundingRouteMenuItem } from '../FundingRouteMenuItem/FundingRouteMenuItem';
+
+type FundingRouteDrawerProps = {
+  visible: boolean;
+  onCloseBottomSheet: (selectedFundingRouteIndex: number) => void;
+  fundingRoutes: any;
+  activeFundingRouteIndex: number;
+};
+
+export function FundingRouteDrawer({
+  visible, onCloseBottomSheet, fundingRoutes, activeFundingRouteIndex,
+}:
+FundingRouteDrawerProps) {
+  const onClickMenuItem = (selectedFundingRouteIndex: number) => {
+    onCloseBottomSheet(selectedFundingRouteIndex);
+  };
+
   return (
-    <Box>
-      <p>
-        hello world from FundingRouteDrawer
-      </p>
-    </Box>
+    <BottomSheet
+      size="full"
+      onCloseBottomSheet={() => onCloseBottomSheet(activeFundingRouteIndex)}
+      visible={visible}
+      showHeaderBar
+      headerBarTitle="Available balance"
+    >
+      <BottomSheet.Content>
+        {fundingRoutes.map((fundingRoute: any, i: number) => (
+          <FundingRouteMenuItem
+            onClick={() => onClickMenuItem(i)}
+            fundingRoute={fundingRoute}
+            selected={activeFundingRouteIndex === i}
+            key={fundingRoute.priority}
+          />
+        ))}
+      </BottomSheet.Content>
+    </BottomSheet>
   );
 }

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/PurchaseMenuItem/PurchaseMenuItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/components/PurchaseMenuItem/PurchaseMenuItem.tsx
@@ -1,0 +1,26 @@
+import { Heading, MenuItem } from '@biom3/react';
+
+export function PurchaseMenuItem() {
+  return (
+    <MenuItem
+      testId="funding-route-purchase-item"
+      size="small"
+    >
+      <MenuItem.FramedImage
+        // eslint-disable-next-line max-len
+        imageUrl="https://uploads-ssl.webflow.com/628b4f4f8c89f8ba7f0966ea/64e6722c5d0ab7fd505ff7b6_Mech_Wardog_L_Uncommon_1.jpg"
+      />
+      <MenuItem.PriceDisplay
+        use={<Heading size="xSmall" />}
+        price="0.0252565"
+        fiatAmount="USD $2.49"
+      />
+      <MenuItem.Label>
+        Starter Pack
+      </MenuItem.Label>
+      <MenuItem.Caption>
+        Metalcore
+      </MenuItem.Caption>
+    </MenuItem>
+  );
+}

--- a/packages/checkout/widgets-lib/src/widgets/primary-revenue/views/FundWithSmartCheckout.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/primary-revenue/views/FundWithSmartCheckout.tsx
@@ -20,7 +20,7 @@ export function FundWithSmartCheckout({ subView }: FundWithSmartCheckoutProps) {
         <LoadingView loadingText="todo loading text" />
       )}
       { subView === FundWithSmartCheckoutSubViews.FUNDING_ROUTE_SELECT && (
-        <FundingRouteSelect />
+        <FundingRouteSelect fundingRoutes={[]} />
       )}
       { subView === FundWithSmartCheckoutSubViews.FUNDING_ROUTE_EXECUTE && (
         <FundingRouteExecute />


### PR DESCRIPTION
Squashed the following commits to avoid Commit Hell from https://github.com/immutable/ts-immutable-sdk/pull/917

Adds FundWithSmartCheckout view + initial components.

Adds a cypress test for FundWithSmartCheckout template switching.

removing dev code.

Fixes var naming.

migrates select + drawer code.

Adds a wrapper for rendering SC options as MenuItems.

Adds a component to display current purchase as a MenuItem.

Adds FundingRouteMenuItem + PurchaseMenuItem to FundingRouteSelect.

Adds UI for bottom sheet drawer.

Adds cypress test for funding route selection.

removes mock data.

removes some eslint comments.

Adds empty state for funding routes.

# Summary
<!--- A short summary about what this PR is doing. -->


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
