### PR TITLE
fix: added typecheck after build for PR jobs

### DIFF
--- a/.github/workflows/build-lint-typecheck-test.yaml
+++ b/.github/workflows/build-lint-typecheck-test.yaml
@@ -29,11 +29,11 @@ jobs:
       - name: Check Single Package Version Policy
         run: yarn syncpack:check
 
-      - name: Build
-        run: yarn build
-
       - name: Typecheck
         run: yarn typecheck
+
+      - name: Build
+        run: yarn build
 
   test:
     name: Test


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

Add back typecheck in PR checks

# Why the changes
<!--- State the reason/context for the change. -->

This is causing PRs to pass all the checks but potentially making the publish job failing.

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
