### PR TITLE
[NO-JIRA] fix: prevent docs PR workflow from publishing docs for alpha releases

### DIFF
--- a/.github/scripts/check-pending-release.sh
+++ b/.github/scripts/check-pending-release.sh
@@ -25,3 +25,8 @@ if [ -n "$PENDING_RELEASE" ]; then
   exit 1
 fi
 
+# check INPUT_DESTINATION_HEAD_BRANCH does not contain the substring `alpha`
+if [[ $INPUT_DESTINATION_HEAD_BRANCH == *"alpha"* ]]; then
+  echo "Docs generation skipped for alpha releases"
+  exit 1
+fi


### PR DESCRIPTION
# Summary

Currently, publishing a release to NPM will trigger a workflow to generate a new set of SDK reference docs for the published version. This also happens for alpha releases. The issue is the workflow also updates the link on the docs website to point to the new version of docs, which would mean docs for alpha releases could get published to the docs website.

The PR includes a check that exits the docs generation workflow for alpha releases which should prevent alpha version SDK references getting published to the main docs website.

# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
