### PR TITLE
Move runners back to ubuntu-latest

### DIFF
--- a/.github/workflows/build-lint-typecheck-test.yaml
+++ b/.github/workflows/build-lint-typecheck-test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: --max-old-space-size=14366
     steps:
@@ -34,7 +34,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
 
   cypress:
     name: Cypress
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: --max-old-space-size=14366
     steps:
@@ -117,7 +117,7 @@ jobs:
   
   lint:
     name: Lint
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ on:
 jobs:
   Publish:
     name: Publish Workflow
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.PLATFORM_SA_GITHUB_TOKEN }}
       NODE_OPTIONS: --max-old-space-size=14366


### PR DESCRIPTION
Since this repository was made public, all github actions have been stalled , unable to select a runner from our enterprise account.

We will need to figure out a strategy here (as switch back to ubuntu-latest will extend build times)

For the moment however, this temporary change will keep CI/CD moving.

Follow up PR will need to consider a runner group just for this repository, and ensure adequate security protections.