### PR TITLE
Revert "Move runners back to ubuntu-latest"

### DIFF
--- a/.github/workflows/build-lint-typecheck-test.yaml
+++ b/.github/workflows/build-lint-typecheck-test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       NODE_OPTIONS: --max-old-space-size=14366
     steps:
@@ -34,7 +34,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
 
   cypress:
     name: Cypress
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       NODE_OPTIONS: --max-old-space-size=14366
     steps:
@@ -117,7 +117,7 @@ jobs:
   
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ on:
 jobs:
   Publish:
     name: Publish Workflow
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       GH_TOKEN: ${{ secrets.PLATFORM_SA_GITHUB_TOKEN }}
       NODE_OPTIONS: --max-old-space-size=14366


### PR DESCRIPTION
Reverts immutable/ts-immutable-sdk#964

We've moved the repo back to private until we can figure out what the github action strategy needs to be for this repo (the 4-core larger runners dont work publicly, TBD if normal runners have security issues e.g., if we expose github secrets)