### PR TITLE
fix: return true for checkDexAvailability sandbox

### DIFF
--- a/packages/checkout/sdk/src/availability/availability.ts
+++ b/packages/checkout/sdk/src/availability/availability.ts
@@ -19,6 +19,9 @@ export const availabilityService = (
   };
 
   const checkDexAvailability = async (): Promise<boolean> => {
+    // Returns true for sandbox environment
+    if (!isDevelopment && !isProduction) return true;
+
     let response;
 
     try {


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

The new WAF rules that intercept `/v1/availability/checkout/swap` endpoint to return 204/403 only applies to devnet and prod environments. This endpoint is an empty endpoint, therefore, it does not return any response object. For sandbox environment, the current bug is that it will always return 404 because this endpoint is not found/does not actually exist.

https://imtbl.slack.com/archives/C0414KQ5162/p1697159056555709

# Why the changes
<!--- State the reason/context for the change. -->

This fix will ensure that this empty endpoint will not get hit when in sandbox environment. It will return true when checkDexAvailability method is called and when environment is sandbox.

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
