### PR TITLE
fix: DX-2413 Prevent test failures when sandbox goes down

### DIFF
--- a/packages/immutablex_client/src/imx.test.ts
+++ b/packages/immutablex_client/src/imx.test.ts
@@ -5,21 +5,31 @@ import { AxiosRequestConfig } from 'axios';
 import { ImxConfiguration, ImxModuleConfiguration, createImmutableXConfiguration } from './config';
 
 describe('ImmutableXClient', () => {
-  it.skip('should instantiate a SANDBOX ImmutableXClient', async () => {
+  it('should instantiate a SANDBOX ImmutableXClient', async () => {
     const imtblConfig = new ImmutableConfiguration({
       environment: Environment.SANDBOX,
     });
 
-    const { assetApi } = new ImmutableXClient({
+    const client = new ImmutableXClient({
       baseConfig: imtblConfig,
     });
 
-    const assetsResponse = await assetApi.listAssets();
-
-    expect(assetsResponse.status).toEqual(200);
-    expect(assetsResponse.config.headers?.['x-sdk-version']).toContain(
-      'ts-immutable-sdk',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let axiosRequest: AxiosRequestConfig = {};
+    const adapter = jest.fn().mockImplementation(
+      async (request: AxiosRequestConfig) => {
+        axiosRequest = request;
+        return { status: 200 };
+      },
     );
+
+    const reqConfig : AxiosRequestConfig = {
+      adapter,
+    };
+
+    // @ts-ignore
+    await client.assetApi.listAssets({}, reqConfig);
+    expect(axiosRequest.headers?.['x-sdk-version']).toEqual('ts-immutable-sdk-__SDK_VERSION__');
   });
 
   it('should instantiate a PRODUCTION ImmutableXClient', async () => {


### PR DESCRIPTION
# Summary
This PR re-activates a test that was skipped in #1047.
The test was skipped in #1047 because it was actually performing an API call, which failed when the environment went down.
This PR makes the test use a mock, so its not coupled to the state of the environment 

# Customer Impact
None

# Things worth calling out
This is only a change to test code.

# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
