### PR TITLE
fix: ID-1124 Login & misc changes

### DIFF
--- a/packages/passport/sdk-sample-app/src/components/PassportMethods.tsx
+++ b/packages/passport/sdk-sample-app/src/components/PassportMethods.tsx
@@ -8,9 +8,8 @@ import WorkflowButton from '@/components/WorkflowButton';
 function PassportMethods() {
   const { isLoading } = useStatusProvider();
   const {
-    userProfile,
     logout,
-    signIn,
+    login,
     getIdToken,
     getAccessToken,
     getUserInfo,
@@ -20,14 +19,12 @@ function PassportMethods() {
   return (
     <CardStack title="Passport Methods">
       <Stack direction="horizontal" style={{ flexWrap: 'wrap' }} gap={3}>
-        {!userProfile && (
         <WorkflowButton
           disabled={isLoading}
-          onClick={signIn}
+          onClick={login}
         >
           Login
         </WorkflowButton>
-        )}
         <WorkflowButton
           disabled={isLoading}
           onClick={logout}

--- a/packages/passport/sdk-sample-app/src/components/imx/ImxWorkflow.tsx
+++ b/packages/passport/sdk-sample-app/src/components/imx/ImxWorkflow.tsx
@@ -19,7 +19,7 @@ function ImxWorkflow() {
   const [showOrder, setShowOrder] = useState<boolean>(false);
 
   const { addMessage, isLoading } = useStatusProvider();
-  const { connectImx, connectImxSilent, imxProvider } = usePassportProvider();
+  const { connectImx, imxProvider } = usePassportProvider();
 
   const getAddress = useCallback(async () => {
     const address = await imxProvider?.getAddress();
@@ -52,12 +52,6 @@ function ImxWorkflow() {
               onClick={connectImx}
             >
               Connect
-            </WorkflowButton>
-            <WorkflowButton
-              disabled={isLoading}
-              onClick={connectImxSilent}
-            >
-              Connect Silent
             </WorkflowButton>
           </>
         )}

--- a/packages/passport/sdk-sample-app/src/context/ImmutableProvider.tsx
+++ b/packages/passport/sdk-sample-app/src/context/ImmutableProvider.tsx
@@ -104,12 +104,13 @@ const getPassportConfig = (environment: EnvironmentNames): PassportModuleConfigu
 };
 
 const ImmutableContext = createContext<{
-  passportClient?: Passport,
+  passportClient: Passport,
   coreSdkClient: ImmutableX,
   environment: EnvironmentNames,
   setEnvironment?:(environment: EnvironmentNames) => void;
 }>({
       coreSdkClient: new ImmutableX(getCoreSdkConfig(EnvironmentNames.DEV)),
+      passportClient: new Passport(getPassportConfig(EnvironmentNames.DEV)),
       environment: EnvironmentNames.DEV,
     });
 
@@ -123,7 +124,9 @@ export function ImmutableProvider({
   const [coreSdkClient, setCoreSdkClient] = useState<ImmutableX>(
     useContext(ImmutableContext).coreSdkClient,
   );
-  const [passportClient, setPassportClient] = useState<Passport>();
+  const [passportClient, setPassportClient] = useState<Passport>(
+    useContext(ImmutableContext).passportClient,
+  );
 
   useEffect(() => {
     setCoreSdkClient(new ImmutableX(getCoreSdkConfig(environment)));

--- a/packages/passport/sdk-sample-app/src/context/PassportProvider.tsx
+++ b/packages/passport/sdk-sample-app/src/context/PassportProvider.tsx
@@ -9,12 +9,10 @@ import { useStatusProvider } from '@/context/StatusProvider';
 const PassportContext = createContext<{
   imxProvider: IMXProvider | undefined;
   zkEvmProvider: Provider | undefined;
-  userProfile: UserProfile | undefined;
   connectImx:() => void;
-  connectImxSilent: () => void;
   connectZkEvm: () => void;
   logout: () => void;
-  signIn: () => void;
+  login: () => void;
   getIdToken: () => Promise<string | undefined>;
   getAccessToken: () => Promise<string | undefined>;
   getUserInfo: () => Promise<UserProfile | undefined>;
@@ -22,12 +20,10 @@ const PassportContext = createContext<{
 }>({
       imxProvider: undefined,
       zkEvmProvider: undefined,
-      userProfile: undefined,
       connectImx: () => undefined,
-      connectImxSilent: () => undefined,
       connectZkEvm: () => undefined,
       logout: () => undefined,
-      signIn: () => Promise.resolve(undefined),
+      login: () => Promise.resolve(undefined),
       getIdToken: () => Promise.resolve(undefined),
       getAccessToken: () => Promise.resolve(undefined),
       getUserInfo: () => Promise.resolve(undefined),
@@ -39,7 +35,6 @@ export function PassportProvider({
 }: { children: JSX.Element | JSX.Element[] }) {
   const [imxProvider, setImxProvider] = useState<IMXProvider | undefined>();
   const [zkEvmProvider, setZkEvmProvider] = useState<Provider | undefined>();
-  const [userProfile, setUserProfile] = useState<UserProfile | undefined>();
 
   const { addMessage, setIsLoading } = useStatusProvider();
   const { passportClient } = useImmutableProvider();
@@ -47,7 +42,7 @@ export function PassportProvider({
   const connectImx = useCallback(async () => {
     try {
       setIsLoading(true);
-      const provider = await passportClient?.connectImx();
+      const provider = await passportClient.connectImx();
       if (provider) {
         setImxProvider(provider);
         addMessage('ConnectImx', 'Connected');
@@ -61,26 +56,9 @@ export function PassportProvider({
     }
   }, [passportClient, setIsLoading, addMessage]);
 
-  const connectImxSilent = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const provider = await passportClient?.connectImxSilent();
-      if (provider) {
-        setImxProvider(provider);
-        addMessage('ConnectImxSilent', 'Connected');
-      } else {
-        addMessage('ConnectImxSilent', 'Failed to connect. Ensure you have logged in before.');
-      }
-    } catch (err) {
-      addMessage('ConnectImxSilent', err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [passportClient, setIsLoading, addMessage]);
-
   const connectZkEvm = useCallback(async () => {
     setIsLoading(true);
-    const provider = passportClient?.connectEvm();
+    const provider = passportClient.connectEvm();
     if (provider) {
       setZkEvmProvider(provider);
       addMessage('ConnectZkEvm', 'Connected');
@@ -92,7 +70,7 @@ export function PassportProvider({
 
   const getIdToken = useCallback(async () => {
     setIsLoading(true);
-    const idToken = await passportClient?.getIdToken();
+    const idToken = await passportClient.getIdToken();
     addMessage('Get ID token', idToken);
     setIsLoading(false);
 
@@ -101,7 +79,7 @@ export function PassportProvider({
 
   const getAccessToken = useCallback(async () => {
     setIsLoading(true);
-    const accessToken = await passportClient?.getAccessToken();
+    const accessToken = await passportClient.getAccessToken();
     addMessage('Get Access token', accessToken);
     setIsLoading(false);
 
@@ -110,7 +88,7 @@ export function PassportProvider({
 
   const getUserInfo = useCallback(async () => {
     setIsLoading(true);
-    const userInfo = await passportClient?.getUserInfo();
+    const userInfo = await passportClient.getUserInfo();
     addMessage('Get User Info', userInfo);
     setIsLoading(false);
 
@@ -119,7 +97,7 @@ export function PassportProvider({
 
   const getLinkedAddresses = useCallback(async () => {
     setIsLoading(true);
-    const linkedAddresses = await passportClient?.getLinkedAddresses();
+    const linkedAddresses = await passportClient.getLinkedAddresses();
     addMessage('Get Linked Addresses', linkedAddresses);
     setIsLoading(false);
 
@@ -129,10 +107,9 @@ export function PassportProvider({
   const logout = useCallback(async () => {
     try {
       setIsLoading(true);
-      await passportClient?.logout();
+      await passportClient.logout();
       setImxProvider(undefined);
       setZkEvmProvider(undefined);
-      setUserProfile(undefined);
     } catch (err) {
       addMessage('Logout', err);
       console.error(err);
@@ -141,13 +118,13 @@ export function PassportProvider({
     }
   }, [addMessage, passportClient, setIsLoading]);
 
-  const signIn = useCallback(async () => {
+  const login = useCallback(async () => {
     try {
       setIsLoading(true);
-      const signInuser = await passportClient?.signIn();
-      setUserProfile(signInuser);
+      const userProfile = await passportClient.login();
+      addMessage('Login', userProfile);
     } catch (err) {
-      addMessage('Logout', err);
+      addMessage('Login', err);
       console.error(err);
     } finally {
       setIsLoading(false);
@@ -157,12 +134,10 @@ export function PassportProvider({
   const providerValues = useMemo(() => ({
     imxProvider,
     zkEvmProvider,
-    userProfile,
     connectImx,
-    connectImxSilent,
     connectZkEvm,
     logout,
-    signIn,
+    login,
     getIdToken,
     getAccessToken,
     getUserInfo,
@@ -170,12 +145,10 @@ export function PassportProvider({
   }), [
     imxProvider,
     zkEvmProvider,
-    userProfile,
     connectImx,
-    connectImxSilent,
     connectZkEvm,
     logout,
-    signIn,
+    login,
     getIdToken,
     getAccessToken,
     getUserInfo,
@@ -191,13 +164,11 @@ export function PassportProvider({
 
 export function usePassportProvider() {
   const {
-    userProfile,
     imxProvider,
     zkEvmProvider,
     connectImx,
-    connectImxSilent,
     connectZkEvm,
-    signIn,
+    login,
     logout,
     getIdToken,
     getAccessToken,
@@ -205,13 +176,11 @@ export function usePassportProvider() {
     getLinkedAddresses,
   } = useContext(PassportContext);
   return {
-    userProfile,
     imxProvider,
     zkEvmProvider,
     connectImx,
-    connectImxSilent,
     connectZkEvm,
-    signIn,
+    login,
     logout,
     getIdToken,
     getAccessToken,

--- a/packages/passport/sdk-sample-app/src/pages/login/callback.ts
+++ b/packages/passport/sdk-sample-app/src/pages/login/callback.ts
@@ -5,6 +5,6 @@ export default function HandleCallback() {
   const { passportClient } = useImmutableProvider();
 
   useEffect(() => {
-    passportClient?.loginCallback();
+    passportClient.loginCallback();
   }, [passportClient]);
 }

--- a/packages/passport/sdk-sample-app/src/pages/silent-logout/callback.ts
+++ b/packages/passport/sdk-sample-app/src/pages/silent-logout/callback.ts
@@ -6,6 +6,6 @@ export default function HandleCallback() {
   const { passportClient } = useImmutableProvider();
 
   useEffect(() => {
-    passportClient?.logoutSilentCallback(SILENT_LOGOUT_PARENT_URI);
+    passportClient.logoutSilentCallback(SILENT_LOGOUT_PARENT_URI);
   }, [passportClient]);
 }

--- a/packages/passport/sdk/src/Passport.test.ts
+++ b/packages/passport/sdk/src/Passport.test.ts
@@ -248,10 +248,10 @@ describe('Passport', () => {
     });
   });
 
-  describe('signIn', () => {
+  describe('login', () => {
     it('should login silently if there is a user', async () => {
       loginSilentMock.mockReturnValue(mockUserImx);
-      const user = await passport.signIn();
+      const user = await passport.login();
 
       expect(loginSilentMock).toBeCalledTimes(1);
       expect(authLoginMock).toBeCalledTimes(0);
@@ -261,7 +261,7 @@ describe('Passport', () => {
     it('should signIn and get a user', async () => {
       loginSilentMock.mockReturnValue(null);
       authLoginMock.mockReturnValue(mockUserImx);
-      const user = await passport.signIn();
+      const user = await passport.login();
 
       expect(loginSilentMock).toBeCalledTimes(1);
       expect(authLoginMock).toBeCalledTimes(1);
@@ -270,7 +270,7 @@ describe('Passport', () => {
 
     it('should only login silently if useCachedSession is true', async () => {
       loginSilentMock.mockReturnValue(mockUserImx);
-      const user = await passport.signIn({ useCachedSession: true });
+      const user = await passport.login({ useCachedSession: true });
 
       expect(loginSilentMock).toBeCalledTimes(1);
       expect(authLoginMock).toBeCalledTimes(0);

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -57,20 +57,9 @@ export class Passport {
     });
   }
 
-  public async signIn(options?: { useCachedSession: boolean }): Promise<UserProfile | null> {
-    const { useCachedSession = false } = options || {};
-    let user = await this.authManager.loginSilent();
-    if (!user && !useCachedSession) {
-      user = await this.authManager.login();
-    }
-    if (!user) {
-      return null;
-    }
-    return user.profile;
-  }
-
   /**
-   * @deprecated The method connectImx(useCachedSession) should be used instead
+   * @deprecated The method `login` with an argument of `{ useCachedSession: true }` should be used in conjunction with
+   * `connectImx` instead.
    */
   public async connectImxSilent(): Promise<IMXProvider | null> {
     return this.passportImxProviderFactory.getProviderSilent();
@@ -78,10 +67,6 @@ export class Passport {
 
   public async connectImx(): Promise<IMXProvider> {
     return this.passportImxProviderFactory.getProvider();
-  }
-
-  public async loginWithDeviceFlow(): Promise<DeviceConnectResponse> {
-    return this.authManager.loginWithDeviceFlow();
   }
 
   public async connectImxDeviceFlow(
@@ -124,6 +109,28 @@ export class Passport {
       confirmationScreen: this.confirmationScreen,
       multiRollupApiClients: this.multiRollupApiClients,
     });
+  }
+
+  /**
+   *
+   * Initiates the authorisation flow.
+   *
+   * @param options.useCachedSession = false - If true, and no active session exists, then the user will not be
+   * prompted to log in and the Promise will resolve with a null value.
+   * @returns {Promise<UserProfile | null>} the user profile if the user is logged in, otherwise null
+   */
+  public async login(options?: { useCachedSession: boolean }): Promise<UserProfile | null> {
+    const { useCachedSession = false } = options || {};
+    let user = await this.authManager.loginSilent();
+    if (!user && !useCachedSession) {
+      user = await this.authManager.login();
+    }
+
+    return user ? user.profile : null;
+  }
+
+  public async loginWithDeviceFlow(): Promise<DeviceConnectResponse> {
+    return this.authManager.loginWithDeviceFlow();
   }
 
   public async loginCallback(): Promise<void> {


### PR DESCRIPTION
# Summary
This PR:
- Renames `signIn` to `login`, in order to be consistent with `logout`, `loginCallback`, `loginWithDeviceFlow`, etc.
- Removes usage of `connectImxSilent` from the sample app, as it's now deprecated
- Changes the sample app to always display the `login` button
- Updated `ImmutableProvider` so that `passportClient` is always set
- Added additional comments to `Passport.ts` & ordered functions so that `login` methods are grouped together

## Changed
- Passport: Renamed `signIn` to `login` to be consistent with other methods

# Before submitting the PR, please consider the following:
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
