### PR TITLE
suggest new signature to avoid create(type, null, provider)

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/global.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/global.ts
@@ -8,7 +8,6 @@ import {
   WidgetProperties,
   WidgetType,
   WidgetEventData,
-  WidgetConfigurations,
 } from './types';
 
 /**
@@ -20,7 +19,7 @@ declare global {
   namespace ImmutableCheckoutWidgets {
     class WidgetsFactory implements IWidgetsFactory {
       constructor(sdk: Checkout, config: CheckoutWidgetsConfig);
-      create<T extends WidgetType>(type: T, config?: WidgetConfigurations[T], provider?: Web3Provider): Widget<T>;
+      create<T extends WidgetType>(type: T, props?: WidgetProperties<T>): Widget<T>;
       updateProvider(provider: Web3Provider): void;
     }
 

--- a/packages/checkout/sdk/src/widgets/definitions/types.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/types.ts
@@ -199,8 +199,13 @@ export interface IWidgetsFactory {
   /**
    * Create a new widget instance.
    * @param type widget type to instantiate.
+   * @param props widget configurations and provider.
    */
-  create<T extends WidgetType>(type: T, config?: WidgetConfigurations[T], provider?: Web3Provider): Widget<T>;
+  create<T extends WidgetType>(type: T, props?: WidgetProperties<T>): Widget<T>;
+  /**
+   * Update the widgets provider instance.
+   * @param provider provider instantiate.
+   */
   updateProvider(provider: Web3Provider): void;
 }
 
@@ -211,6 +216,7 @@ export interface Widget<T extends WidgetType> {
   /**
    * Mount a widget to a DOM ref element.
    * @param id ID of the DOM element where the widget will be mounted.
+   * @param params widget parameters.
    */
   mount(id: string, params?: WidgetParameters[T]): void;
   /**

--- a/packages/checkout/widgets-lib/src/factory.ts
+++ b/packages/checkout/widgets-lib/src/factory.ts
@@ -1,12 +1,10 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable max-len */
 import {
   Widget,
   Checkout,
   WidgetType,
   IWidgetsFactory,
-  WidgetConfigurations,
   WidgetConfiguration,
+  WidgetProperties,
 } from '@imtbl/checkout-sdk';
 import { Bridge } from 'widgets/bridge/BridgeWidgetRoot';
 import { Connect } from 'widgets/connect/ConnectWidgetRoot';
@@ -31,7 +29,9 @@ export class WidgetsFactory implements IWidgetsFactory {
     sendProviderUpdatedEvent({ provider });
   }
 
-  create<T extends WidgetType>(type: T, config?: WidgetConfigurations[T], provider?: Web3Provider): Widget<T> {
+  create<T extends WidgetType>(type: T, props?: WidgetProperties<T>): Widget<T> {
+    const { config = {}, provider } = props ?? {};
+
     switch (type) {
       case WidgetType.CONNECT: {
         return new Connect(this.sdk, {

--- a/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
@@ -96,7 +96,7 @@ export function SaleUI() {
   const passportInstance = useMemo(() => usePassportInstance(JSON.parse(passportConfig)), []);
   const checkout = useMemo(() => new Checkout({baseConfig: {environment: Environment.SANDBOX}, passport: passportInstance as unknown as Passport}), [passportInstance])
   const factory = useMemo(() => new WidgetsFactory(checkout, {theme: WidgetTheme.DARK}), [checkout])
-  const saleWidget = useMemo(() => factory.create(WidgetType.SALE, {theme: WidgetTheme.DARK}), 
+  const saleWidget = useMemo(() => factory.create(WidgetType.SALE, { config: { theme: WidgetTheme.DARK } }), 
   [factory, amount, environmentId, fromContractAddress, defaultItems]
   )
 


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

Suggest new signature for the `create` function in order to avoid `create("swap", null, provider)` and make the addition of new props scalable.
This is beneficial if we want to expand the number of params pass on creation without introducing breaking changes.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->


<!-- Remove the H2 sections as required -->
## Added 
<!-- Section for new features. -->


## Changed
<!-- Section for changes in existing functionality. -->


## Deprecated
<!-- Section for soon-to-be removed features. -->


## Removed
<!-- Section for now removed features. -->


## Fixed
<!-- Section for any bug fixes. -->


## Security
<!-- Section in case of vulnerabilities. -->




# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
