### PR TITLE
chore: [TD-1060] Orderbook rename start_amount to amount in internal API client

### DIFF
--- a/packages/orderbook/src/api-client/api-client.ts
+++ b/packages/orderbook/src/api-client/api-client.ts
@@ -121,7 +121,7 @@ export class ImmutableApiClient {
               === ItemType.NATIVE
                 ? 'NATIVE'
                 : 'ERC20',
-            start_amount: orderComponents.consideration[0].startAmount,
+            amount: orderComponents.consideration[0].startAmount,
             contract_address: orderComponents.consideration[0].token,
           },
         ],

--- a/packages/orderbook/src/openapi/mapper.ts
+++ b/packages/orderbook/src/openapi/mapper.ts
@@ -17,14 +17,14 @@ export function mapFromOpenApiOrder(order: OpenApiOrder): Order {
       return {
         type: 'ERC20',
         contractAddress: item.contract_address,
-        amount: item.start_amount,
+        amount: item.amount,
       };
     }
 
     if (item.item_type === 'NATIVE') {
       return {
         type: 'NATIVE',
-        amount: item.start_amount,
+        amount: item.amount,
       };
     }
 
@@ -77,14 +77,14 @@ export function mapFromOpenApiTrade(trade: OpenApiTrade): Trade {
       return {
         type: 'ERC20',
         contractAddress: item.contract_address,
-        amount: item.start_amount,
+        amount: item.amount,
       };
     }
 
     if (item.item_type === 'NATIVE') {
       return {
         type: 'NATIVE',
-        amount: item.start_amount,
+        amount: item.amount,
       };
     }
 

--- a/packages/orderbook/src/openapi/sdk/models/ERC20Item.ts
+++ b/packages/orderbook/src/openapi/sdk/models/ERC20Item.ts
@@ -14,6 +14,6 @@ export type ERC20Item = {
   /**
    * A string representing the starting price at which the user is willing to sell the token. This value is provided in the smallest unit of the token (e.g., wei for Ethereum).
    */
-  start_amount: string;
+  amount: string;
 };
 

--- a/packages/orderbook/src/openapi/sdk/models/NativeItem.ts
+++ b/packages/orderbook/src/openapi/sdk/models/NativeItem.ts
@@ -10,6 +10,6 @@ export type NativeItem = {
   /**
    * A string representing the starting price at which the user is willing to sell the token. This value is provided in the smallest unit of the token (e.g., wei for Ethereum).
    */
-  start_amount: string;
+  amount: string;
 };
 

--- a/packages/orderbook/src/seaport/map-to-seaport-order.ts
+++ b/packages/orderbook/src/seaport/map-to-seaport-order.ts
@@ -16,8 +16,8 @@ export function mapImmutableOrderToSeaportOrderComponents(
     switch (buyItem.item_type) {
       case 'NATIVE':
         return {
-          startAmount: buyItem.start_amount,
-          endAmount: buyItem.start_amount,
+          startAmount: buyItem.amount,
+          endAmount: buyItem.amount,
           itemType: ItemType.NATIVE,
           recipient: order.account_address,
           token: constants.AddressZero,
@@ -25,8 +25,8 @@ export function mapImmutableOrderToSeaportOrderComponents(
         };
       case 'ERC20':
         return {
-          startAmount: buyItem.start_amount,
-          endAmount: buyItem.start_amount,
+          startAmount: buyItem.amount,
+          endAmount: buyItem.amount,
           itemType: ItemType.ERC20,
           recipient: order.account_address,
           token: buyItem.contract_address! || constants.AddressZero,

--- a/packages/orderbook/src/seaport/seaport.test.ts
+++ b/packages/orderbook/src/seaport/seaport.test.ts
@@ -389,7 +389,7 @@ describe('Seaport', () => {
 
       const immutableOrder: Order = {
         account_address: offerer,
-        buy: [{ item_type: 'NATIVE', start_amount: '100' }],
+        buy: [{ item_type: 'NATIVE', amount: '100' }],
         fees: [],
         chain: { id: '1', name: 'imtbl-zkevm-local' },
         created_at: new Date().toISOString(),


### PR DESCRIPTION
# Summary

Renames `start_amount` to `amount` in internal API client.


# Customer Impact

Customers will require a upgrade to the SDK to correctly create and receive listings from the order book.


# Things worth calling out

N/A


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
