### PR TITLE
TP-1758: Set the right swap recipient

### DIFF
--- a/packages/internal/dex/sdk/src/test/utils.ts
+++ b/packages/internal/dex/sdk/src/test/utils.ts
@@ -450,7 +450,7 @@ export function expectToBeDefined<T>(x: T): asserts x is NonNullable<T> {
 
 // expectToBeDefined ensures that x is a string, while
 // also narrowing its type.
-export function expectToBeString(x: string): asserts x is string {
+export function expectToBeString(x: unknown): asserts x is string {
   expect(typeof x).toBe('string');
 }
 


### PR DESCRIPTION
Related to: https://github.com/immutable/secondary-fee-contracts/pull/45

Depending on whether there are fees and whether the token out is native, the swap recipient should be different.