### PR TITLE
[NO-JIRA] Remove internal endpoint referenced in blockchain data config

### DIFF
--- a/packages/blockchain-data/sdk/src/config/index.ts
+++ b/packages/blockchain-data/sdk/src/config/index.ts
@@ -63,7 +63,7 @@ export class BlockchainDataConfiguration {
         }
         case Environment.PRODUCTION: {
           this.apiConfig = createAPIConfiguration({
-            basePath: 'https://indexer-mr.imtbl.com',
+            basePath: 'https://api.immutable.com',
             baseConfig,
           });
           break;


### PR DESCRIPTION
`imtbl.com` should be only used internally, as per these SRE updates: https://github.com/immutable/ts-immutable-sdk/pull/604