### PR TITLE
Remove len check for publishable-key

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -22,7 +22,6 @@ export class ImmutableConfiguration {
 
 const API_KEY_PREFIX = 'sk_imapik-';
 const PUBLISHABLE_KEY_PREFIX = 'pk_imapik-';
-const PUBLISHABLE_KEY_LENGTH = 30;
 
 export const addApiKeyToAxiosHeader = (apiKey: string) => {
   if (!apiKey.startsWith(API_KEY_PREFIX)) {
@@ -32,7 +31,7 @@ export const addApiKeyToAxiosHeader = (apiKey: string) => {
 };
 
 export const addPublishableKeyToAxiosHeader = (publishableKey: string) => {
-  if (!publishableKey.startsWith(PUBLISHABLE_KEY_PREFIX) || publishableKey.length !== PUBLISHABLE_KEY_LENGTH) {
+  if (!publishableKey.startsWith(PUBLISHABLE_KEY_PREFIX)) {
     throw new Error(
       'Invalid Publishable key. Create your Publishable key in Immutable developer hub.'
       + ' https://hub.immutable.com',


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

Remove len check for publishable key due to adding differentiation between prod and non prod generated publishable keys.

Non prod will be prefixed with pk_imapik-test while prod stays with pk_imapik- prefix.


# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->


<!-- Remove the H2 sections as required -->
## Added 
<!-- Section for new features. -->


## Changed
<!-- Section for changes in existing functionality. -->


## Deprecated
<!-- Section for soon-to-be removed features. -->


## Removed
<!-- Section for now removed features. -->


## Fixed
<!-- Section for any bug fixes. -->


## Security
<!-- Section in case of vulnerabilities. -->




# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
