### PR TITLE
WT-1941 Export CreateProviderParams and CreateProviderResult

### DIFF
--- a/packages/checkout/sdk/src/index.ts
+++ b/packages/checkout/sdk/src/index.ts
@@ -49,6 +49,8 @@ export type {
   CheckoutSwapConfiguration,
   ConnectParams,
   ConnectResult,
+  CreateProviderParams,
+  CreateProviderResult,
   DexConfig,
   ERC20ItemRequirement,
   ERC721Balance,


### PR DESCRIPTION
Exports CreateProviderParams & CreateProviderResult

CreateProviderResult was being referenced in docs but link was broken as the type isnt exported. This will ensure the types can be seen in the docs and fix the broken link.