### PR TITLE
chore: upgrade openzeppelin contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "private": true,
   "repository": "immutable/ts-immutable-sdk.git",
   "resolutions": {
-    "@biom3/design-tokens": "0.2.4-beta"
+    "@biom3/design-tokens": "0.2.4-beta",
+    "@openzeppelin/contracts": "3.4.2-solc-0.7"
   },
   "scripts": {
     "build": "NODE_OPTIONS=--max-old-space-size=14366 wsrun -y 4 -p @imtbl/sdk -p @imtbl/checkout-widgets-lib -e -r --serial build && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5429,13 +5429,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:3.4.1-solc-0.7-2":
-  version: 3.4.1-solc-0.7-2
-  resolution: "@openzeppelin/contracts@npm:3.4.1-solc-0.7-2"
-  checksum: 3608a4065f65946117caa543ef72477ce637bd5cc4f4853303b5f5b6c26516f8b50898ea3a8486e2877689cae81453ce22c72c8624c77c363c63f019b4086ffa
-  languageName: node
-  linkType: hard
-
 "@openzeppelin/contracts@npm:3.4.2-solc-0.7":
   version: 3.4.2-solc-0.7
   resolution: "@openzeppelin/contracts@npm:3.4.2-solc-0.7"


### PR DESCRIPTION
# Summary

Patch upgrade to the `@openzeppelin/contracts` package to resolve the following critical dependabot alerts: https://github.com/immutable/sample-passport-unity-game/security/dependabot/1 

# Customer Impact
SDK should report less security vulnerabilities.

## Security
- Patched security vulnerability with `@openzepplin/contracts` package.

# Things worth calling out

- Needed to add a `package.json` resolutions override for the open the openzeppelin contracts package since the UniSwap packages that used the OZ contracts package were already at the latest version.
- UniSwap packages are used by the internal Dex package.
- The resolutions section needs to be in the workspace root `package.json`.

# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
