### PR TITLE
Address casing reproduction

### DIFF
--- a/packages/checkout/sdk/src/smartCheckout/balanceCheck/balanceRequirement.ts
+++ b/packages/checkout/sdk/src/smartCheckout/balanceCheck/balanceRequirement.ts
@@ -90,7 +90,8 @@ export const getTokenBalanceRequirement = (
   // Get the requirements related balance
   if (itemRequirement.type === ItemType.ERC20) {
     itemBalanceResult = balances.find((balance) => {
-      return (balance as TokenBalance).token?.address === itemRequirement.contractAddress;
+      // return (balance as TokenBalance).token?.address === itemRequirement.contractAddress;
+      return (balance as TokenBalance).token?.address?.toLowerCase() === itemRequirement.contractAddress;
     });
   } else if (itemRequirement.type === ItemType.NATIVE) {
     itemBalanceResult = balances.find((balance) => {


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->
* passing in a lower case address to smart checkout (I was using `0x21b51ec6fb7654b7e59e832f9e9687f29df94fb8`) causes Smart Checkout to miscalculate
* if the ERC20 has a `decimal` value other than 18, it isn't able to get that value and defaults to 18
* caused by address casing mismatch
