### PR TITLE
WT-1972 Gas fee estimate drawer

### DIFF
--- a/packages/checkout/widgets-lib/src/resources/text/textConfig.ts
+++ b/packages/checkout/widgets-lib/src/resources/text/textConfig.ts
@@ -203,13 +203,6 @@ export const text = {
       header: {
         title: 'Move coins',
       },
-      xBridgeContent: {
-        title: 'How much would you like to move?',
-      },
-      xBridgeFees: {
-        title: 'Gas Fee',
-        fiatPricePrefix: '~ USD',
-      },
       content: {
         title: 'What would you like to move from Ethereum to Immutable zkEVM?',
         fiatPricePrefix: 'Approx USD',
@@ -458,6 +451,27 @@ export const text = {
       },
       submitButton: {
         text: 'Next',
+      },
+    },
+    [XBridgeWidgetViews.BRIDGE_FORM]: {
+      header: {
+        title: 'Move coins',
+      },
+      fees: {
+        title: 'Gas Fee',
+        fiatPricePrefix: '~ USD $',
+      },
+      content: {
+        title: 'How much would you like to move?',
+        fiatPricePrefix: 'Approx USD',
+        availableBalancePrefix: 'Available',
+      },
+      bridgeForm: {
+        from: {
+          inputPlaceholder: '0',
+          selectorTitle: 'What would you like to move?',
+        },
+        buttonText: 'Review',
       },
     },
     [XBridgeWidgetViews.BRIDGE_REVIEW]: {

--- a/packages/checkout/widgets-lib/src/widgets/x-bridge/components/BridgeForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/x-bridge/components/BridgeForm.tsx
@@ -12,10 +12,10 @@ import {
   useCallback, useContext, useEffect, useMemo, useRef, useState,
 } from 'react';
 import { BigNumber, utils } from 'ethers';
+import { FeesBreakdown } from 'components/FeesBreakdown/FeesBreakdown';
 import { amountInputValidation } from '../../../lib/validations/amountInputValidations';
 import { BridgeActions, XBridgeContext } from '../context/XBridgeContext';
 import { ViewActions, ViewContext } from '../../../context/view-context/ViewContext';
-import { BridgeWidgetViews } from '../../../context/view-context/BridgeViewContextTypes';
 import { CryptoFiatActions, CryptoFiatContext } from '../../../context/crypto-fiat-context/CryptoFiatContext';
 import { text } from '../../../resources/text/textConfig';
 import { TextInputForm } from '../../../components/FormComponents/TextInputForm/TextInputForm';
@@ -28,6 +28,7 @@ import {
   bridgeFormButtonContainerStyles,
   bridgeFormWrapperStyles,
   formInputsContainerStyles,
+  gasAmountHeadingStyles,
 } from './BridgeFormStyles';
 import { CoinSelectorOptionProps } from '../../../components/CoinSelector/CoinSelectorOption';
 import { useInterval } from '../../../lib/hooks/useInterval';
@@ -71,11 +72,10 @@ export function BridgeForm(props: BridgeFormProps) {
     isTokenBalancesLoading,
   } = props;
   const {
-    xBridgeContent,
-    xBridgeFees,
+    fees,
     content,
     bridgeForm,
-  } = text.views[BridgeWidgetViews.BRIDGE];
+  } = text.views[XBridgeWidgetViews.BRIDGE_FORM];
 
   // Form state
   const [formAmount, setFormAmount] = useState<string>(defaultAmount || '');
@@ -96,6 +96,7 @@ export function BridgeForm(props: BridgeFormProps) {
   const [gasFee, setGasFee] = useState<string>('');
   const [gasFeeFiatValue, setGasFeeFiatValue] = useState<string>('');
   const [tokensOptions, setTokensOptions] = useState<CoinSelectorOptionProps[]>([]);
+  const [showFeeBreakdown, setShowFeeBreakdown] = useState(false);
 
   // Not enough ETH to cover gas
   const [showNotEnoughGasDrawer, setShowNotEnoughGasDrawer] = useState(false);
@@ -108,6 +109,9 @@ export function BridgeForm(props: BridgeFormProps) {
     if (!address) return symbol.toLowerCase();
     return `${symbol.toLowerCase()}-${address.toLowerCase()}`;
   }, []);
+
+  const gasFiatAmount = `${fees.fiatPricePrefix} ${gasFeeFiatValue}`;
+  const gasTokenAmount = `${estimates?.gasFee.token?.symbol} ${tokenValueFormat(gasFee)}`;
 
   useEffect(() => {
     if (tokenBalances.length === 0) return;
@@ -396,7 +400,7 @@ export function BridgeForm(props: BridgeFormProps) {
           weight="regular"
           sx={{ paddingBottom: 'base.spacing.x4' }}
         >
-          {xBridgeContent.title}
+          {content.title}
         </Heading>
         {isTokenBalancesLoading && (
           <TokenSelectShimmer sx={formInputsContainerStyles} />
@@ -432,17 +436,34 @@ export function BridgeForm(props: BridgeFormProps) {
         {gasFee && (
           <Box sx={{ paddingY: 'base.spacing.x2' }}>
             <MenuItem emphasized size="small">
-              <MenuItem.Label>
-                {xBridgeFees.title}
+              <MenuItem.Label sx={gasAmountHeadingStyles}>
+                {fees.title}
               </MenuItem.Label>
               <MenuItem.PriceDisplay
-                fiatAmount={`${xBridgeFees.fiatPricePrefix} ${gasFeeFiatValue}`}
+                fiatAmount={`${fees.fiatPricePrefix} ${gasFeeFiatValue}`}
                 price={`${estimates?.gasFee.token?.symbol} ${tokenValueFormat(gasFee)}`}
+              />
+              <MenuItem.StatefulButtCon
+                icon="ChevronExpand"
+                onClick={() => setShowFeeBreakdown(true)}
               />
             </MenuItem>
           </Box>
         )}
       </Box>
+      <FeesBreakdown
+        totalFiatAmount={gasFiatAmount}
+        totalAmount={gasTokenAmount}
+        fees={[
+          {
+            label: text.drawers.feesBreakdown.fees.gas.label,
+            fiatAmount: gasFiatAmount,
+            amount: gasTokenAmount,
+          },
+        ]}
+        visible={showFeeBreakdown}
+        onCloseBottomSheet={() => setShowFeeBreakdown(false)}
+      />
       <Box sx={bridgeFormButtonContainerStyles}>
         <Button
           testId={`${testId}-button`}

--- a/packages/checkout/widgets-lib/src/widgets/x-bridge/components/BridgeFormStyles.ts
+++ b/packages/checkout/widgets-lib/src/widgets/x-bridge/components/BridgeFormStyles.ts
@@ -17,3 +17,8 @@ export const bridgeFormButtonContainerStyles = {
   paddingY: 'base.spacing.x6',
   paddingX: 'base.spacing.x4',
 };
+
+export const gasAmountHeadingStyles = {
+  marginBottom: 'base.spacing.x4',
+  color: 'base.color.text.secondary',
+};

--- a/packages/checkout/widgets-lib/src/widgets/x-bridge/components/BridgeReviewSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/x-bridge/components/BridgeReviewSummary.tsx
@@ -1,5 +1,5 @@
 import { text } from 'resources/text/textConfig';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { XBridgeWidgetViews } from 'context/view-context/XBridgeViewContextTypes';
 import {
   Body,
@@ -13,6 +13,7 @@ import { calculateCryptoToFiat } from 'lib/utils';
 import { Web3Provider } from '@ethersproject/providers';
 import { DEFAULT_QUOTE_REFRESH_INTERVAL } from 'lib';
 import { useInterval } from 'lib/hooks/useInterval';
+import { FeesBreakdown } from 'components/FeesBreakdown/FeesBreakdown';
 import { networkIconStyles } from './WalletNetworkButtonStyles';
 import {
   arrowIconStyles,
@@ -56,6 +57,7 @@ export function BridgeReviewSummary() {
   } = useContext(XBridgeContext);
 
   const { cryptoFiatState } = useContext(CryptoFiatContext);
+  const [showFeeBreakdown, setShowFeeBreakdown] = useState(false);
 
   const walletProviderName = (provider: Web3Provider | undefined) => (isPassportProvider(provider)
     ? WalletProviderName.PASSPORT
@@ -89,7 +91,11 @@ export function BridgeReviewSummary() {
 
   // Fetch on useInterval interval when available
   const gasEstimate = 'ETH 0.007984';
-  const gasFiatEstimate = '15.00';
+  const gasFiatEstimate = calculateCryptoToFiat(
+    '0.007984',
+    'ETH',
+    cryptoFiatState.conversions,
+  );
 
   return (
     <Box testId={testId} sx={bridgeReviewWrapperStyles}>
@@ -204,6 +210,10 @@ export function BridgeReviewSummary() {
           price={gasEstimate ?? '-'}
           fiatAmount={`${fiatPricePrefix}${gasFiatEstimate}`}
         />
+        <MenuItem.StatefulButtCon
+          icon="ChevronExpand"
+          onClick={() => setShowFeeBreakdown(true)}
+        />
       </MenuItem>
       <Box
         sx={{
@@ -222,6 +232,19 @@ export function BridgeReviewSummary() {
           {submitButton.buttonText}
         </Button>
       </Box>
+      <FeesBreakdown
+        totalFiatAmount={`${fiatPricePrefix}${gasFiatEstimate}`}
+        totalAmount={gasEstimate}
+        fees={[
+          {
+            label: text.drawers.feesBreakdown.fees.gas.label,
+            fiatAmount: `${fiatPricePrefix}${gasFiatEstimate}`,
+            amount: gasEstimate,
+          },
+        ]}
+        visible={showFeeBreakdown}
+        onCloseBottomSheet={() => setShowFeeBreakdown(false)}
+      />
     </Box>
   );
 }

--- a/packages/checkout/widgets-lib/src/widgets/x-bridge/views/Bridge.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/x-bridge/views/Bridge.tsx
@@ -5,13 +5,13 @@ import {
   useState,
 } from 'react';
 import { TokenFilterTypes } from '@imtbl/checkout-sdk';
+import { XBridgeWidgetViews } from 'context/view-context/XBridgeViewContextTypes';
 import { sendBridgeWidgetCloseEvent } from '../BridgeWidgetEvents';
 import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
 import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
 import { FooterLogo } from '../../../components/Footer/FooterLogo';
 import { BridgeForm } from '../components/BridgeForm';
 import { text } from '../../../resources/text/textConfig';
-import { BridgeWidgetViews } from '../../../context/view-context/BridgeViewContextTypes';
 import { BridgeActions, XBridgeContext } from '../context/XBridgeContext';
 import { useInterval } from '../../../lib/hooks/useInterval';
 import { EventTargetContext } from '../../../context/event-target-context/EventTargetContext';
@@ -25,7 +25,7 @@ export interface BridgeProps {
 }
 
 export function Bridge({ amount, fromContractAddress }: BridgeProps) {
-  const { header } = text.views[BridgeWidgetViews.BRIDGE];
+  const { header } = text.views[XBridgeWidgetViews.BRIDGE_FORM];
   const { bridgeState, bridgeDispatch } = useContext(XBridgeContext);
   const { checkout, web3Provider } = bridgeState;
   const { eventTargetState: { eventTarget } } = useContext(EventTargetContext);


### PR DESCRIPTION
# Summary

Adds gas fee estimate drawers to the fee estimate MenuItem

Note that the design has the chevron button on left hand side. This is not currently possible in biome, but will be possible with accordions once the chevron buttons on accordions can be overriden. Accordion components can be designed to look like MenuItem components.


https://github.com/immutable/ts-immutable-sdk/assets/122326421/4d4d9bfb-15e7-4722-a32c-3cb9c7a2563b

https://github.com/immutable/ts-immutable-sdk/assets/122326421/9a635878-c460-41f2-a751-57a1980ca960


