### PR TITLE
fix: update publish workflow, wait for tag to write, notify slack on GH release failure

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Pre Release Step
         if: contains(github.event.inputs.release_type, 'alpha')
         id: pre_release
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.PLATFORM_SA_NPM_TOKEN }}
           access: public


### PR DESCRIPTION
# Summary

Publish to NPM workflow failed at the step trying to create a GitHub release from a tag created during the workflow. The `gh` CLI returned a `404` error, probably cause it could not find the recently pushed tag.

Confirmed the tag was pushed after the workflow ran, but the GitHub release was not created, so it appears the GitHub read API hadn't updated fast enough for the GitHub release step to pick up the new tag. The PR adds a wait time between pushing the tag and running the GitHub release step.

Update the `Publish to NPM` workflow:
- Add sleep/wait after pushing tags to GitHub to help prevent tag not found error when trying to create a GitHub release.
- Update Slack failure notification to include the GitHub release step.

# Customer Impact

None. Update only impacts the internal use workflow to publish the SDK to NPM.

<!-- Remove the H2 sections as required -->

## Changed
- Publish to NPM workflow behaviour.

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
