### PR TITLE
fix: add back GH_TOKEN env var to Publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,7 @@ jobs:
     name: Publish Workflow
     runs-on: ubuntu-latest-4-cores
     env:
+      GH_TOKEN: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
       NODE_OPTIONS: --max-old-space-size=14366
       SDK_PUBLISH_SLACK_WEBHOOK: ${{ secrets.SDK_PUBLISH_SLACK_WEBHOOK }}
     steps:
@@ -124,10 +125,10 @@ jobs:
         if: contains(github.event.inputs.release_type, 'release')
         run: yarn release --ci --no-increment -c .release-it.json $( ${{ github.event.inputs.dry_run }} && echo "--dry-run" || echo "") --github.tokenRef=${{ secrets.RELEASE_TOKEN }}
 
-      # Wait for 60 seconds to make sure the tag is available on GitHub
+      # Wait for 30 seconds to make sure the tag is available on GitHub
       - uses: GuillaumeFalourd/wait-sleep-action@v1
         with:
-          time: '60'
+          time: '30'
 
       - name: Create GitHub Release
         id: gh_release


### PR DESCRIPTION
# Summary

Adding new workflow token to fix the Publish to NPM workflow.

# Customer Impact
None.

<!-- Remove the H2 sections as required -->


## Fixed
- Missing token in Publish to NPM workflow.


# Things worth calling out
- Token was removed during the org secrets reshuffle.


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
