### PR TITLE
chore: DX-2478 swap NPM_TOKEN from org level token to repo level

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -110,7 +110,7 @@ jobs:
         id: pre_release
         uses: JS-DevTools/npm-publish@v3
         with:
-          token: ${{ secrets.PLATFORM_SA_NPM_TOKEN }}
+          token: ${{ secrets.TS_IMMUTABLE_SDK_NPM_TOKEN }}
           access: public
           package: ./sdk/package.json
           tag: ${{ contains(github.event.inputs.release_type, 'alpha') && 'alpha' }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Authenticate NPM
         if: contains(github.event.inputs.release_type, 'release')
-        run: npm config set //registry.npmjs.org/:_authToken ${{ secrets.PLATFORM_SA_NPM_TOKEN }}
+        run: npm config set //registry.npmjs.org/:_authToken ${{ secrets.TS_IMMUTABLE_SDK_NPM_TOKEN }}
 
       - name: Release
         id: npm_release


### PR DESCRIPTION
# Summary
swap the NPM TOKEN from org level secret to be at repo level to prepare for this repo to open source


# Customer Impact
none

## Changed
usage of NPM_TOKEN switched from org level to repo level

