### PR TITLE
ID-1186: Adjust Passport transaction confirmation window height

### DIFF
--- a/packages/passport/sdk/src/confirmation/confirmation.ts
+++ b/packages/passport/sdk/src/confirmation/confirmation.ts
@@ -8,7 +8,7 @@ import { openPopupCenter } from './popup';
 import { PassportConfiguration } from '../config';
 
 const CONFIRMATION_WINDOW_TITLE = 'Confirm this transaction';
-const CONFIRMATION_WINDOW_HEIGHT = 380;
+const CONFIRMATION_WINDOW_HEIGHT = 720;
 const CONFIRMATION_WINDOW_WIDTH = 480;
 const CONFIRMATION_WINDOW_CLOSED_POLLING_DURATION = 1000;
 


### PR DESCRIPTION
# Summary
Adjusting the default IMX transaction screen height in order to accommodate the new layout with the cancel button

## Changed
IMX transaction screen default height: 380 > 720

# Things worth calling out
Accompanies https://github.com/immutable/imx-passport-ts/pull/112

# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
