### PR TITLE
WT-1946 - fix balances error due to change of network

### DIFF
--- a/packages/checkout/widgets-lib/src/lib/balance.ts
+++ b/packages/checkout/widgets-lib/src/lib/balance.ts
@@ -30,7 +30,7 @@ export const getAllowedBalances = async ({
   chainId,
   allowZero = false,
   retryPolicy = DEFAULT_BALANCE_RETRY_POLICY,
-}: GetAllowedBalancesParamsType):Promise<GetAllowedBalancesResultType> => {
+}: GetAllowedBalancesParamsType): Promise<GetAllowedBalancesResultType | undefined> => {
   const currentChainId = chainId || (await checkout.getNetworkInfo({ provider })).chainId;
 
   const walletAddress = await provider.getSigner().getAddress();
@@ -43,6 +43,17 @@ export const getAllowedBalances = async ({
     { ...retryPolicy },
   );
 
+  // Why is this needed?
+  // getAllowedBalances has a retry logic, if the user changes network
+  // the retry holds the ref to the old provider causing an error due
+  // to the mismatch of chain id between what's held by the retry and
+  // what's currently set in the latest provider.
+  // Due to this error, the POLICY automatically returns undefined
+  // and this is backfilled with an empty object making the application
+  // believe that the wallet has no tokens.
+  // This is now handled in the Bridge and Swap widget.
+  if (tokenBalances === undefined) return undefined;
+
   const allowList = await checkout.getTokenAllowList({
     chainId: currentChainId,
     type: allowTokenListType,
@@ -51,7 +62,7 @@ export const getAllowedBalances = async ({
   const tokensAddresses = new Map();
   allowList.tokens.forEach((token) => tokensAddresses.set(token.address || NATIVE, true));
 
-  const allowedBalances = tokenBalances?.balances.filter((balance) => {
+  const allowedBalances = tokenBalances.balances.filter((balance) => {
     // Balance is <= 0 and it is not allow to have zeros
     if (balance.balance.lte(0) && !allowZero) return false;
 

--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
@@ -49,10 +49,7 @@ import { ApproveERC20Onboarding } from './views/ApproveERC20Onboarding';
 import { TopUpView } from '../../views/top-up/TopUpView';
 import { ConnectLoaderContext } from '../../context/connect-loader-context/ConnectLoaderContext';
 import { EventTargetContext } from '../../context/event-target-context/EventTargetContext';
-import {
-  GetAllowedBalancesResultType,
-  getAllowedBalances,
-} from '../../lib/balance';
+import { getAllowedBalances } from '../../lib/balance';
 import { UserJourney, useAnalytics } from '../../context/analytics-provider/SegmentAnalyticsProvider';
 
 export type SwapWidgetInputs = SwapWidgetParams & {
@@ -129,16 +126,16 @@ export function SwapWidget({
     if (!checkout) throw new Error('loadBalances: missing checkout');
     if (!provider) throw new Error('loadBalances: missing provider');
 
-    let tokensAndBalances: GetAllowedBalancesResultType = {
-      allowList: { tokens: [] },
-      allowedBalances: [],
-    };
     try {
-      tokensAndBalances = await getAllowedBalances({
+      const tokensAndBalances = await getAllowedBalances({
         checkout,
         provider,
         allowTokenListType: TokenFilterTypes.SWAP,
       });
+
+      // Why? Check getAllowedBalances
+      if (tokensAndBalances === undefined) return false;
+
       swapDispatch({
         payload: {
           type: SwapActions.SET_ALLOWED_TOKENS,

--- a/packages/checkout/widgets-lib/src/widgets/x-bridge/views/Bridge.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/x-bridge/views/Bridge.tsx
@@ -48,10 +48,20 @@ export function Bridge({ amount, contractAddress }: BridgeProps) {
         retryPolicy: { retryIntervalMs: 0, retries: 0 },
       });
 
+      // Why? Check getAllowedBalances
+      if (tokensAndBalances === undefined) return;
+
       bridgeDispatch({
         payload: {
           type: BridgeActions.SET_TOKEN_BALANCES,
           tokenBalances: tokensAndBalances.allowedBalances,
+        },
+      });
+
+      bridgeDispatch({
+        payload: {
+          type: BridgeActions.SET_ALLOWED_TOKENS,
+          allowedTokens: tokensAndBalances.allowList.tokens,
         },
       });
 


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

Due to an error in the retry logic when the user changes network; the widget, at time, believes that there are no balances and therefore it fires a no enough IMX screen this also affected the bridge widget.

Additional follow up bug ticket https://immutable.atlassian.net/browse/WT-1948

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->


<!-- Remove the H2 sections as required -->
## Added 
<!-- Section for new features. -->


## Changed
<!-- Section for changes in existing functionality. -->


## Deprecated
<!-- Section for soon-to-be removed features. -->


## Removed
<!-- Section for now removed features. -->


## Fixed
<!-- Section for any bug fixes. -->


## Security
<!-- Section in case of vulnerabilities. -->




# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
