### PR TITLE
WT-1996 Correctly handle token decimals when getting unsigned transactions from bridge

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/x-bridge/components/BridgeReviewSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/x-bridge/components/BridgeReviewSummary.tsx
@@ -114,7 +114,7 @@ export function BridgeReviewSummary() {
       tokenBridge!.getUnsignedApproveBridgeTx({
         senderAddress: fromAddress,
         token: token?.address,
-        amount: utils.parseUnits(amount, DEFAULT_TOKEN_DECIMALS),
+        amount: utils.parseUnits(amount, token.decimals),
         sourceChainId: from?.network.toString(),
         destinationChainId: to?.network.toString(),
       }),
@@ -122,7 +122,7 @@ export function BridgeReviewSummary() {
         senderAddress: fromAddress,
         recipientAddress: toAddress,
         token: token?.address,
-        amount: utils.parseUnits(amount, DEFAULT_TOKEN_DECIMALS),
+        amount: utils.parseUnits(amount, token.decimals),
         sourceChainId: from?.network.toString(),
         destinationChainId: to?.network.toString(),
         gasMultiplier: 1.1,


### PR DESCRIPTION
# Summary

When getting the unsigned txns for the bridge we were sending the default token decimals of 18. We should use the decimals that come from the token to handle all token decimals. This fixes the issue when trying to bridge across the 6 decimal usdc contract.