### PR TITLE
WT-1971 - allow get balances without connected provider

### DIFF
--- a/packages/checkout/sdk/src/balances/balances.test.ts
+++ b/packages/checkout/sdk/src/balances/balances.test.ts
@@ -203,7 +203,7 @@ describe('balances', () => {
     });
   });
 
-  describe.only('getAllBalances()', () => {
+  describe('getAllBalances()', () => {
     let mockProviderForAllBalances: jest.Mock;
     let balanceOfMock: jest.Mock;
     let decimalsMock: jest.Mock;

--- a/packages/checkout/sdk/src/balances/balances.test.ts
+++ b/packages/checkout/sdk/src/balances/balances.test.ts
@@ -203,7 +203,7 @@ describe('balances', () => {
     });
   });
 
-  describe('getAllBalances()', () => {
+  describe.only('getAllBalances()', () => {
     let mockProviderForAllBalances: jest.Mock;
     let balanceOfMock: jest.Mock;
     let decimalsMock: jest.Mock;
@@ -284,6 +284,50 @@ describe('balances', () => {
         name: nameMock,
         symbol: symbolMock,
       });
+    });
+
+    it('should fail if no wallet address or provider are given', async () => {
+      let message;
+      try {
+        await getAllBalances(
+          {
+            remote: {
+              getTokensConfig: () => ({
+                blockscout: false,
+              }),
+            },
+            networkMap: testCheckoutConfig.networkMap,
+          } as unknown as CheckoutConfiguration,
+          undefined,
+          undefined,
+          ChainId.ETHEREUM,
+        );
+      } catch (e: any) {
+        message = e.message;
+      }
+      expect(message).toContain('both walletAddress and provider as missing');
+    });
+
+    it('should fail if no provider is given and indexer is disabled', async () => {
+      let message;
+      try {
+        await getAllBalances(
+          {
+            remote: {
+              getTokensConfig: () => ({
+                blockscout: false,
+              }),
+            },
+            networkMap: testCheckoutConfig.networkMap,
+          } as unknown as CheckoutConfiguration,
+          undefined,
+          'wallet-address',
+          ChainId.ETHEREUM,
+        );
+      } catch (e: any) {
+        message = e.message;
+      }
+      expect(message).toContain('indexer is disabled for this chain, you must provide a provider');
     });
 
     it('should call getBalance and getERC20Balance functions with native and ERC20 tokens', async () => {

--- a/packages/checkout/sdk/src/balances/balances.test.ts
+++ b/packages/checkout/sdk/src/balances/balances.test.ts
@@ -305,7 +305,7 @@ describe('balances', () => {
       } catch (e: any) {
         message = e.message;
       }
-      expect(message).toContain('both walletAddress and provider as missing');
+      expect(message).toContain('both walletAddress and provider are missing');
     });
 
     it('should fail if no provider is given and indexer is disabled', async () => {

--- a/packages/checkout/sdk/src/balances/balances.ts
+++ b/packages/checkout/sdk/src/balances/balances.ts
@@ -244,7 +244,7 @@ export const getAllBalances = async (
 ): Promise<GetAllBalancesResult> => {
   if (!walletAddress && !web3Provider) {
     throw new CheckoutError(
-      'both walletAddress and provider as missing. At least one must be provided.',
+      'both walletAddress and provider are missing. At least one must be provided.',
       CheckoutErrorType.MISSING_PARAMS,
     );
   }

--- a/packages/checkout/sdk/src/balances/balances.ts
+++ b/packages/checkout/sdk/src/balances/balances.ts
@@ -238,12 +238,16 @@ export const getBalances = async (
 
 export const getAllBalances = async (
   config: CheckoutConfiguration,
-  web3Provider: Web3Provider,
-  walletAddress: string,
-  chainId?: ChainId,
+  web3Provider: Web3Provider | undefined,
+  walletAddress: string | undefined,
+  chainId: ChainId,
 ): Promise<GetAllBalancesResult> => {
-  // eslint-disable-next-line no-param-reassign
-  chainId ||= await web3Provider.getSigner().getChainId();
+  if (!walletAddress && !web3Provider) {
+    throw new CheckoutError(
+      'both walletAddress and provider as missing. At least one must be provided.',
+      CheckoutErrorType.MISSING_PARAMS,
+    );
+  }
 
   const { tokens } = await getTokenAllowList(
     config,
@@ -264,6 +268,7 @@ export const getAllBalances = async (
     console.error(err);
   }
 
+  let address = walletAddress;
   if (flag && Blockscout.isChainSupported(chainId)) {
     // This is a hack because the widgets are still using the tokens symbol
     // to drive the conversions. If we remove all the token symbols from e.g. zkevm
@@ -271,19 +276,28 @@ export const getAllBalances = async (
     // Please remove this hack once https://immutable.atlassian.net/browse/WT-1710
     // is done.
     const isL1Chain = getL1ChainId(config) === chainId;
+    if (!address) address = await web3Provider?.getSigner().getAddress();
     return await measureAsyncExecution<GetAllBalancesResult>(
       config,
       `Time to fetch balances using blockscout for ${chainId}`,
-      getIndexerBalance(walletAddress, chainId, isL1Chain ? tokens : undefined),
+      getIndexerBalance(address!, chainId, isL1Chain ? tokens : undefined),
+    );
+  }
+
+  if (!web3Provider) {
+    throw new CheckoutError(
+      'indexer is disabled for this chain, you must provide a provider.',
+      CheckoutErrorType.MISSING_PARAMS,
     );
   }
 
   // This fallback to use ERC20s calls which is a best effort solution
   // Fails in fetching data from the RCP calls might result in some
   // missing data.
+  address ||= await web3Provider.getSigner().getAddress();
   return await measureAsyncExecution<GetBalancesResult>(
     config,
     `Time to fetch balances using RPC for ${chainId}`,
-    getBalances(config, web3Provider, walletAddress, tokens),
+    getBalances(config, web3Provider, address, tokens),
   );
 };

--- a/packages/checkout/sdk/src/errors/checkoutError.ts
+++ b/packages/checkout/sdk/src/errors/checkoutError.ts
@@ -2,6 +2,7 @@
  * Enum representing different types of errors that can occur during the checkout process.
  */
 export enum CheckoutErrorType {
+  MISSING_PARAMS = 'MISSING_PARAMS',
   WEB3_PROVIDER_ERROR = 'WEB3_PROVIDER_ERROR',
   PROVIDER_ERROR = 'PROVIDER_ERROR',
   DEFAULT_PROVIDER_ERROR = 'DEFAULT_PROVIDER_ERROR',

--- a/packages/checkout/sdk/src/sdk.ts
+++ b/packages/checkout/sdk/src/sdk.ts
@@ -251,14 +251,9 @@ export class Checkout {
   public async getAllBalances(
     params: GetAllBalancesParams,
   ): Promise<GetAllBalancesResult> {
-    const web3Provider = await provider.validateProvider(
-      this.config,
-      params.provider,
-    );
-
     return balances.getAllBalances(
       this.config,
-      web3Provider,
+      params.provider,
       params.walletAddress,
       params.chainId,
     );

--- a/packages/checkout/sdk/src/types/balances.ts
+++ b/packages/checkout/sdk/src/types/balances.ts
@@ -29,13 +29,13 @@ export interface GetBalanceResult {
 
 /**
  * Interface representing the parameters for {@link Checkout.getAllBalances}.
- * @property {Web3Provider} provider - The provider used to get the balances.
- * @property {string} walletAddress - The wallet address.
+ * @property {Web3Provider} provider - The provider used to get the balances, it is a required parameter if no walletAddress is provided.
+ * @property {string} walletAddress - The wallet address, , it is a required parameter if no provider is provided.
  * @property {ChainId} chainId - The ID of the network.
  */
 export interface GetAllBalancesParams {
-  provider: Web3Provider;
-  walletAddress: string;
+  provider?: Web3Provider;
+  walletAddress?: string;
   chainId: ChainId;
 }
 

--- a/packages/checkout/sdk/src/types/balances.ts
+++ b/packages/checkout/sdk/src/types/balances.ts
@@ -30,7 +30,7 @@ export interface GetBalanceResult {
 /**
  * Interface representing the parameters for {@link Checkout.getAllBalances}.
  * @property {Web3Provider} provider - The provider used to get the balances, it is a required parameter if no walletAddress is provided.
- * @property {string} walletAddress - The wallet address, , it is a required parameter if no provider is provided.
+ * @property {string} walletAddress - The wallet address, it is a required parameter if no provider is provided.
  * @property {ChainId} chainId - The ID of the network.
  */
 export interface GetAllBalancesParams {


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

<img width="1223" alt="Screenshot 2023-12-19 at 11 29 45 am" src="https://github.com/immutable/ts-immutable-sdk/assets/4301501/746bf386-5edc-4b67-9214-3184177e1488">

Allow a user to use `getAllBalances` without a connected `web3provider` as long as a walletAddress is provided.

A `web3provider` is a must if the indexer is disabled.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->


<!-- Remove the H2 sections as required -->
## Added 
<!-- Section for new features. -->


## Changed
<!-- Section for changes in existing functionality. -->


## Deprecated
<!-- Section for soon-to-be removed features. -->


## Removed
<!-- Section for now removed features. -->


## Fixed
<!-- Section for any bug fixes. -->


## Security
<!-- Section in case of vulnerabilities. -->




# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
