### PR TITLE
WT-1980 Update smart checkout fee types

### DIFF
--- a/packages/checkout/sdk/src/index.ts
+++ b/packages/checkout/sdk/src/index.ts
@@ -18,6 +18,7 @@ export {
   ChainSlug,
   CheckoutStatus,
   ExchangeType,
+  FeeType,
   FundingStepType,
   GasEstimateType,
   GasTokenType,

--- a/packages/checkout/sdk/src/smartCheckout/routing/bridge/bridgeRoute.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/bridge/bridgeRoute.test.ts
@@ -9,6 +9,7 @@ import {
 import { CheckoutConfiguration } from '../../../config';
 import {
   ChainId,
+  FeeType,
   FundingStepType,
   ItemType,
 } from '../../../types';
@@ -130,7 +131,8 @@ describe('bridgeRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: utils.formatUnits(BigNumber.from(0), DEFAULT_TOKEN_DECIMALS),
               token: {
@@ -139,7 +141,8 @@ describe('bridgeRoute', () => {
                 decimals: 18,
               },
             },
-            bridgeGasFees: {
+            bridgeGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(2),
               formattedAmount: utils.formatUnits(BigNumber.from(2), DEFAULT_TOKEN_DECIMALS),
               token: {
@@ -150,6 +153,7 @@ describe('bridgeRoute', () => {
             },
             bridgeFees: [
               {
+                type: FeeType.BRIDGE_FEE,
                 amount: BigNumber.from(3),
                 formattedAmount: utils.formatUnits(BigNumber.from(3), DEFAULT_TOKEN_DECIMALS),
                 token: {
@@ -159,6 +163,7 @@ describe('bridgeRoute', () => {
                 },
               },
               {
+                type: FeeType.IMMUTABLE_FEE,
                 amount: BigNumber.from(4),
                 formattedAmount: utils.formatUnits(BigNumber.from(4), DEFAULT_TOKEN_DECIMALS),
                 token: {
@@ -221,7 +226,8 @@ describe('bridgeRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: utils.formatUnits(BigNumber.from(0), DEFAULT_TOKEN_DECIMALS),
               token: {
@@ -230,7 +236,8 @@ describe('bridgeRoute', () => {
                 decimals: 18,
               },
             },
-            bridgeGasFees: {
+            bridgeGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(2),
               formattedAmount: utils.formatUnits(BigNumber.from(2), DEFAULT_TOKEN_DECIMALS),
               token: {
@@ -241,6 +248,7 @@ describe('bridgeRoute', () => {
             },
             bridgeFees: [
               {
+                type: FeeType.BRIDGE_FEE,
                 amount: BigNumber.from(3),
                 formattedAmount: utils.formatUnits(BigNumber.from(3), DEFAULT_TOKEN_DECIMALS),
                 token: {
@@ -250,6 +258,7 @@ describe('bridgeRoute', () => {
                 },
               },
               {
+                type: FeeType.IMMUTABLE_FEE,
                 amount: BigNumber.from(4),
                 formattedAmount: utils.formatUnits(BigNumber.from(4), DEFAULT_TOKEN_DECIMALS),
                 token: {
@@ -432,7 +441,8 @@ describe('bridgeRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(1),
               formattedAmount: utils.formatUnits(BigNumber.from(1), DEFAULT_TOKEN_DECIMALS),
               token: {
@@ -441,7 +451,8 @@ describe('bridgeRoute', () => {
                 decimals: 18,
               },
             },
-            bridgeGasFees: {
+            bridgeGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(2),
               formattedAmount: utils.formatUnits(BigNumber.from(2), DEFAULT_TOKEN_DECIMALS),
               token: {
@@ -452,6 +463,7 @@ describe('bridgeRoute', () => {
             },
             bridgeFees: [
               {
+                type: FeeType.BRIDGE_FEE,
                 amount: BigNumber.from(3),
                 formattedAmount: utils.formatUnits(BigNumber.from(3), DEFAULT_TOKEN_DECIMALS),
                 token: {
@@ -461,6 +473,7 @@ describe('bridgeRoute', () => {
                 },
               },
               {
+                type: FeeType.IMMUTABLE_FEE,
                 amount: BigNumber.from(4),
                 formattedAmount: utils.formatUnits(BigNumber.from(4), DEFAULT_TOKEN_DECIMALS),
                 token: {
@@ -533,7 +546,8 @@ describe('bridgeRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(1),
               formattedAmount: utils.formatUnits(BigNumber.from(1), DEFAULT_TOKEN_DECIMALS),
               token: {
@@ -542,7 +556,8 @@ describe('bridgeRoute', () => {
                 decimals: 18,
               },
             },
-            bridgeGasFees: {
+            bridgeGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(2),
               formattedAmount: utils.formatUnits(BigNumber.from(2), DEFAULT_TOKEN_DECIMALS),
               token: {
@@ -553,6 +568,7 @@ describe('bridgeRoute', () => {
             },
             bridgeFees: [
               {
+                type: FeeType.BRIDGE_FEE,
                 amount: BigNumber.from(3),
                 formattedAmount: utils.formatUnits(BigNumber.from(3), DEFAULT_TOKEN_DECIMALS),
                 token: {
@@ -562,6 +578,7 @@ describe('bridgeRoute', () => {
                 },
               },
               {
+                type: FeeType.IMMUTABLE_FEE,
                 amount: BigNumber.from(4),
                 formattedAmount: utils.formatUnits(BigNumber.from(4), DEFAULT_TOKEN_DECIMALS),
                 token: {

--- a/packages/checkout/sdk/src/smartCheckout/routing/bridge/bridgeRoute.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/bridge/bridgeRoute.ts
@@ -8,6 +8,7 @@ import {
   AvailableRoutingOptions,
   BridgeFees,
   TokenInfo,
+  FeeType,
 } from '../../../types';
 import { CheckoutConfiguration, getL1ChainId, getL2ChainId } from '../../../config';
 import {
@@ -33,36 +34,47 @@ export const hasSufficientL1Eth = (
 };
 
 const constructFees = (
-  bridgeGasFees: BigNumber,
+  bridgeGasFee: BigNumber,
   bridgeFee: BigNumber,
   imtblFee: BigNumber,
-  approvalGasFees: BigNumber,
+  approvalGasFee: BigNumber,
   token?: TokenInfo,
 ): BridgeFees => {
   const bridgeFeeDecimals = token?.decimals ?? DEFAULT_TOKEN_DECIMALS;
+  const bridgeFees = [];
+
+  if (bridgeFee.gt(0)) {
+    bridgeFees.push({
+      type: FeeType.BRIDGE_FEE,
+      amount: bridgeFee,
+      formattedAmount: utils.formatUnits(bridgeFee, bridgeFeeDecimals),
+      token,
+    });
+  }
+
+  if (imtblFee.gt(0)) {
+    bridgeFees.push({
+      type: FeeType.IMMUTABLE_FEE,
+      amount: imtblFee,
+      formattedAmount: utils.formatUnits(imtblFee, bridgeFeeDecimals),
+      token,
+    });
+  }
+
   return {
-    approvalGasFees: {
-      amount: approvalGasFees,
-      formattedAmount: utils.formatUnits(approvalGasFees, DEFAULT_TOKEN_DECIMALS),
+    approvalGasFee: {
+      type: FeeType.GAS,
+      amount: approvalGasFee,
+      formattedAmount: utils.formatUnits(approvalGasFee, DEFAULT_TOKEN_DECIMALS),
       token,
     },
-    bridgeGasFees: {
-      amount: bridgeGasFees,
-      formattedAmount: utils.formatUnits(bridgeGasFees, DEFAULT_TOKEN_DECIMALS),
+    bridgeGasFee: {
+      type: FeeType.GAS,
+      amount: bridgeGasFee,
+      formattedAmount: utils.formatUnits(bridgeGasFee, DEFAULT_TOKEN_DECIMALS),
       token,
     },
-    bridgeFees: [
-      {
-        amount: bridgeFee,
-        formattedAmount: utils.formatUnits(bridgeFee, bridgeFeeDecimals),
-        token,
-      },
-      {
-        amount: imtblFee,
-        formattedAmount: utils.formatUnits(imtblFee, bridgeFeeDecimals),
-        token,
-      },
-    ],
+    bridgeFees,
   };
 };
 

--- a/packages/checkout/sdk/src/smartCheckout/routing/bridgeAndSwap/bridgeAndSwapRoute.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/bridgeAndSwap/bridgeAndSwapRoute.test.ts
@@ -5,6 +5,7 @@ import { Quote } from '@imtbl/dex-sdk';
 import { CheckoutConfiguration } from '../../../config';
 import {
   ChainId,
+  FeeType,
   FundingStepType,
   ItemType,
   TokenInfo,
@@ -213,15 +214,18 @@ describe('bridgeAndSwapRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             },
-            bridgeGasFees: {
+            bridgeGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             },
             bridgeFees: [{
+              type: FeeType.BRIDGE_FEE,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             }],
@@ -249,15 +253,18 @@ describe('bridgeAndSwapRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             },
-            bridgeGasFees: {
+            bridgeGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             },
             bridgeFees: [{
+              type: FeeType.BRIDGE_FEE,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             }],
@@ -287,15 +294,18 @@ describe('bridgeAndSwapRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             },
-            swapGasFees: {
+            swapGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             },
             swapFees: [{
+              type: FeeType.SWAP_FEE,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             }],
@@ -322,15 +332,18 @@ describe('bridgeAndSwapRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             },
-            swapGasFees: {
+            swapGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             },
             swapFees: [{
+              type: FeeType.SWAP_FEE,
               amount: BigNumber.from(0),
               formattedAmount: '0',
             }],
@@ -447,15 +460,18 @@ describe('bridgeAndSwapRoute', () => {
               },
             },
             fees: {
-              approvalGasFees: {
+              approvalGasFee: {
+                type: FeeType.GAS,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               },
-              bridgeGasFees: {
+              bridgeGasFee: {
+                type: FeeType.GAS,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               },
               bridgeFees: [{
+                type: FeeType.BRIDGE_FEE,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               }],
@@ -482,15 +498,18 @@ describe('bridgeAndSwapRoute', () => {
               },
             },
             fees: {
-              approvalGasFees: {
+              approvalGasFee: {
+                type: FeeType.GAS,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               },
-              swapGasFees: {
+              swapGasFee: {
+                type: FeeType.GAS,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               },
               swapFees: [{
+                type: FeeType.SWAP_FEE,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               }],
@@ -518,15 +537,18 @@ describe('bridgeAndSwapRoute', () => {
               },
             },
             fees: {
-              approvalGasFees: {
+              approvalGasFee: {
+                type: FeeType.GAS,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               },
-              bridgeGasFees: {
+              bridgeGasFee: {
+                type: FeeType.GAS,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               },
               bridgeFees: [{
+                type: FeeType.BRIDGE_FEE,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               }],
@@ -553,15 +575,18 @@ describe('bridgeAndSwapRoute', () => {
               },
             },
             fees: {
-              approvalGasFees: {
+              approvalGasFee: {
+                type: FeeType.GAS,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               },
-              swapGasFees: {
+              swapGasFee: {
+                type: FeeType.GAS,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               },
               swapFees: [{
+                type: FeeType.SWAP_FEE,
                 amount: BigNumber.from(0),
                 formattedAmount: '0',
               }],

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.test.ts
@@ -14,6 +14,7 @@ import {
 import { bridgeRoute } from './bridge/bridgeRoute';
 import {
   ChainId,
+  FeeType,
   FundingStepType,
   ItemType,
   RoutingOutcomeType,
@@ -182,15 +183,18 @@ describe('routingCalculator', () => {
         },
       },
       fees: {
-        approvalGasFees: {
+        approvalGasFee: {
+          type: FeeType.GAS,
           amount: BigNumber.from(0),
           formattedAmount: '0',
         },
-        bridgeGasFees: {
+        bridgeGasFee: {
+          type: FeeType.GAS,
           amount: BigNumber.from(0),
           formattedAmount: '0',
         },
         bridgeFees: [{
+          type: FeeType.BRIDGE_FEE,
           amount: BigNumber.from(0),
           formattedAmount: '0',
         }],
@@ -803,15 +807,18 @@ describe('routingCalculator', () => {
         },
       },
       fees: {
-        approvalGasFees: {
+        approvalGasFee: {
+          type: FeeType.GAS,
           amount: BigNumber.from(0),
           formattedAmount: '0',
         },
-        bridgeGasFees: {
+        bridgeGasFee: {
+          type: FeeType.GAS,
           amount: BigNumber.from(0),
           formattedAmount: '0',
         },
         bridgeFees: [{
+          type: FeeType.BRIDGE_FEE,
           amount: BigNumber.from(0),
           formattedAmount: '0',
         }],

--- a/packages/checkout/sdk/src/smartCheckout/routing/swap/swapRoute.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/swap/swapRoute.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../types';
 import {
   ChainId,
+  FeeType,
   FundingStepType,
   ItemType,
 } from '../../../types';
@@ -247,7 +248,8 @@ describe('swapRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(1),
               formattedAmount: utils.formatUnits(BigNumber.from(1), 18),
               token: {
@@ -256,7 +258,8 @@ describe('swapRoute', () => {
                 symbol: 'IMX',
               },
             },
-            swapGasFees: {
+            swapGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(2),
               formattedAmount: utils.formatUnits(BigNumber.from(2), 18),
               token: {
@@ -266,6 +269,7 @@ describe('swapRoute', () => {
               },
             },
             swapFees: [{
+              type: FeeType.SWAP_FEE,
               amount: BigNumber.from(3),
               formattedAmount: utils.formatUnits(BigNumber.from(3), 18),
               token: {
@@ -364,7 +368,8 @@ describe('swapRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(1),
               formattedAmount: utils.formatUnits(BigNumber.from(1), 18),
               token: {
@@ -373,7 +378,8 @@ describe('swapRoute', () => {
                 symbol: 'IMX',
               },
             },
-            swapGasFees: {
+            swapGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(2),
               formattedAmount: utils.formatUnits(BigNumber.from(2), 18),
               token: {
@@ -383,6 +389,7 @@ describe('swapRoute', () => {
               },
             },
             swapFees: [{
+              type: FeeType.SWAP_FEE,
               amount: BigNumber.from(3),
               formattedAmount: utils.formatUnits(BigNumber.from(3), 18),
               token: {
@@ -503,7 +510,8 @@ describe('swapRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(1),
               formattedAmount: utils.formatUnits(BigNumber.from(1), 18),
               token: {
@@ -512,7 +520,8 @@ describe('swapRoute', () => {
                 symbol: 'IMX',
               },
             },
-            swapGasFees: {
+            swapGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(2),
               formattedAmount: utils.formatUnits(BigNumber.from(2), 18),
               token: {
@@ -522,6 +531,7 @@ describe('swapRoute', () => {
               },
             },
             swapFees: [{
+              type: FeeType.SWAP_FEE,
               amount: BigNumber.from(3),
               formattedAmount: utils.formatUnits(BigNumber.from(3), 18),
               token: {
@@ -553,7 +563,8 @@ describe('swapRoute', () => {
             },
           },
           fees: {
-            approvalGasFees: {
+            approvalGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(1),
               formattedAmount: utils.formatUnits(BigNumber.from(1), 18),
               token: {
@@ -562,7 +573,8 @@ describe('swapRoute', () => {
                 symbol: 'IMX',
               },
             },
-            swapGasFees: {
+            swapGasFee: {
+              type: FeeType.GAS,
               amount: BigNumber.from(2),
               formattedAmount: utils.formatUnits(BigNumber.from(2), 18),
               token: {
@@ -572,6 +584,7 @@ describe('swapRoute', () => {
               },
             },
             swapFees: [{
+              type: FeeType.SWAP_FEE,
               amount: BigNumber.from(3),
               formattedAmount: utils.formatUnits(BigNumber.from(3), 18),
               token: {
@@ -1110,15 +1123,18 @@ describe('swapRoute', () => {
         },
       };
       const fees = {
-        approvalGasFees: {
+        approvalGasFee: {
+          type: FeeType.GAS,
           amount: BigNumber.from(1),
           formattedAmount: '1',
         },
-        swapGasFees: {
+        swapGasFee: {
+          type: FeeType.GAS,
           amount: BigNumber.from(2),
           formattedAmount: '2',
         },
         swapFees: [{
+          type: FeeType.SWAP_FEE,
           amount: BigNumber.from(3),
           formattedAmount: '3',
         }],
@@ -1164,15 +1180,18 @@ describe('swapRoute', () => {
         },
       };
       const fees = {
-        approvalGasFees: {
+        approvalGasFee: {
+          type: FeeType.GAS,
           amount: BigNumber.from(1),
           formattedAmount: '1',
         },
-        swapGasFees: {
+        swapGasFee: {
+          type: FeeType.GAS,
           amount: BigNumber.from(2),
           formattedAmount: '2',
         },
         swapFees: [{
+          type: FeeType.SWAP_FEE,
           amount: BigNumber.from(3),
           formattedAmount: '3',
         }],
@@ -1464,7 +1483,7 @@ describe('swapRoute', () => {
         approvalGasTokenAddress: '',
       };
 
-      const swapGasFees = {
+      const swapGasFee = {
         token: {
           chainId: ChainId.IMTBL_ZKEVM_TESTNET,
           address: '',
@@ -1481,7 +1500,7 @@ describe('swapRoute', () => {
       const canCoverSwapFees = checkUserCanCoverSwapFees(
         l2Balances,
         approvalFees,
-        swapGasFees,
+        swapGasFee,
         swapFees,
         tokenBeingSwapped,
       );
@@ -1525,7 +1544,7 @@ describe('swapRoute', () => {
         approvalGasTokenAddress: '',
       };
 
-      const swapGasFees = {
+      const swapGasFee = {
         token: {
           chainId: ChainId.IMTBL_ZKEVM_TESTNET,
           address: '',
@@ -1542,7 +1561,7 @@ describe('swapRoute', () => {
       const canCoverSwapFees = checkUserCanCoverSwapFees(
         l2Balances,
         approvalFees,
-        swapGasFees,
+        swapGasFee,
         swapFees,
         tokenBeingSwapped,
       );
@@ -1586,7 +1605,7 @@ describe('swapRoute', () => {
         approvalGasTokenAddress: '',
       };
 
-      const swapGasFees = {
+      const swapGasFee = {
         token: {
           chainId: ChainId.IMTBL_ZKEVM_TESTNET,
           address: '',
@@ -1603,7 +1622,7 @@ describe('swapRoute', () => {
       const canCoverSwapFees = checkUserCanCoverSwapFees(
         l2Balances,
         approvalFees,
-        swapGasFees,
+        swapGasFee,
         swapFees,
         tokenBeingSwapped,
       );
@@ -1699,7 +1718,7 @@ describe('swapRoute', () => {
           approvalGasTokenAddress: '0xERC20_1',
         };
 
-        const swapGasFees = {
+        const swapGasFee = {
           token: {
             chainId: ChainId.IMTBL_ZKEVM_TESTNET,
             address: '0xERC20_1',
@@ -1716,7 +1735,7 @@ describe('swapRoute', () => {
         const canCoverSwapFees = checkUserCanCoverSwapFees(
           l2Balances,
           approvalFees,
-          swapGasFees,
+          swapGasFee,
           swapFees,
           tokenBeingSwapped,
         );
@@ -1747,7 +1766,7 @@ describe('swapRoute', () => {
         approvalGasTokenAddress: '',
       };
 
-      const swapGasFees = {
+      const swapGasFee = {
         token: {
           chainId: ChainId.IMTBL_ZKEVM_TESTNET,
           address: '',
@@ -1764,7 +1783,7 @@ describe('swapRoute', () => {
       const canCoverSwapFees = checkUserCanCoverSwapFees(
         l2Balances,
         approvalFees,
-        swapGasFees,
+        swapGasFee,
         swapFees,
         tokenBeingSwapped,
       );
@@ -1809,7 +1828,7 @@ describe('swapRoute', () => {
         approvalGasTokenAddress: '',
       };
 
-      const swapGasFees = {
+      const swapGasFee = {
         token: {
           chainId: ChainId.IMTBL_ZKEVM_TESTNET,
           address: '',
@@ -1826,7 +1845,7 @@ describe('swapRoute', () => {
       const canCoverSwapFees = checkUserCanCoverSwapFees(
         l2Balances,
         approvalFees,
-        swapGasFees,
+        swapGasFee,
         swapFees,
         tokenBeingSwapped,
       );
@@ -1864,7 +1883,7 @@ describe('swapRoute', () => {
         },
       ];
 
-      const swapGasFees = {
+      const swapGasFee = {
         token: {
           chainId: ChainId.IMTBL_ZKEVM_TESTNET,
           address: '',
@@ -1887,7 +1906,7 @@ describe('swapRoute', () => {
       const canCoverSwapFees = checkUserCanCoverSwapFees(
         l2Balances,
         approvalFees,
-        swapGasFees,
+        swapGasFee,
         swapFees,
         tokenBeingSwapped,
       );
@@ -1932,7 +1951,7 @@ describe('swapRoute', () => {
         approvalGasTokenAddress: '',
       };
 
-      const swapGasFees = {
+      const swapGasFee = {
         token: {
           chainId: ChainId.IMTBL_ZKEVM_TESTNET,
           address: '',
@@ -1949,7 +1968,7 @@ describe('swapRoute', () => {
       const canCoverSwapFees = checkUserCanCoverSwapFees(
         l2Balances,
         approvalFees,
-        swapGasFees,
+        swapGasFee,
         swapFees,
         tokenBeingSwapped,
       );

--- a/packages/checkout/sdk/src/smartCheckout/routing/swap/swapRoute.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/swap/swapRoute.ts
@@ -4,6 +4,7 @@ import { CheckoutConfiguration, getL2ChainId } from '../../../config';
 import {
   AvailableRoutingOptions,
   ChainId,
+  FeeType,
   FundingStepType,
   GetBalanceResult,
   ItemType,
@@ -17,41 +18,42 @@ import { quoteFetcher } from './quoteFetcher';
 import { isNativeToken } from '../../../tokens';
 
 const constructFees = (
-  approvalGasFees: Amount | null | undefined,
-  swapGasFees: Amount | null,
+  approvalGasFee: Amount | null | undefined,
+  swapGasFee: Amount | null,
   swapFees: Fee[],
 ): SwapFees => {
   let approvalGasFeeAmount = BigNumber.from(0);
   let approvalGasFeeFormatted = '0';
   let approvalToken: TokenInfo | undefined;
-  if (approvalGasFees) {
-    approvalGasFeeAmount = approvalGasFees.value;
-    approvalGasFeeFormatted = utils.formatUnits(approvalGasFees.value, approvalGasFees.token.decimals);
+  if (approvalGasFee) {
+    approvalGasFeeAmount = approvalGasFee.value;
+    approvalGasFeeFormatted = utils.formatUnits(approvalGasFee.value, approvalGasFee.token.decimals);
     approvalToken = {
-      name: approvalGasFees.token.name ?? '',
-      symbol: approvalGasFees.token.symbol ?? '',
-      address: approvalGasFees.token.address,
-      decimals: approvalGasFees.token.decimals,
+      name: approvalGasFee.token.name ?? '',
+      symbol: approvalGasFee.token.symbol ?? '',
+      address: approvalGasFee.token.address,
+      decimals: approvalGasFee.token.decimals,
     };
   }
 
   let swapGasFeeAmount = BigNumber.from(0);
   let swapGasFeeFormatted = '0';
   let swapGasToken: TokenInfo | undefined;
-  if (swapGasFees) {
-    swapGasFeeAmount = swapGasFees.value;
-    swapGasFeeFormatted = utils.formatUnits(swapGasFees.value, swapGasFees.token.decimals);
+  if (swapGasFee) {
+    swapGasFeeAmount = swapGasFee.value;
+    swapGasFeeFormatted = utils.formatUnits(swapGasFee.value, swapGasFee.token.decimals);
     swapGasToken = {
-      name: swapGasFees.token.name ?? '',
-      symbol: swapGasFees.token.symbol ?? '',
-      address: swapGasFees.token.address,
-      decimals: swapGasFees.token.decimals,
+      name: swapGasFee.token.name ?? '',
+      symbol: swapGasFee.token.symbol ?? '',
+      address: swapGasFee.token.address,
+      decimals: swapGasFee.token.decimals,
     };
   }
 
   const fees = [];
   for (const swapFee of swapFees) {
     fees.push({
+      type: FeeType.SWAP_FEE,
       amount: swapFee.amount.value,
       formattedAmount: utils.formatUnits(swapFee.amount.value, swapFee.amount.token.decimals),
       token: {
@@ -64,12 +66,14 @@ const constructFees = (
   }
 
   return {
-    approvalGasFees: {
+    approvalGasFee: {
+      type: FeeType.GAS,
       amount: approvalGasFeeAmount,
       formattedAmount: approvalGasFeeFormatted,
       token: approvalToken,
     },
-    swapGasFees: {
+    swapGasFee: {
+      type: FeeType.GAS,
       amount: swapGasFeeAmount,
       formattedAmount: swapGasFeeFormatted,
       token: swapGasToken,
@@ -192,7 +196,7 @@ export const checkUserCanCoverApprovalFees = (
 export const checkUserCanCoverSwapFees = (
   l2Balances: GetBalanceResult[],
   approvalFees: SufficientApprovalFees,
-  swapGasFees: Amount | null,
+  swapGasFee: Amount | null,
   swapFees: Fee[],
   tokenBeingSwapped: { amount: BigNumber, address: string },
 ): boolean => {
@@ -205,12 +209,12 @@ export const checkUserCanCoverSwapFees = (
   }
 
   // Add the swap gas fee to list of fees
-  if (swapGasFees) {
-    const fee = feeMap.get(swapGasFees.token.address);
+  if (swapGasFee) {
+    const fee = feeMap.get(swapGasFee.token.address);
     if (fee) {
-      feeMap.set(swapGasFees.token.address, fee.add(swapGasFees.value));
+      feeMap.set(swapGasFee.token.address, fee.add(swapGasFee.value));
     } else {
-      feeMap.set(swapGasFees.token.address, swapGasFees.value);
+      feeMap.set(swapGasFee.token.address, swapGasFee.value);
     }
   }
 

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -539,6 +539,8 @@ export type FundingRoute = {
  * @property {TokenInfo | undefined} token
  */
 export type Fee = {
+  /** The type of fee */
+  type: FeeType;
   /** The amount of the fee */
   amount: BigNumber;
   /** The formatted amount of the fee */
@@ -546,6 +548,21 @@ export type Fee = {
   /** The token info for the fee */
   token?: TokenInfo;
 };
+
+/**
+ * An enum representing the funding step types
+ * @enum {string}
+ * @property {string} GAS - If the fee is a gas fee.
+ * @property {string} BRIDGE_FEE - If the fee is a bridge fee.
+ * @property {string} SWAP_FEE - If the fee is a swap fee.
+ * @property {string} IMMUTABLE_FEE - If the fee is an immutable fee.
+ */
+export enum FeeType {
+  GAS = 'GAS',
+  BRIDGE_FEE = 'BRIDGE_FEE',
+  SWAP_FEE = 'SWAP_FEE',
+  IMMUTABLE_FEE = 'IMMUTABLE_FEE',
+}
 
 /*
 * Type representing the various funding steps
@@ -572,15 +589,15 @@ export type BridgeFundingStep = {
 
 /**
  * Represents the fees for a bridge funding step
- * @property {Fee} approvalGasFees
- * @property {Fee} bridgeGasFees
+ * @property {Fee} approvalGasFee
+ * @property {Fee} bridgeGasFee
  * @property {Fee[]} bridgeFees
  */
 export type BridgeFees = {
-  /** The approval gas fees for the bridge */
-  approvalGasFees: Fee,
-  /** The bridge gas fees for the bridge */
-  bridgeGasFees: Fee,
+  /** The approval gas fee for the bridge */
+  approvalGasFee: Fee,
+  /** The bridge gas fee for the bridge */
+  bridgeGasFee: Fee,
   /** Additional bridge fees for the bridge */
   bridgeFees: Fee[],
 };
@@ -605,15 +622,15 @@ export type SwapFundingStep = {
 
 /**
  * Represents the fees for a swap funding step
- * @property {Fee} approvalGasFees
- * @property {Fee} swapGasFees
+ * @property {Fee} approvalGasFee
+ * @property {Fee} swapGasFee
  * @property {Fee[]} swapFees
  */
 export type SwapFees = {
-  /** The approval gas fees for the swap */
-  approvalGasFees: Fee,
-  /** The swap gas fees for the swap */
-  swapGasFees: Fee,
+  /** The approval gas fee for the swap */
+  approvalGasFee: Fee,
+  /** The swap gas fee for the swap */
+  swapGasFee: Fee,
   /** Additional swap fees for the swap */
   swapFees: Fee[],
 };

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/FundingRouteSelect/FundingRouteSelect.cy.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/FundingRouteSelect/FundingRouteSelect.cy.tsx
@@ -1,6 +1,6 @@
 import {
   BridgeFundingStep,
-  ChainId, Checkout, FundingRoute, FundingStepType, ItemType, SwapFundingStep,
+  ChainId, Checkout, FeeType, FundingRoute, FundingStepType, ItemType, SwapFundingStep,
 } from '@imtbl/checkout-sdk';
 import { mount } from 'cypress/react18';
 import { BigNumber, utils } from 'ethers';
@@ -36,15 +36,18 @@ describe('FundingRouteSelect View', () => {
       },
     },
     fees: {
-      approvalGasFees: {
+      approvalGasFee: {
+        type: FeeType.GAS,
         amount: BigNumber.from(0),
         formattedAmount: '0',
       },
-      bridgeGasFees: {
+      bridgeGasFee: {
+        type: FeeType.GAS,
         amount: BigNumber.from(0),
         formattedAmount: '0',
       },
       bridgeFees: [{
+        type: FeeType.BRIDGE_FEE,
         amount: BigNumber.from(0),
         formattedAmount: '0',
       }],
@@ -72,15 +75,18 @@ describe('FundingRouteSelect View', () => {
       },
     },
     fees: {
-      approvalGasFees: {
+      approvalGasFee: {
+        type: FeeType.GAS,
         amount: BigNumber.from(0),
         formattedAmount: '0',
       },
-      swapGasFees: {
+      swapGasFee: {
+        type: FeeType.GAS,
         amount: BigNumber.from(0),
         formattedAmount: '0',
       },
       swapFees: [{
+        type: FeeType.SWAP_FEE,
         amount: BigNumber.from(0),
         formattedAmount: '0',
       }],

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/smartCheckoutUtils.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/smartCheckoutUtils.test.ts
@@ -177,9 +177,9 @@ describe('fundingRouteFees', () => {
         {
           type: FundingStepType.BRIDGE,
           fees: {
-            approvalGasFees: ethFee,
+            approvalGasFee: ethFee,
             bridgeFees: [ethFee, ethFee],
-            bridgeGasFees: ethFee,
+            bridgeGasFee: ethFee,
 
           },
         },
@@ -197,9 +197,9 @@ describe('fundingRouteFees', () => {
         {
           type: FundingStepType.SWAP,
           fees: {
-            approvalGasFees: imxFee,
+            approvalGasFee: imxFee,
             swapFees: [imxFee, imxFee],
-            swapGasFees: imxFee,
+            swapGasFee: imxFee,
 
           },
         },
@@ -217,18 +217,18 @@ describe('fundingRouteFees', () => {
         {
           type: FundingStepType.BRIDGE,
           fees: {
-            approvalGasFees: ethFee,
+            approvalGasFee: ethFee,
             bridgeFees: [ethFee, ethFee],
-            bridgeGasFees: ethFee,
+            bridgeGasFee: ethFee,
 
           },
         },
         {
           type: FundingStepType.SWAP,
           fees: {
-            approvalGasFees: imxFee,
+            approvalGasFee: imxFee,
             swapFees: [imxFee, imxFee],
-            swapGasFees: imxFee,
+            swapGasFee: imxFee,
 
           },
         },

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/smartCheckoutUtils.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/smartCheckoutUtils.ts
@@ -85,7 +85,6 @@ export const fundingRouteFees = (
   }
 
   let totalUsd: number = 0;
-  console.log(fees);
   for (const fee of fees) {
     if (fee.token) {
       const feeUsd = calculateCryptoToFiat(fee.formattedAmount, fee.token.symbol, conversions);

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/smartCheckoutUtils.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/smartCheckoutUtils.ts
@@ -71,20 +71,21 @@ export const fundingRouteFees = (
   for (const step of fundingRoute.steps) {
     switch (step.type) {
       case FundingStepType.BRIDGE:
-        fees.push(step.fees.approvalGasFees);
+        fees.push(step.fees.approvalGasFee);
         fees.push(...step.fees.bridgeFees);
-        fees.push(step.fees.bridgeGasFees);
+        fees.push(step.fees.bridgeGasFee);
         break;
       case FundingStepType.SWAP:
-        fees.push(step.fees.approvalGasFees);
+        fees.push(step.fees.approvalGasFee);
         fees.push(...step.fees.swapFees);
-        fees.push(step.fees.swapGasFees);
+        fees.push(step.fees.swapGasFee);
         break;
       default:
     }
   }
 
   let totalUsd: number = 0;
+  console.log(fees);
   for (const fee of fees) {
     if (fee.token) {
       const feeUsd = calculateCryptoToFiat(fee.formattedAmount, fee.token.symbol, conversions);


### PR DESCRIPTION
# Summary

Adds a fee type to clearly differentiate between gas, bridge/swap & the immutable fee

Also this PR renames the following, as they are just a singular fee and not part of an array:
- `approvalGasFees` -> `approvalGasFee`
- `swapGasFees` -> `swapGasFee`
- `bridgeGasFees` -> `bridgeGasFee`

