### PR TITLE
fix: tokenId is uint256 so must be a BigNumber

### DIFF
--- a/packages/checkout/sdk/src/smartCheckout/allowance/erc721.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/allowance/erc721.test.ts
@@ -19,7 +19,7 @@ jest.mock('ethers', () => ({
 describe('erc721', () => {
   const mockProvider = {} as unknown as Web3Provider;
 
-  describe('getERC20Allowance', () => {
+  describe('getERC721ApprovedAddress', () => {
     it('should get the allowance from the contract', async () => {
       const getApprovedMock = jest.fn().mockResolvedValue('0xSEAPORT');
       (Contract as unknown as jest.Mock).mockReturnValue({
@@ -29,10 +29,10 @@ describe('erc721', () => {
       const address = await getERC721ApprovedAddress(
         mockProvider,
         '0xERC721',
-        0,
+        BigNumber.from(0),
       );
       expect(address).toEqual('0xSEAPORT');
-      expect(getApprovedMock).toBeCalledWith(0);
+      expect(getApprovedMock).toBeCalledWith(BigNumber.from(0));
     });
 
     it('should throw checkout error when getApproved call errors', async () => {
@@ -49,7 +49,7 @@ describe('erc721', () => {
         await getERC721ApprovedAddress(
           mockProvider,
           '0xERC721',
-          0,
+          BigNumber.from(0),
         );
       } catch (err: any) {
         message = err.message;
@@ -59,10 +59,11 @@ describe('erc721', () => {
 
       expect(message).toEqual('Failed to get approved address for ERC721');
       expect(type).toEqual(CheckoutErrorType.GET_ERC721_ALLOWANCE_ERROR);
-      expect(data.error).toBeDefined();
-      expect(data.id).toEqual('0');
-      expect(data.contractAddress).toEqual('0xERC721');
-      expect(getApprovedMock).toBeCalledWith(0);
+      expect(data).toEqual({
+        id: '0',
+        contractAddress: '0xERC721',
+      });
+      expect(getApprovedMock).toBeCalledWith(BigNumber.from(0));
     });
   });
 
@@ -80,10 +81,10 @@ describe('erc721', () => {
         '0xADDRESS',
         '0xERC721',
         '0xSEAPORT',
-        0,
+        BigNumber.from(0),
       );
       expect(approvalTransaction).toEqual({ from: '0xADDRESS', data: '0xDATA' });
-      expect(approveMock).toBeCalledWith('0xSEAPORT', 0);
+      expect(approveMock).toBeCalledWith('0xSEAPORT', BigNumber.from(0));
     });
 
     it('should throw checkout error if call to approve fails', async () => {
@@ -104,7 +105,7 @@ describe('erc721', () => {
           '0xADDRESS',
           '0xERC721',
           '0xSEAPORT',
-          0,
+          BigNumber.from(0),
         );
       } catch (err: any) {
         message = err.message;
@@ -114,12 +115,13 @@ describe('erc721', () => {
 
       expect(message).toEqual('Failed to get the approval transaction for ERC721');
       expect(type).toEqual(CheckoutErrorType.GET_ERC721_ALLOWANCE_ERROR);
-      expect(data.error).toBeDefined();
-      expect(data.id).toEqual('0');
-      expect(data.contractAddress).toEqual('0xERC721');
-      expect(data.spenderAddress).toEqual('0xSEAPORT');
-      expect(data.ownerAddress).toEqual('0xADDRESS');
-      expect(approveMock).toBeCalledWith('0xSEAPORT', 0);
+      expect(data).toEqual({
+        id: '0',
+        contractAddress: '0xERC721',
+        spenderAddress: '0xSEAPORT',
+        ownerAddress: '0xADDRESS',
+      });
+      expect(approveMock).toBeCalledWith('0xSEAPORT', BigNumber.from(0));
     });
   });
 
@@ -472,7 +474,7 @@ describe('erc721', () => {
     it('should converts a valid string ID to a number', () => {
       const id = '123';
       const result = convertIdToNumber(id, '0xERC721');
-      expect(result).toBe(123);
+      expect(result.toNumber()).toBe(123);
     });
 
     it('should throw checkout error an error for invalid string ID', () => {

--- a/packages/checkout/sdk/src/smartCheckout/allowance/erc721.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/allowance/erc721.test.ts
@@ -61,6 +61,7 @@ describe('erc721', () => {
       expect(type).toEqual(CheckoutErrorType.GET_ERC721_ALLOWANCE_ERROR);
       expect(data).toEqual({
         id: '0',
+        error: {},
         contractAddress: '0xERC721',
       });
       expect(getApprovedMock).toBeCalledWith(BigNumber.from(0));
@@ -117,6 +118,9 @@ describe('erc721', () => {
       expect(type).toEqual(CheckoutErrorType.GET_ERC721_ALLOWANCE_ERROR);
       expect(data).toEqual({
         id: '0',
+        error: {
+          from: '0xADDRESS',
+        },
         contractAddress: '0xERC721',
         spenderAddress: '0xSEAPORT',
         ownerAddress: '0xADDRESS',

--- a/packages/checkout/sdk/src/smartCheckout/allowance/erc721.ts
+++ b/packages/checkout/sdk/src/smartCheckout/allowance/erc721.ts
@@ -1,5 +1,5 @@
 import { TransactionRequest, Web3Provider } from '@ethersproject/providers';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { CheckoutError, CheckoutErrorType } from '../../errors';
 import { ItemRequirement, ItemType } from '../../types';
 import { Allowance, InsufficientERC721 } from './types';
@@ -39,7 +39,7 @@ export const getApproveTransaction = async (
   ownerAddress: string,
   contractAddress: string,
   spenderAddress: string,
-  id: number,
+  id: BigNumber,
 ): Promise<TransactionRequest | undefined> => {
   try {
     const contract = new Contract(
@@ -70,7 +70,7 @@ export const getApproveTransaction = async (
 export const getERC721ApprovedAddress = async (
   provider: Web3Provider,
   contractAddress: string,
-  id: number,
+  id: BigNumber,
 ): Promise<string> => {
   try {
     const contract = new Contract(
@@ -92,18 +92,16 @@ export const getERC721ApprovedAddress = async (
   }
 };
 
-export const convertIdToNumber = (id: string, contractAddress: string): number => {
-  const parsedId = parseInt(id, 10);
-
-  if (Number.isNaN(parsedId)) {
+export const convertIdToNumber = (id: string, contractAddress: string): BigNumber => {
+  try {
+    return BigNumber.from(id);
+  } catch (e) {
     throw new CheckoutError(
       'Invalid ERC721 ID',
       CheckoutErrorType.GET_ERC721_ALLOWANCE_ERROR,
       { id, contractAddress },
     );
   }
-
-  return parsedId;
 };
 
 export const getApprovedCollections = async (


### PR DESCRIPTION
# Summary

tokenId is uint256 so must be a BigNumber


Test in checkout sdk-sample-app


# Customer Impact

When listing NFTs with a number that is too big to fit in a JS number, it will succeed.

## Added 
<!-- Section for new features. -->


## Changed
<!-- Section for changes in existing functionality. -->


## Deprecated
<!-- Section for soon-to-be removed features. -->


## Removed
<!-- Section for now removed features. -->


## Fixed
<!-- Section for any bug fixes. -->


## Security
<!-- Section in case of vulnerabilities. -->




# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
