### PR TITLE
fix: WT-2040 - dynamic from and to address in the in-progress screen

### DIFF
--- a/packages/checkout/widgets-lib/src/components/Transactions/TransactionItem.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/TransactionItem.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   MenuItem,
   Link,
+  EllipsizedText,
 } from '@biom3/react';
 import { ChainId } from '@imtbl/checkout-sdk';
 import { logoColour, networkIcon, networkName } from 'lib';
@@ -27,6 +28,8 @@ type TransactionItemProps = {
   amount: string
   fromChain: ChainId
   toChain: ChainId
+  fromAddress: string
+  toAddress: string
   // action: () => void
 };
 
@@ -37,6 +40,8 @@ export function TransactionItem({
   amount,
   fromChain,
   toChain,
+  fromAddress,
+  toAddress,
   // action
 }: TransactionItemProps) {
   // The action prop is designed for injecting the action to perform
@@ -172,7 +177,7 @@ export function TransactionItem({
               <Body size="xxSmall" sx={{ color: 'base.color.translucent.standard.900' }}>
                 {networkName[fromChain]}
               </Body>
-              <Body size="xxSmall" sx={{ color: 'base.color.translucent.standard.600' }}>0x1E8d...CfDf</Body>
+              <EllipsizedText size="xxSmall" sx={{ color: 'base.color.translucent.standard.600' }} text={fromAddress} />
             </Box>
             <Box sx={{ flexGrow: '1' }} />
             <Icon
@@ -202,7 +207,7 @@ export function TransactionItem({
               <Body size="xxSmall" sx={{ color: 'base.color.translucent.standard.900' }}>
                 {networkName[toChain]}
               </Body>
-              <Body size="xxSmall" sx={{ color: 'base.color.translucent.standard.600' }}>0x1E8d...CfDf</Body>
+              <EllipsizedText size="xxSmall" sx={{ color: 'base.color.translucent.standard.600' }} text={toAddress} />
             </Box>
           </Box>
         </Accordion.ExpandedContent>

--- a/packages/checkout/widgets-lib/src/components/Transactions/TransactionsInProgress.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/TransactionsInProgress.tsx
@@ -72,6 +72,8 @@ export function TransactionsInProgress({
               amount={amount}
               fromChain={getChainIdBySlug(t.details.from_chain as ChainSlug)}
               toChain={getChainIdBySlug(t.details.to_chain as ChainSlug)}
+              fromAddress={t.details.from_address}
+              toAddress={t.details.to_address}
             />
           );
         })}


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

After completing a Bridge, going to the Transaction in progress screen should show details about the wallets and networks that the bridge is between. It currently doesn’t show the correct wallet addresses.

Data returned by the backend
```
{
    "result": [
        {
            "blockchain_metadata": {
                "transaction_hash": "0x1b8c4a3252b8ead7e4d942be3d8c6c6d1cb049edde11bc014536263062cc5a07"
            },
            "created_at": "2024-01-11T00:47:00Z",
            "details": {
                "amount": "100000",
                "current_status": {
                    "status": "in_progress"
                },
                "from_address": "0x1e8dc77bed0da06621e819fa0afb59d50f76cfdf",
                "from_chain": "sepolia",
                "from_token_address": "0x40b87d235a5b010a20a241f15797c9debf1ecd01",
                "to_address": "0x1e8dc77bed0da06621e819fa0afb59d50f76cfdf",
                "to_chain": "imtbl-zkevm-testnet",
                "to_token_address": "0x3b2d8a1931736fc321c24864bceee981b11c3c57"
            },
            "tx_type": "bridge"
        }
    ]
}
```

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->

Fix UX

## Fixed
<!-- Section for any bug fixes. -->

Bridge In Progress screen

<img width="437" alt="Screenshot 2024-01-11 at 11 48 15 am" src="https://github.com/immutable/ts-immutable-sdk/assets/4301501/e99e562e-539c-49c5-8d9b-49d5976a5578">


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
