### PR TITLE
feat: WT-2032 - Warm up CDN as soon as a new NPM package has been released

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -125,6 +125,11 @@ jobs:
         if: contains(github.event.inputs.release_type, 'release')
         run: yarn release --ci --no-increment -c .release-it.json $( ${{ github.event.inputs.dry_run }} && echo "--dry-run" || echo "") --github.tokenRef=${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
 
+      - name: Warm up CDN
+        id: warm_up_cdn
+        if: contains(github.event.inputs.release_type, 'release')
+        run: wget https://cdn.jsdelivr.net/npm/@imtbl/sdk/dist/browser/checkout.js
+
       # Wait for 30 seconds to make sure the tag is available on GitHub
       - uses: GuillaumeFalourd/wait-sleep-action@v1
         with:


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

Checkout JS bundle is fetched from JS Deliver. JS Deliver will cache that bundle at the first hit; however given the size of the bundle, the time to fetch and cache it is not negligible; therefore on release we can pre-warm the CDN by making the first request.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->

Reduce the load time of the Checkout bundle when a new NPM version is released.

## Changed
<!-- Section for changes in existing functionality. -->

Hit JS Deliver when a new NPM version is released.

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
