### PR TITLE
feat: [TD-1158] Add `taker_address` to fulfillment data request

### DIFF
--- a/packages/orderbook/src/openapi/sdk/models/FulfillmentDataRequest.ts
+++ b/packages/orderbook/src/openapi/sdk/models/FulfillmentDataRequest.ts
@@ -6,6 +6,10 @@ import type { Fee } from './Fee';
 
 export type FulfillmentDataRequest = {
   order_id: string;
+  /**
+   * Address of the intended account fulfilling the order
+   */
+  taker_address?: string;
   fees: Array<Fee>;
 };
 

--- a/packages/orderbook/src/orderbook.ts
+++ b/packages/orderbook/src/orderbook.ts
@@ -197,7 +197,8 @@ export class Orderbook {
    * transaction exists it must be signed and submitted to the chain before the fulfilment
    * transaction can be submitted or it will be reverted.
    * @param {string} listingId - The listingId to fulfil.
-   * @param {string} fulfillerAddress - The address of the account fulfilling the order.
+   * @param {string} takerAddress - The address of the account fulfilling the order.
+   * @param {FeeValue[]} takerFees - Taker ecosystem fees to be paid.
    * @return {FulfillOrderResponse} Approval and fulfilment transactions.
    */
   async fulfillOrder(
@@ -208,6 +209,7 @@ export class Orderbook {
     const fulfillmentDataRes = await this.apiClient.fulfillmentData([
       {
         order_id: listingId,
+        taker_address: takerAddress,
         fees: takerFees.map((fee) => ({
           amount: fee.amount,
           type:
@@ -244,6 +246,7 @@ export class Orderbook {
     const fulfillmentDataRes = await this.apiClient.fulfillmentData(
       listings.map((listingRequest) => ({
         order_id: listingRequest.listingId,
+        taker_address: takerAddress,
         fees: listingRequest.takerFees.map((fee) => ({
           amount: fee.amount,
           type:


### PR DESCRIPTION
# Summary

Adds the taker address to the fulfillment data request in the order fulfillment flow.


# Customer Impact

Fulfillment data retrieved will no longer be valid when submitted by any other address than the specified taker address to the settlement contract.


## Changed

Fulfillment data retrieved will no longer be valid when submitted by any other address than the specified taker address to the settlement contract.


# Things worth calling out

N/A


# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
