### PR TITLE
fix: ID-1356 Fixed zkEvm message signing implementation

### DIFF
--- a/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
@@ -63,6 +63,7 @@ describe('getSignedTypedData', () => {
       // and so its signature should be FIRST in the combined signature
       const lowAddressSigner = new Wallet('0xdac4f6ad57b2977b13c57b65ee7c98d07f4e4afccdf04849e7df7da03fa928be');
       const signMessageSpy = jest.spyOn(lowAddressSigner, 'signMessage');
+
       const result = await getSignedTypedData(
         typedDataPayload,
         relayerSignature,
@@ -70,6 +71,7 @@ describe('getSignedTypedData', () => {
         walletAddress,
         lowAddressSigner,
       );
+
       const eoaSignature = await signMessageSpy.mock.results[0].value;
       const eoaSignatureWithoutPrefix = eoaSignature.slice(2); // Remove leading `0x`
       expect(result).toEqual([
@@ -87,6 +89,7 @@ describe('getSignedTypedData', () => {
       // The wallet used here has an address of `0x7E...` which is GREATER than the relayer address (`0x1B...`),
       // and so its signature should be LAST in the combined signature
       const signMessageSpy = jest.spyOn(signer, 'signMessage');
+
       const result = await getSignedTypedData(
         typedDataPayload,
         relayerSignature,
@@ -94,6 +97,7 @@ describe('getSignedTypedData', () => {
         walletAddress,
         signer,
       );
+
       const eoaSignature = await signMessageSpy.mock.results[0].value;
       const eoaSignatureWithoutPrefix = eoaSignature.slice(2); // Remove leading `0x`
       expect(result).toEqual([

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
@@ -57,9 +57,9 @@ describe('getSignedTypedData', () => {
     expect(signature).toEqual(expectedSignature);
   });
 
-  describe('when the EOA address is smaller than the relayer address', () => {
+  describe('when the EOA address is smaller than the Immutable signer address', () => {
     it('should include the EOA signature in the combined signature first', async () => {
-      // The following wallet has an address of `0x15...` which is SMALLER than the relayer address (`0x1B...`),
+      // The following wallet has an address of `0x15...` which is SMALLER than the Immutable signer address (`0x1B...`),
       // and so its signature should be FIRST in the combined signature
       const lowAddressSigner = new Wallet('0xdac4f6ad57b2977b13c57b65ee7c98d07f4e4afccdf04849e7df7da03fa928be');
       const signMessageSpy = jest.spyOn(lowAddressSigner, 'signMessage');
@@ -84,9 +84,9 @@ describe('getSignedTypedData', () => {
     });
   });
 
-  describe('when the EOA address is greater than the relayer address', () => {
-    it('should include the relayer signature in the combined signature first', async () => {
-      // The wallet used here has an address of `0x7E...` which is GREATER than the relayer address (`0x1B...`),
+  describe('when the EOA address is greater than the Immutable signer address', () => {
+    it('should include the Immutable signer signature in the combined signature first', async () => {
+      // The wallet used here has an address of `0x7E...` which is GREATER than the Immutable signer address (`0x1B...`),
       // and so its signature should be LAST in the combined signature
       const signMessageSpy = jest.spyOn(signer, 'signMessage');
 

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
@@ -59,7 +59,7 @@ describe('getSignedTypedData', () => {
 
   describe('when the EOA address is smaller than the relayer address', () => {
     it('should include the EOA address in the combined signature first', async () => {
-      // The following wallet has an address of `0x15...` which is greater than the relayer address (`0x1B...`),
+      // The following wallet has an address of `0x15...` which is SMALLER than the relayer address (`0x1B...`),
       // and so its signature should be FIRST in the combined signature
       const lowAddressSigner = new Wallet('0xdac4f6ad57b2977b13c57b65ee7c98d07f4e4afccdf04849e7df7da03fa928be');
       const signMessageSpy = jest.spyOn(lowAddressSigner, 'signMessage');
@@ -84,7 +84,7 @@ describe('getSignedTypedData', () => {
 
   describe('when the EOA address is greater than the relayer address', () => {
     it('should include the relayer address in the combined signature first', async () => {
-      // The wallet used here has an address of `0x7E...` which is greater than the relayer address (`0x1B...`),
+      // The wallet used here has an address of `0x7E...` which is GREATER than the relayer address (`0x1B...`),
       // and so its signature should be LAST in the combined signature
       const signMessageSpy = jest.spyOn(signer, 'signMessage');
       const result = await getSignedTypedData(

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
@@ -36,12 +36,15 @@ describe('getSignedMetaTransactions', () => {
 });
 
 describe('getSignedTypedData', () => {
-  it('should correctly generate the signature for a given typed data payload', async () => {
-    const typedDataPayload = JSON.parse('{"domain":{"name":"Ether Mail","version":"1","chainId":13472,"verifyingContract":"0xd64b0d2d72bb1b3f18046b8a7fc6c9ee6bccd287"},"message":{"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},"contents":"Hello, Bob!"},"primaryType":"Mail","types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}]}}') as TypedDataPayload;
-    const relayerSignature = '02011b1d383526a2815d26550eb314b5d7e05513273300439b63b94e127c13e1bae9f3f24ab42717c7ae2e25fb82e7fd24afc320690413ca6581c798f91cce8296bd21f4f35a4b33b882a5401499f829481d8ed8d3de23741b0103';
-    const expectedSignature = '0x000202011b1d383526a2815d26550eb314b5d7e05513273300439b63b94e127c13e1bae9f3f24ab42717c7ae2e25fb82e7fd24afc320690413ca6581c798f91cce8296bd21f4f35a4b33b882a5401499f829481d8ed8d3de23741b01030001aec95114a3b8cf3c9693177a2abd8321cf775366a6c6aadf5953e082680fd90c6cb44972a1635b5e9f7f02490a47425be37a1965a6cbaaaa64404cb2cf3880f71c02';
+  const typedDataPayload = JSON.parse('{"domain":{"name":"Ether Mail","version":"1","chainId":13472,"verifyingContract":"0xd64b0d2d72bb1b3f18046b8a7fc6c9ee6bccd287"},"message":{"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},"contents":"Hello, Bob!"},"primaryType":"Mail","types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}]}}') as TypedDataPayload;
+  const relayerSignature = '02011b1d383526a2815d26550eb314b5d7e05513273300439b63b94e127c13e1bae9f3f24ab42717c7ae2e25fb82e7fd24afc320690413ca6581c798f91cce8296bd21f4f35a4b33b882a5401499f829481d8ed8d3de23741b0103';
+  const chainId = 13472;
+  const signaturePrefixWithThreshold = '0x0002';
+  const eoaSignatureWeight = '0001';
+  const ethSignFlag = '02';
 
-    const chainId = 13472;
+  it('should correctly generate the signature for a given typed data payload', async () => {
+    const expectedSignature = '0x000202011b1d383526a2815d26550eb314b5d7e05513273300439b63b94e127c13e1bae9f3f24ab42717c7ae2e25fb82e7fd24afc320690413ca6581c798f91cce8296bd21f4f35a4b33b882a5401499f829481d8ed8d3de23741b01030001aec95114a3b8cf3c9693177a2abd8321cf775366a6c6aadf5953e082680fd90c6cb44972a1635b5e9f7f02490a47425be37a1965a6cbaaaa64404cb2cf3880f71c02';
 
     const signature = await getSignedTypedData(
       typedDataPayload,
@@ -52,5 +55,54 @@ describe('getSignedTypedData', () => {
     );
 
     expect(signature).toEqual(expectedSignature);
+  });
+
+  describe('when the EOA address is smaller than the relayer address', () => {
+    it('should include the EOA address in the combined signature first', async () => {
+      // The following wallet has an address of `0x15...` which is greater than the relayer address (`0x1B...`),
+      // and so its signature should be FIRST in the combined signature
+      const lowAddressSigner = new Wallet('0xdac4f6ad57b2977b13c57b65ee7c98d07f4e4afccdf04849e7df7da03fa928be');
+      const signMessageSpy = jest.spyOn(lowAddressSigner, 'signMessage');
+      const result = await getSignedTypedData(
+        typedDataPayload,
+        relayerSignature,
+        BigNumber.from(chainId),
+        walletAddress,
+        lowAddressSigner,
+      );
+      const eoaSignature = await signMessageSpy.mock.results[0].value;
+      const eoaSignatureWithoutPrefix = eoaSignature.slice(2); // Remove leading `0x`
+      expect(result).toEqual([
+        signaturePrefixWithThreshold,
+        eoaSignatureWeight,
+        eoaSignatureWithoutPrefix,
+        ethSignFlag,
+        relayerSignature,
+      ].join(''));
+    });
+  });
+
+  describe('when the EOA address is greater than the relayer address', () => {
+    it('should include the relayer address in the combined signature first', async () => {
+      // The wallet used here has an address of `0x7E...` which is greater than the relayer address (`0x1B...`),
+      // and so its signature should be LAST in the combined signature
+      const signMessageSpy = jest.spyOn(signer, 'signMessage');
+      const result = await getSignedTypedData(
+        typedDataPayload,
+        relayerSignature,
+        BigNumber.from(chainId),
+        walletAddress,
+        signer,
+      );
+      const eoaSignature = await signMessageSpy.mock.results[0].value;
+      const eoaSignatureWithoutPrefix = eoaSignature.slice(2); // Remove leading `0x`
+      expect(result).toEqual([
+        signaturePrefixWithThreshold,
+        relayerSignature,
+        eoaSignatureWeight,
+        eoaSignatureWithoutPrefix,
+        ethSignFlag,
+      ].join(''));
+    });
   });
 });

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
@@ -58,7 +58,7 @@ describe('getSignedTypedData', () => {
   });
 
   describe('when the EOA address is smaller than the relayer address', () => {
-    it('should include the EOA address in the combined signature first', async () => {
+    it('should include the EOA signature in the combined signature first', async () => {
       // The following wallet has an address of `0x15...` which is SMALLER than the relayer address (`0x1B...`),
       // and so its signature should be FIRST in the combined signature
       const lowAddressSigner = new Wallet('0xdac4f6ad57b2977b13c57b65ee7c98d07f4e4afccdf04849e7df7da03fa928be');
@@ -83,7 +83,7 @@ describe('getSignedTypedData', () => {
   });
 
   describe('when the EOA address is greater than the relayer address', () => {
-    it('should include the relayer address in the combined signature first', async () => {
+    it('should include the relayer signature in the combined signature first', async () => {
       // The wallet used here has an address of `0x7E...` which is GREATER than the relayer address (`0x1B...`),
       // and so its signature should be LAST in the combined signature
       const signMessageSpy = jest.spyOn(signer, 'signMessage');

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.ts
@@ -119,31 +119,46 @@ export const getSignedTypedData = async (
   // @ts-ignore
   delete types.EIP712Domain;
 
-  // eslint-disable-next-line no-underscore-dangle
-  const digest = ethers.utils._TypedDataEncoder.hash(typedData.domain, types, typedData.message);
+  // Hash the EIP712 payload and generate the complete payload
+  const { _TypedDataEncoder: typedDataEncoder } = ethers.utils;
+  const digest = typedDataEncoder.hash(typedData.domain, types, typedData.message);
   const completePayload = encodeMessageSubDigest(chainId, walletAddress, digest);
-
   const hash = ethers.utils.keccak256(completePayload);
 
-  // Sign the digest
+  // Sign the complete payload
   const hashArray = ethers.utils.arrayify(hash);
   const ethsigNoType = await signer.signMessage(hashArray);
   const signedDigest = `${ethsigNoType}${ETH_SIGN_FLAG}`;
 
-  const { signers } = decodeRelayerTypedDataSignature(relayerSignature);
+  // Combine the relayer and user signatures; sort by address to match the imageHash order
+  const { signers: relayerSigners } = decodeRelayerTypedDataSignature(relayerSignature);
+  const combinedSigners = [
+    ...relayerSigners,
+    {
+      isDynamic: false,
+      unrecovered: true,
+      weight: SIGNATURE_WEIGHT,
+      signature: signedDigest,
+      address: await signer.getAddress(),
+    },
+  ];
+  console.log('combinedSigners', combinedSigners);
+  const sortedSigners = combinedSigners.sort((a, b) => {
+    const bigA = BigNumber.from(a.address);
+    const bigB = BigNumber.from(b.address);
+
+    if (bigA.lte(bigB)) {
+      return -1;
+    } if (bigA.eq(bigB)) {
+      return 0;
+    }
+    return 1;
+  });
 
   return sequenceCoreV1.signature.encodeSignature({
     version: 1,
     threshold: EIP712_SIGNATURE_THRESHOLD,
-    signers: [
-      ...signers,
-      {
-        isDynamic: false,
-        unrecovered: true,
-        weight: SIGNATURE_WEIGHT,
-        signature: signedDigest,
-      },
-    ],
+    signers: sortedSigners,
   });
 };
 

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.ts
@@ -121,11 +121,12 @@ export const getSignedTypedData = async (
 
   // Hash the EIP712 payload and generate the complete payload
   const { _TypedDataEncoder: typedDataEncoder } = ethers.utils;
-  const digest = typedDataEncoder.hash(typedData.domain, types, typedData.message);
-  const completePayload = encodeMessageSubDigest(chainId, walletAddress, digest);
-  const hash = ethers.utils.keccak256(completePayload);
+  const typedDataHash = typedDataEncoder.hash(typedData.domain, types, typedData.message);
+  const messageSubDigest = encodeMessageSubDigest(chainId, walletAddress, typedDataHash);
+  const hash = ethers.utils.keccak256(messageSubDigest);
 
-  // Sign the complete payload
+  // Sign the sub digest
+  // https://github.com/immutable/wallet-contracts/blob/7824b5f24b2e0eb2dc465ecb5cd71f3984556b73/src/contracts/modules/commons/ModuleAuth.sol#L155
   const hashArray = ethers.utils.arrayify(hash);
   const ethsigNoType = await signer.signMessage(hashArray);
   const signedDigest = `${ethsigNoType}${ETH_SIGN_FLAG}`;

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.ts
@@ -142,7 +142,6 @@ export const getSignedTypedData = async (
       address: await signer.getAddress(),
     },
   ];
-  console.log('combinedSigners', combinedSigners);
   const sortedSigners = combinedSigners.sort((a, b) => {
     const bigA = BigNumber.from(a.address);
     const bigB = BigNumber.from(b.address);


### PR DESCRIPTION
# Summary
This PR fixes an issue where signatures generated by some certain would be invalid.

## Fixed
- Passport: Fixed an issue where EIP-712 signatures generated by certain wallets would fail to validate.

# Before submitting the PR, please consider the following:
<!-- List of things to check before submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
