### PR TITLE
[GPR-370] Update sign transaction response type

### DIFF
--- a/packages/checkout/widgets-lib/src/components/Transak/TransakTypes.ts
+++ b/packages/checkout/widgets-lib/src/components/Transak/TransakTypes.ts
@@ -2,7 +2,7 @@ export type TransakNFTData = {
   collectionAddress: string;
   imageURL: string;
   nftName: string;
-  nftType: 'ERC721';
+  nftType: string;
   price: number[];
   quantity: number;
   tokenID: string[];

--- a/packages/checkout/widgets-lib/src/components/Transak/useTransakIframe.ts
+++ b/packages/checkout/widgets-lib/src/components/Transak/useTransakIframe.ts
@@ -1,16 +1,8 @@
+import pako from 'pako';
 import { useCallback, useEffect, useState } from 'react';
 import { Environment } from '@imtbl/config';
-import pako from 'pako';
 
-export type TransakNFTData = {
-  imageURL: string;
-  quantity: number;
-  nftName: string;
-  collectionAddress: string;
-  tokenID: Array<string>;
-  price: Array<number>;
-  nftType: 'ERC721';
-};
+import { TransakNFTData } from './TransakTypes';
 
 export type TransakWidgetType = 'on-ramp' | 'nft-checkout';
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/WithCard.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/WithCard.tsx
@@ -41,7 +41,7 @@ export function WithCard(props: WithCardProps) {
       price: product.amount,
       quantity: product.qty,
       tokenID: product.tokenId,
-      nftType: 'ERC721',
+      nftType: product.contractType || 'ERC721',
     })),
     [signResponse],
   );

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
@@ -36,12 +36,13 @@ type SignApiTransaction = {
 };
 
 type SignApiProduct = {
+  product_id: string;
+  collection_address: string
+  contract_type: string
   detail: {
     amount: number;
-    collection_address: string;
     token_id: string;
   }[];
-  product_id: string;
 };
 
 type SignApiResponse = {
@@ -93,7 +94,8 @@ const toSignedProduct = (
   name: item?.name || '',
   description: item?.description || '',
   currency,
-  collectionAddress: product.detail[0]?.collection_address,
+  contractType: product.contract_type,
+  collectionAddress: product.collection_address,
   amount: product.detail.map(({ amount }) => amount),
   tokenId: product.detail.map(({ token_id: tokenId }) => tokenId),
 });

--- a/packages/checkout/widgets-lib/src/widgets/sale/types.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/types.ts
@@ -10,6 +10,7 @@ export type SignedOrderProduct = {
   amount: number[];
   tokenId: string[];
   currency: string;
+  contractType: string;
   collectionAddress: string;
 };
 


### PR DESCRIPTION
# Summary
Signed transaction responses have changed after sales backend added ERC115 support. This PR updates the types and mapping to:

```
type SignApiResponse = {
  order: {
    currency: {
      name: string;
      decimals: number;
      erc20_address: string;
    };
    currency_symbol: string;
    products: Array<{
      product_id: string;
      collection_address: string;
      contract_type: string;
      detail: Array<{
        amount: number;
        token_id: string;
      }>;
    }>;
    total_amount: string;
  };
  transactions: Array<{
    contract_address: string;
    gas_estimate: number;
    method_call: string;
    params: {
      amount?: number;
      spender?: string;
      data?: Array<string>;
      deadline?: number;
      multicallSigner?: string;
      reference?: string;
      signature?: string;
      targets?: Array<string>;
    };
    raw_data: string;
  }>
};
```