### PR TITLE
Add block explorer urls to Checkout 'add network'

### DIFF
--- a/packages/checkout/sdk/src/env/constants.ts
+++ b/packages/checkout/sdk/src/env/constants.ts
@@ -86,6 +86,7 @@ NetworkDetails
       chainName: ChainName.IMTBL_ZKEVM_MAINNET,
       rpcUrls: ['https://rpc.immutable.com'],
       nativeCurrency: ZKEVM_NATIVE_TOKEN,
+      blockExplorerUrls: ['https://explorer.immutable.com/'],
     },
   ],
 ]);
@@ -117,6 +118,7 @@ NetworkDetails
       chainName: ChainName.IMTBL_ZKEVM_TESTNET,
       rpcUrls: ['https://rpc.testnet.immutable.com'],
       nativeCurrency: ZKEVM_NATIVE_TOKEN,
+      blockExplorerUrls: ['https://explorer.testnet.immutable.com/'],
     },
   ],
 ]);


### PR DESCRIPTION
add network payloads

# Summary

When Checkout calls to add network, include the block explorer urls in the config for zkEVM testnet and mainnet


