### PR TITLE
Feat: WT-2058 Add change account functionality to SDK connect

### DIFF
--- a/packages/checkout/sdk-sample-app/src/components/Connect.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/Connect.tsx
@@ -19,18 +19,19 @@ export default function Connect(props: ConnectProps) {
 
   async function connectClick() {
     if (!checkout) {
-      console.error('missing checkout, please connect frist');
+      console.error('missing checkout, please connect first');
       return;
     }
     if (!provider) {
-      console.error('missing provider, please connect frist');
+      console.error('missing provider, please connect first');
       return;
     }
     setError(null);
     setLoading(true);
     try {
       const resp = await checkout.connect({
-        provider 
+        provider,
+        requestWalletPermissions: true,
       });
       setProvider(resp.provider);
       setResult(resp.provider);
@@ -46,7 +47,7 @@ export default function Connect(props: ConnectProps) {
   }
 
   useEffect(() => {
-    // reset state wehn checkout changes from environment switch
+    // reset state when checkout changes from environment switch
     setResult(undefined);
     setError(null);
     setLoading(false);

--- a/packages/checkout/sdk/src/connect/connect.test.ts
+++ b/packages/checkout/sdk/src/connect/connect.test.ts
@@ -155,7 +155,8 @@ describe('connect', () => {
       expect(reqRes?.provider).not.toBe(null);
       expect(reqRes?.provider.request).toBeCalledWith({
         method: WalletAction.REQUEST_PERMISSIONS,
-        params: [{ ethAccounts: {} }],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        params: [{ eth_accounts: {} }],
       });
     });
 

--- a/packages/checkout/sdk/src/connect/connect.ts
+++ b/packages/checkout/sdk/src/connect/connect.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Web3Provider } from '@ethersproject/providers';
-import { WalletAction, CheckConnectionResult } from '../types';
+import {
+  WalletAction, CheckConnectionResult,
+} from '../types';
 import { CheckoutError, CheckoutErrorType, withCheckoutError } from '../errors';
 
 export async function checkIsWalletConnected(
@@ -55,6 +57,31 @@ export async function connectSite(web3Provider: Web3Provider): Promise<Web3Provi
       await web3Provider.provider.request({
         method: WalletAction.CONNECT,
         params: [],
+      });
+    },
+    { type: CheckoutErrorType.USER_REJECTED_REQUEST_ERROR },
+  );
+
+  return web3Provider;
+}
+
+export async function requestPermissions(web3Provider: Web3Provider): Promise<Web3Provider> {
+  if (!web3Provider || !web3Provider.provider?.request) {
+    throw new CheckoutError(
+      'Incompatible provider',
+      CheckoutErrorType.PROVIDER_REQUEST_MISSING_ERROR,
+      { details: 'Attempting to connect with an incompatible provider' },
+    );
+  }
+
+  await withCheckoutError<void>(
+    async () => {
+      if (!web3Provider.provider.request) return;
+
+      await web3Provider.provider.request({
+        method: WalletAction.REQUEST_PERMISSIONS,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        params: [{ eth_accounts: {} }],
       });
     },
     { type: CheckoutErrorType.USER_REJECTED_REQUEST_ERROR },

--- a/packages/checkout/sdk/src/sdk.ts
+++ b/packages/checkout/sdk/src/sdk.ts
@@ -194,7 +194,11 @@ export class Checkout {
       { allowUnsupportedProvider: true } as ValidateProviderOptions,
     );
 
-    await connect.connectSite(web3Provider);
+    if (params.requestWalletPermissions && !(web3Provider.provider as any)?.isPassport) {
+      await connect.requestPermissions(web3Provider);
+    } else {
+      await connect.connectSite(web3Provider);
+    }
 
     return { provider: web3Provider };
   }

--- a/packages/checkout/sdk/src/types/connect.ts
+++ b/packages/checkout/sdk/src/types/connect.ts
@@ -3,9 +3,11 @@ import { Web3Provider } from '@ethersproject/providers';
 /**
  * Interface representing the params of {@link Checkout.connect}.
  * @property {Web3Provider} provider - The provider used to connect to the network.
+ * @property {boolean | undefined} requestWalletPermissions - A boolean that will trigger a permission request for wallet connection.
  */
 export interface ConnectParams {
   provider: Web3Provider
+  requestWalletPermissions?: boolean
 }
 
 /**
@@ -26,7 +28,7 @@ export interface CheckConnectionParams {
 
 /**
  * Interface representing the result of {@link Checkout.checkIsWalletConnected}.
- * @property {boolean} isConnected - A boolean indicating the connection status of th Web3 provider.
+ * @property {boolean} isConnected - A boolean indicating the connection status of the Web3 provider.
  * @property {string} walletAddress - The wallet address used to check the connection.
  */
 export interface CheckConnectionResult {

--- a/packages/checkout/sdk/src/types/wallet.ts
+++ b/packages/checkout/sdk/src/types/wallet.ts
@@ -6,6 +6,7 @@ export enum WalletAction {
   ADD_NETWORK = 'wallet_addEthereumChain',
   SWITCH_NETWORK = 'wallet_switchEthereumChain',
   GET_CHAINID = 'eth_chainId',
+  REQUEST_PERMISSIONS = 'wallet_requestPermissions',
 }
 
 /**


### PR DESCRIPTION
# Summary
<!--- A short summary about what this PR is doing. -->

https://immutable.atlassian.net/browse/WT-2058

- implement `requestPermissions` function
- added new param `requestWalletPermissions` to `ConnectParams`
- extended the `checkout.connect` function to check for `requestWalletPermissions` and wallet type to determine whether to action `wallet_requestPermissions` or `eth_requestAccounts` 
- add tests
- add `requestWalletPermissions` param when calling `checkout.connect` in sdk sample app