### PR TITLE
fix: [GPR-347][Sale widget] Handle failed/success events for individual transactions

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/events/sale.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/events/sale.ts
@@ -33,8 +33,10 @@ export type SaleSuccess = {
  * @property {Array} transactions
  */
 export type SaleFailed = {
-  /** The reason why the swap failed. */
+  /** The reason why sale transaction failed. */
   reason: string;
+  /** The error object. */
+  error: Record<string, unknown>;
   /** The timestamp of the failed swap. */
   timestamp: number;
   /** Chosen payment method */

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetEvents.ts
@@ -46,6 +46,7 @@ export const sendSaleSuccessEvent = (
 export const sendSaleFailedEvent = (
   eventTarget: Window | EventTarget,
   reason: string,
+  error: Record<string, unknown>,
   paymentMethod: SalePaymentTypes | undefined,
   transactions: ExecutedTransaction[] = [],
 ) => {
@@ -56,9 +57,10 @@ export const sendSaleFailedEvent = (
       type: SaleEventType.FAILURE,
       data: {
         reason,
-        timestamp: new Date().getTime(),
+        error,
         paymentMethod,
         transactions,
+        timestamp: new Date().getTime(),
       },
     },
   });

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -57,7 +57,9 @@ type SaleContextValues = SaleContextProps & {
     callback?: (response: SignResponse | undefined) => void
   ) => Promise<SignResponse | undefined>;
   execute: (
-    signResponse: SignResponse | undefined
+    signResponse: SignResponse | undefined,
+    onTxnSuccess: (txn: ExecutedTransaction) => void,
+    onTxnError: (error: any, txns: ExecutedTransaction[]) => void,
   ) => Promise<ExecutedTransaction[]>;
   recipientAddress: string;
   recipientEmail: string;

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
@@ -87,9 +87,9 @@ export const useSaleEvent = () => {
 
   const sendFailedEvent = (
     reason: string,
+    error: Record<string, unknown>,
     transactions: ExecutedTransaction[] = [],
     screen: string = defaultView,
-    details?: Record<string, unknown>,
   ) => {
     track({
       ...commonProps,
@@ -99,18 +99,18 @@ export const useSaleEvent = () => {
       action: 'Failed',
       extras: {
         transactions: toStringifyTransactions(transactions),
-        ...details,
+        ...error,
         ...orderProps,
         ...userProps,
         paymentMethod,
         reason,
       },
     });
-    sendSaleFailedEvent(eventTarget, reason, paymentMethod, transactions);
+    sendSaleFailedEvent(eventTarget, reason, error, paymentMethod, transactions);
   };
 
-  const sendTransactionSuccessEvent = (transactions: ExecutedTransaction[]) => {
-    sendSaleTransactionSuccessEvent(eventTarget, paymentMethod, transactions);
+  const sendTransactionSuccessEvent = (transaction: ExecutedTransaction) => {
+    sendSaleTransactionSuccessEvent(eventTarget, paymentMethod, [transaction]);
   };
 
   const sendSelectedPaymentMethod = (type: SalePaymentTypes, screen: string) => {

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
@@ -8,7 +8,7 @@ import { useSaleEvent } from '../hooks/useSaleEvents';
 export function PayWithCoins() {
   const { t } = useTranslation();
   const processing = useRef(false);
-  const { sendPageView, sendTransactionSuccessEvent } = useSaleEvent();
+  const { sendPageView, sendTransactionSuccessEvent, sendFailedEvent } = useSaleEvent();
   const {
     execute, signResponse, executeResponse, goToSuccessView,
   } = useSaleContext();
@@ -28,10 +28,15 @@ export function PayWithCoins() {
   }
 
   const sendTransaction = async () => {
-    const transactions = await execute(signResponse);
-    if (transactions.length !== expectedTxns) {
-      sendTransactionSuccessEvent(transactions);
-    }
+    execute(
+      signResponse,
+      (txn) => {
+        sendTransactionSuccessEvent(txn);
+      },
+      (error, txns) => {
+        sendFailedEvent(error.toString(), error, txns);
+      },
+    );
   };
 
   useEffect(() => {


### PR DESCRIPTION
# Summary
After a transaction is executed or cancelled handle the necessary events.

## Fixed
* A successful transaction event was being sent every time regardless of transaction completion


- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] Prefix your PR title with `breaking-change:` if you have introduced breaking changes to this SDK. Breaking changes are modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities. Ensure you write clear summary explain the change.
