### PR TITLE
feat: [WT-2071] Swap and Bridge Widget analytics update

### DIFF
--- a/packages/checkout/widgets-lib/src/context/view-context/SwapViewContextTypes.ts
+++ b/packages/checkout/widgets-lib/src/context/view-context/SwapViewContextTypes.ts
@@ -55,10 +55,6 @@ interface SwapInProgressView extends ViewType {
   data: {
     transactionResponse: TransactionResponse;
     swapForm: PrefilledSwapForm;
-    fromTokenAddress: string;
-    fromAmount: string;
-    toTokenAddress: string;
-    toAmount: string;
   }
 }
 export interface ApproveERC20SwapData {
@@ -71,4 +67,5 @@ export interface PrefilledSwapForm {
   fromAmount: string;
   fromTokenAddress: string;
   toTokenAddress: string;
+  toAmount?: string;
 }

--- a/packages/checkout/widgets-lib/src/context/view-context/SwapViewContextTypes.ts
+++ b/packages/checkout/widgets-lib/src/context/view-context/SwapViewContextTypes.ts
@@ -22,6 +22,10 @@ export type SwapWidgetView =
 export interface SwapSuccessView extends ViewType {
   type: SwapWidgetViews.SUCCESS;
   data: {
+    fromTokenAddress: string;
+    fromAmount: string;
+    toTokenAddress: string;
+    toAmount: string;
     transactionHash: string;
   }
 }
@@ -51,6 +55,10 @@ interface SwapInProgressView extends ViewType {
   data: {
     transactionResponse: TransactionResponse;
     swapForm: PrefilledSwapForm;
+    fromTokenAddress: string;
+    fromAmount: string;
+    toTokenAddress: string;
+    toAmount: string;
   }
 }
 export interface ApproveERC20SwapData {

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
@@ -197,6 +197,7 @@ export function BridgeReviewSummary() {
           isMetaMask: isMetaMaskProvider(to?.web3Provider),
         },
         amount,
+        fiatAmount: fromFiatAmount,
         tokenAddress: token?.address,
       },
     });

--- a/packages/checkout/widgets-lib/src/widgets/bridge/views/MoveInProgress.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/views/MoveInProgress.tsx
@@ -13,6 +13,8 @@ import { sendBridgeTransactionSentEvent, sendBridgeWidgetCloseEvent } from '../B
 import { FooterLogo } from '../../../components/Footer/FooterLogo';
 import { EventTargetContext } from '../../../context/event-target-context/EventTargetContext';
 import { BridgeContext } from '../context/BridgeContext';
+import { calculateCryptoToFiat } from '../../../lib/utils';
+import { CryptoFiatContext } from '../../../context/crypto-fiat-context/CryptoFiatContext';
 
 export interface MoveInProgressProps {
   transactionHash: string;
@@ -23,9 +25,16 @@ export function MoveInProgress({ transactionHash }: MoveInProgressProps) {
   const { eventTargetState: { eventTarget } } = useContext(EventTargetContext);
   const { page } = useAnalytics();
 
+  const { cryptoFiatState } = useContext(CryptoFiatContext);
   const { viewDispatch } = useContext(ViewContext);
   const {
-    bridgeState: { checkout },
+    bridgeState: {
+      checkout,
+      from,
+      to,
+      token,
+      amount,
+    },
   } = useContext(BridgeContext);
 
   useEffect(() => {
@@ -33,9 +42,18 @@ export function MoveInProgress({ transactionHash }: MoveInProgressProps) {
       eventTarget,
       transactionHash,
     );
+
+    const fiatAmount = calculateCryptoToFiat(amount, token?.symbol ?? '', cryptoFiatState.conversions);
     page({
       userJourney: UserJourney.BRIDGE,
       screen: 'InProgress',
+      extras: {
+        fromWalletAddress: from?.walletAddress,
+        toWalletAddress: to?.walletAddress,
+        amount,
+        fiatAmount,
+        tokenAddress: token?.address,
+      },
     });
   }, []);
 

--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
@@ -243,6 +243,12 @@ export function SwapWidget({
               page({
                 userJourney: UserJourney.SWAP,
                 screen: 'SwapSuccess',
+                extras: {
+                  fromTokenAddress: viewState.view.data?.fromTokenAddress,
+                  fromAmount: viewState.view.data?.fromAmount,
+                  toTokenAddress: viewState.view.data?.toTokenAddress,
+                  toAmount: viewState.view.data?.toAmount,
+                },
               });
               sendSwapSuccessEvent(
                 eventTarget,

--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
@@ -230,10 +230,6 @@ export function SwapWidget({
           <SwapInProgress
             transactionResponse={viewState.view.data.transactionResponse}
             swapForm={viewState.view.data.swapForm}
-            fromTokenAddress={viewState.view.data.fromTokenAddress}
-            fromAmount={viewState.view.data.fromAmount}
-            toTokenAddress={viewState.view.data.toTokenAddress}
-            toAmount={viewState.view.data.toAmount}
           />
           )}
           {viewState.view.type === SwapWidgetViews.APPROVE_ERC20 && (

--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
@@ -230,6 +230,10 @@ export function SwapWidget({
           <SwapInProgress
             transactionResponse={viewState.view.data.transactionResponse}
             swapForm={viewState.view.data.swapForm}
+            fromTokenAddress={viewState.view.data.fromTokenAddress}
+            fromAmount={viewState.view.data.fromAmount}
+            toTokenAddress={viewState.view.data.toTokenAddress}
+            toAmount={viewState.view.data.toAmount}
           />
           )}
           {viewState.view.type === SwapWidgetViews.APPROVE_ERC20 && (

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapButton.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapButton.tsx
@@ -70,6 +70,7 @@ export function SwapButton({
         fromAmount: data?.fromAmount || '',
         fromTokenAddress: data?.fromTokenAddress || '',
         toTokenAddress: data?.toTokenAddress || '',
+        toAmount: data?.toAmount || '',
       };
 
       if (transaction.approval) {
@@ -104,10 +105,6 @@ export function SwapButton({
             data: {
               transactionResponse: txn.transactionResponse,
               swapForm: prefilledSwapData as PrefilledSwapForm,
-              fromTokenAddress: data?.fromTokenAddress ?? '',
-              fromAmount: data?.fromAmount ?? '',
-              toTokenAddress: data?.toTokenAddress ?? '',
-              toAmount: data?.toAmount ?? '',
             },
           },
         },

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapButton.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapButton.tsx
@@ -104,6 +104,10 @@ export function SwapButton({
             data: {
               transactionResponse: txn.transactionResponse,
               swapForm: prefilledSwapData as PrefilledSwapForm,
+              fromTokenAddress: data?.fromTokenAddress ?? '',
+              fromAmount: data?.fromAmount ?? '',
+              toTokenAddress: data?.toTokenAddress ?? '',
+              toAmount: data?.toAmount ?? '',
             },
           },
         },

--- a/packages/checkout/widgets-lib/src/widgets/swap/views/SwapInProgress.cy.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/SwapInProgress.cy.tsx
@@ -26,6 +26,7 @@ describe('SwapInProgress View', () => {
             fromAmount: '',
             fromTokenAddress: '',
             toTokenAddress: '',
+            toAmount: '',
           }}
         />
       </SwapWidgetTestComponent>,

--- a/packages/checkout/widgets-lib/src/widgets/swap/views/SwapInProgress.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/SwapInProgress.tsx
@@ -15,19 +15,11 @@ import { UserJourney, useAnalytics } from '../../../context/analytics-provider/S
 interface SwapInProgressProps {
   transactionResponse: TransactionResponse;
   swapForm: PrefilledSwapForm;
-  fromTokenAddress: string;
-  fromAmount: string;
-  toTokenAddress: string;
-  toAmount: string;
 }
 
 export function SwapInProgress({
   transactionResponse,
   swapForm,
-  fromTokenAddress,
-  fromAmount,
-  toTokenAddress,
-  toAmount,
 }: SwapInProgressProps) {
   const { t } = useTranslation();
   const { viewDispatch } = useContext(ViewContext);
@@ -56,10 +48,10 @@ export function SwapInProgress({
               view: {
                 type: SwapWidgetViews.SUCCESS,
                 data: {
-                  fromTokenAddress,
-                  fromAmount,
-                  toTokenAddress,
-                  toAmount,
+                  fromTokenAddress: swapForm.fromTokenAddress,
+                  fromAmount: swapForm.fromAmount,
+                  toTokenAddress: swapForm.toTokenAddress,
+                  toAmount: swapForm.toAmount || '',
                   transactionHash: receipt.transactionHash,
                 },
               },

--- a/packages/checkout/widgets-lib/src/widgets/swap/views/SwapInProgress.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/SwapInProgress.tsx
@@ -15,9 +15,20 @@ import { UserJourney, useAnalytics } from '../../../context/analytics-provider/S
 interface SwapInProgressProps {
   transactionResponse: TransactionResponse;
   swapForm: PrefilledSwapForm;
+  fromTokenAddress: string;
+  fromAmount: string;
+  toTokenAddress: string;
+  toAmount: string;
 }
 
-export function SwapInProgress({ transactionResponse, swapForm }: SwapInProgressProps) {
+export function SwapInProgress({
+  transactionResponse,
+  swapForm,
+  fromTokenAddress,
+  fromAmount,
+  toTokenAddress,
+  toAmount,
+}: SwapInProgressProps) {
   const { t } = useTranslation();
   const { viewDispatch } = useContext(ViewContext);
 
@@ -45,10 +56,10 @@ export function SwapInProgress({ transactionResponse, swapForm }: SwapInProgress
               view: {
                 type: SwapWidgetViews.SUCCESS,
                 data: {
-                  // fromTokenAddress: swapForm.fromTokenAddress,
-                  // fromAmount:swapForm.fromAmount,
-                  // toTokenAddress: swapForm.toTokenAddress,
-                  // toAmount: viewState.view.data?.toAmount,
+                  fromTokenAddress,
+                  fromAmount,
+                  toTokenAddress,
+                  toAmount,
                   transactionHash: receipt.transactionHash,
                 },
               },

--- a/packages/checkout/widgets-lib/src/widgets/swap/views/SwapInProgress.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/SwapInProgress.tsx
@@ -45,6 +45,10 @@ export function SwapInProgress({ transactionResponse, swapForm }: SwapInProgress
               view: {
                 type: SwapWidgetViews.SUCCESS,
                 data: {
+                  // fromTokenAddress: swapForm.fromTokenAddress,
+                  // fromAmount:swapForm.fromAmount,
+                  // toTokenAddress: swapForm.toTokenAddress,
+                  // toAmount: viewState.view.data?.toAmount,
                   transactionHash: receipt.transactionHash,
                 },
               },


### PR DESCRIPTION
# Summary
Added additional tracking analytics to the Swap and Bridget Widgets success events.
https://immutable.atlassian.net/browse/WT-2071

`checkoutSwapSwapSuccess` includes fromAmount, fromTokenAddress, toAmount, toTokenAddress
<img width="461" alt="Screenshot 2024-01-30 at 2 07 24 pm" src="https://github.com/immutable/ts-immutable-sdk/assets/1617003/7ce3c1db-066b-467c-b1a0-5e4d285c119b">

`checkoutBridgeInProgress` includes fromWalletAddress, toWalletAddress, amount, fiatAmount, tokenAddress
<img width="476" alt="Screenshot 2024-01-30 at 2 09 26 pm" src="https://github.com/immutable/ts-immutable-sdk/assets/1617003/cd06a0bc-9233-4d09-8e94-49a2a4b09d48">


