### PR TITLE
fix: [Sale Widget] Enable retries after a Transak order fails

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
@@ -212,7 +212,7 @@ export const useSignOrder = (input: SignOrderInput) => {
         }`.toLowerCase();
         transactionHash = (err as any)?.transactionHash;
 
-        let errorType = SaleErrorTypes.DEFAULT;
+        let errorType = SaleErrorTypes.WALLET_FAILED;
         if (reason.includes('rejected') && reason.includes('user')) {
           errorType = SaleErrorTypes.WALLET_REJECTED;
         }

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/SaleErrorView.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/SaleErrorView.tsx
@@ -67,9 +67,7 @@ export function SaleErrorView({
       },
     },
     [SaleErrorTypes.TRANSAK_FAILED]: {
-      onActionClick: () => {
-        /* TODO: start over the transak flow */
-      },
+      onActionClick: goBackToPaymentMethods,
       onSecondaryActionClick: closeWidget,
       statusType: StatusType.INFORMATION,
     },
@@ -103,11 +101,6 @@ export function SaleErrorView({
       onSecondaryActionClick: closeWidget,
       statusType: StatusType.INFORMATION,
     },
-    [SaleErrorTypes.DEFAULT]: {
-      onActionClick: goBackToPaymentMethods,
-      onSecondaryActionClick: closeWidget,
-      statusType: StatusType.INFORMATION,
-    },
     [SaleErrorTypes.INVALID_PARAMETERS]: {
       onSecondaryActionClick: closeWidget,
       statusType: StatusType.ALERT,
@@ -115,6 +108,11 @@ export function SaleErrorView({
         fill: biomeTheme.color.status.attention.dim,
         transform: 'none',
       },
+    },
+    [SaleErrorTypes.DEFAULT]: {
+      onActionClick: goBackToPaymentMethods,
+      onSecondaryActionClick: closeWidget,
+      statusType: StatusType.INFORMATION,
     },
   };
 


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
After Transak emits event `"TRANSAK_ORDER_FAILED"` allow user to retry by redirecting them to Payment Methods view