### PR TITLE
Small bridge txn fixes

### DIFF
--- a/packages/checkout/widgets-lib/src/components/Transactions/Transactions.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/Transactions.tsx
@@ -232,6 +232,31 @@ export function Transactions({ onBackButtonClick }: TransactionsProps) {
     return client.getTransactions({ txType: TransactionType.BRIDGE, fromAddress: address });
   }, []);
 
+  const handleBackButtonClick = () => {
+    if (from) {
+      bridgeDispatch({
+        payload: {
+          type: BridgeActions.SET_WALLETS_AND_NETWORKS,
+          from: {
+            web3Provider: from?.web3Provider,
+            walletAddress: from?.walletAddress,
+            network: from?.network,
+          },
+          to: null,
+        },
+      });
+      bridgeDispatch({
+        payload: {
+          type: BridgeActions.SET_TOKEN_AND_AMOUNT,
+          token: null,
+          amount: '',
+        },
+      });
+    }
+
+    onBackButtonClick();
+  };
+
   const fetchData = useCallback(async () => {
     if (!from?.walletAddress) return undefined;
 
@@ -281,7 +306,7 @@ export function Transactions({ onBackButtonClick }: TransactionsProps) {
 
       setLoading(false);
     })();
-  }, [from?.walletAddress, checkout]);
+  }, [from, checkout]);
 
   useEffect(() => {
     page({
@@ -296,7 +321,7 @@ export function Transactions({ onBackButtonClick }: TransactionsProps) {
       header={(
         <HeaderNavigation
           showBack
-          onBackButtonClick={onBackButtonClick}
+          onBackButtonClick={handleBackButtonClick}
           title={t('views.TRANSACTIONS.layoutHeading')}
           onCloseButtonClick={() => sendBridgeWidgetCloseEvent(eventTarget)}
         />

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
@@ -34,7 +34,6 @@ import {
 import { SelectForm } from '../../../components/FormComponents/SelectForm/SelectForm';
 import { validateAmount, validateToken } from '../functions/BridgeFormValidator';
 import {
-  bridgeButtonIconLoadingStyle,
   bridgeFormButtonContainerStyles,
   bridgeFormWrapperStyles,
   formInputsContainerStyles,
@@ -472,7 +471,6 @@ export function BridgeForm(props: BridgeFormProps) {
               textAlign="left"
               errorMessage={t(tokenError)}
               onSelectChange={(option) => handleSelectTokenChange(option)}
-              disabled={isFetching}
             />
             <TextInputForm
               testId="bridge-amount"
@@ -485,7 +483,6 @@ export function BridgeForm(props: BridgeFormProps) {
               onTextInputBlur={(value) => handleAmountInputBlur(value)}
               textAlign="right"
               errorMessage={t(amountError)}
-              disabled={isFetching}
             />
           </Box>
         )}
@@ -533,12 +530,9 @@ export function BridgeForm(props: BridgeFormProps) {
           testId={`${testId}-button`}
           variant="primary"
           onClick={submitBridge}
-          disabled={loading}
           size="large"
         >
-          {loading ? (
-            <Button.Icon icon="Loading" sx={bridgeButtonIconLoadingStyle} />
-          ) : t('views.BRIDGE_FORM.bridgeForm.buttonText')}
+          {t('views.BRIDGE_FORM.bridgeForm.buttonText')}
         </Button>
         <TransactionRejected
           visible={showTxnRejectedState}

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
@@ -539,7 +539,6 @@ export function BridgeForm(props: BridgeFormProps) {
           {loading ? (
             <Button.Icon icon="Loading" sx={bridgeButtonIconLoadingStyle} />
           ) : t('views.BRIDGE_FORM.bridgeForm.buttonText')}
-          {t('views.BRIDGE_FORM.bridgeForm.buttonText')}
         </Button>
         <TransactionRejected
           visible={showTxnRejectedState}

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
@@ -34,6 +34,7 @@ import {
 import { SelectForm } from '../../../components/FormComponents/SelectForm/SelectForm';
 import { validateAmount, validateToken } from '../functions/BridgeFormValidator';
 import {
+  bridgeButtonIconLoadingStyle,
   bridgeFormButtonContainerStyles,
   bridgeFormWrapperStyles,
   formInputsContainerStyles,
@@ -471,6 +472,7 @@ export function BridgeForm(props: BridgeFormProps) {
               textAlign="left"
               errorMessage={t(tokenError)}
               onSelectChange={(option) => handleSelectTokenChange(option)}
+              disabled={isFetching}
             />
             <TextInputForm
               testId="bridge-amount"
@@ -483,6 +485,7 @@ export function BridgeForm(props: BridgeFormProps) {
               onTextInputBlur={(value) => handleAmountInputBlur(value)}
               textAlign="right"
               errorMessage={t(amountError)}
+              disabled={isFetching}
             />
           </Box>
         )}
@@ -530,8 +533,12 @@ export function BridgeForm(props: BridgeFormProps) {
           testId={`${testId}-button`}
           variant="primary"
           onClick={submitBridge}
+          disabled={loading}
           size="large"
         >
+          {loading ? (
+            <Button.Icon icon="Loading" sx={bridgeButtonIconLoadingStyle} />
+          ) : t('views.BRIDGE_FORM.bridgeForm.buttonText')}
           {t('views.BRIDGE_FORM.bridgeForm.buttonText')}
         </Button>
         <TransactionRejected


### PR DESCRIPTION
## Bridge fix

When clicking back from the Transactions screen, reset the to wallet in state so that wallets are not pre-filled in the wallet network selector.

Also, re-fetch transactions on wallet change in the transactions screen.
