### PR TITLE
fix: NOJIRA passport dev fix

### DIFF
--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -1,5 +1,6 @@
 import { IMXProvider } from '@imtbl/x-provider';
 import {
+  createConfig,
   ImxApiClients,
   imxApiConfig,
   MultiRollupApiClients,
@@ -60,7 +61,7 @@ export class Passport {
       ? imxApiConfig.getProduction()
       : imxApiConfig.getSandbox();
     const imxApiClients = passportModuleConfiguration.overrides?.imxApiClients
-      ?? (passportModuleConfiguration.overrides?.imxPublicApiDomain
+      || (passportModuleConfiguration.overrides?.imxPublicApiDomain
         ? new ImxApiClients(createConfig({ basePath: passportModuleConfiguration.overrides.imxPublicApiDomain }))
         : new ImxApiClients(imxClientConfig));
 

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -60,7 +60,9 @@ export class Passport {
       ? imxApiConfig.getProduction()
       : imxApiConfig.getSandbox();
     const imxApiClients = passportModuleConfiguration.overrides?.imxApiClients
-      || new ImxApiClients(imxClientConfig);
+      ?? (passportModuleConfiguration.overrides?.imxPublicApiDomain
+        ? new ImxApiClients(createConfig({ basePath: passportModuleConfiguration.overrides.imxPublicApiDomain }))
+        : new ImxApiClients(imxClientConfig));
 
     this.passportImxProviderFactory = new PassportImxProviderFactory({
       authManager: this.authManager,

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -27,6 +27,59 @@ import { ZkEvmProvider } from './zkEvm';
 import { Provider } from './zkEvm/types';
 import TypedEventEmitter from './utils/typedEventEmitter';
 
+const buildImxClientConfig = (passportModuleConfiguration: PassportModuleConfiguration) => {
+  if (passportModuleConfiguration.overrides) {
+    return createConfig({ basePath: passportModuleConfiguration.overrides.imxPublicApiDomain });
+  }
+  if (passportModuleConfiguration.baseConfig.environment === Environment.SANDBOX) {
+    return imxApiConfig.getSandbox();
+  }
+  return imxApiConfig.getProduction();
+};
+
+const buildImxApiClients = (passportModuleConfiguration: PassportModuleConfiguration) => {
+  if (passportModuleConfiguration.overrides?.imxApiClients) return passportModuleConfiguration.overrides.imxApiClients;
+
+  const config = buildImxClientConfig(passportModuleConfiguration);
+  return new ImxApiClients(config);
+};
+
+export const buildPrivateVars = (passportModuleConfiguration: PassportModuleConfiguration) => {
+  const config = new PassportConfiguration(passportModuleConfiguration);
+  const authManager = new AuthManager(config);
+  const magicAdapter = new MagicAdapter(config);
+  const confirmationScreen = new ConfirmationScreen(config);
+  const multiRollupApiClients = new MultiRollupApiClients(config.multiRollupConfig);
+  const passportEventEmitter = new TypedEventEmitter<PassportEventMap>();
+
+  const immutableXClient = passportModuleConfiguration.overrides
+    ? passportModuleConfiguration.overrides.immutableXClient
+    : new IMXClient({ baseConfig: passportModuleConfiguration.baseConfig });
+
+  const imxApiClients = buildImxApiClients(passportModuleConfiguration);
+
+  const passportImxProviderFactory = new PassportImxProviderFactory({
+    authManager,
+    config,
+    confirmationScreen,
+    immutableXClient,
+    magicAdapter,
+    passportEventEmitter,
+    imxApiClients,
+  });
+
+  return {
+    config,
+    authManager,
+    magicAdapter,
+    confirmationScreen,
+    immutableXClient,
+    multiRollupApiClients,
+    passportEventEmitter,
+    passportImxProviderFactory,
+  };
+};
+
 export class Passport {
   private readonly authManager: AuthManager;
 
@@ -45,35 +98,16 @@ export class Passport {
   private readonly passportEventEmitter: TypedEventEmitter<PassportEventMap>;
 
   constructor(passportModuleConfiguration: PassportModuleConfiguration) {
-    this.config = new PassportConfiguration(passportModuleConfiguration);
-    this.authManager = new AuthManager(this.config);
-    this.magicAdapter = new MagicAdapter(this.config);
-    this.confirmationScreen = new ConfirmationScreen(this.config);
-    this.immutableXClient = passportModuleConfiguration.overrides?.immutableXClient
-      || new IMXClient({
-        baseConfig: passportModuleConfiguration.baseConfig,
-      });
-    this.multiRollupApiClients = new MultiRollupApiClients(
-      this.config.multiRollupConfig,
-    );
-    this.passportEventEmitter = new TypedEventEmitter<PassportEventMap>();
-    const imxClientConfig = this.config.baseConfig.environment === Environment.PRODUCTION
-      ? imxApiConfig.getProduction()
-      : imxApiConfig.getSandbox();
-    const imxApiClients = passportModuleConfiguration.overrides?.imxApiClients
-      || (passportModuleConfiguration.overrides?.imxPublicApiDomain
-        ? new ImxApiClients(createConfig({ basePath: passportModuleConfiguration.overrides.imxPublicApiDomain }))
-        : new ImxApiClients(imxClientConfig));
+    const privateVars = buildPrivateVars(passportModuleConfiguration);
 
-    this.passportImxProviderFactory = new PassportImxProviderFactory({
-      authManager: this.authManager,
-      config: this.config,
-      confirmationScreen: this.confirmationScreen,
-      immutableXClient: this.immutableXClient,
-      magicAdapter: this.magicAdapter,
-      passportEventEmitter: this.passportEventEmitter,
-      imxApiClients,
-    });
+    this.config = privateVars.config;
+    this.authManager = privateVars.authManager;
+    this.magicAdapter = privateVars.magicAdapter;
+    this.confirmationScreen = privateVars.confirmationScreen;
+    this.immutableXClient = privateVars.immutableXClient;
+    this.multiRollupApiClients = privateVars.multiRollupApiClients;
+    this.passportEventEmitter = privateVars.passportEventEmitter;
+    this.passportImxProviderFactory = privateVars.passportImxProviderFactory;
 
     setPassportClientId(passportModuleConfiguration.clientId);
     track('passport', 'initialised');

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -101,6 +101,7 @@ export default class AuthManager {
     this.userManager = new UserManager(getAuthConfiguration(config));
     this.deviceCredentialsManager = new DeviceCredentialsManager();
     this.logoutMode = config.oidcConfiguration.logoutMode || 'redirect';
+    this.userManager.events.addSilentRenewError(() => this.logout());
   }
 
   private static mapOidcUserToDomainModel = (oidcUser: OidcUser): User => {

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -101,7 +101,6 @@ export default class AuthManager {
     this.userManager = new UserManager(getAuthConfiguration(config));
     this.deviceCredentialsManager = new DeviceCredentialsManager();
     this.logoutMode = config.oidcConfiguration.logoutMode || 'redirect';
-    this.userManager.events.addSilentRenewError(() => this.logout());
   }
 
   private static mapOidcUserToDomainModel = (oidcUser: OidcUser): User => {

--- a/packages/passport/sdk/src/starkEx/passportImxProvider.ts
+++ b/packages/passport/sdk/src/starkEx/passportImxProvider.ts
@@ -20,10 +20,10 @@ import {
 } from '@imtbl/core-sdk';
 import { IMXClient } from '@imtbl/x-client';
 import { IMXProvider } from '@imtbl/x-provider';
-import AuthManager from 'authManager';
-import TypedEventEmitter from 'utils/typedEventEmitter';
 import { Web3Provider } from '@ethersproject/providers';
 import { ImxApiClients } from '@imtbl/generated-clients';
+import TypedEventEmitter from '../utils/typedEventEmitter';
+import AuthManager from '../authManager';
 import GuardianClient from '../guardian/guardian';
 import {
   PassportEventMap, PassportEvents, UserImx, User, IMXSigners,

--- a/packages/passport/sdk/src/starkEx/passportImxProviderFactory.ts
+++ b/packages/passport/sdk/src/starkEx/passportImxProviderFactory.ts
@@ -33,7 +33,7 @@ export class PassportImxProviderFactory {
 
   private readonly passportEventEmitter: TypedEventEmitter<PassportEventMap>;
 
-  private readonly imxApiClients: ImxApiClients;
+  public readonly imxApiClients: ImxApiClients;
 
   constructor({
     authManager,

--- a/packages/passport/sdk/src/types.ts
+++ b/packages/passport/sdk/src/types.ts
@@ -58,12 +58,12 @@ export interface PassportOverrides {
   passportDomain: string;
   imxPublicApiDomain: string;
   immutableXClient: IMXClient;
-  imxApiClients: ImxApiClients;
   zkEvmRpcUrl: string;
   relayerUrl: string;
   indexerMrBasePath: string;
   orderBookMrBasePath: string;
   passportMrBasePath: string;
+  imxApiClients?: ImxApiClients; // needs to be optional because ImxApiClients is not exposed publicly
 }
 
 export interface PassportModuleConfiguration extends ModuleConfiguration<PassportOverrides>,


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
The current overrides prevents us from using the dev environment with Passport outside of the SDK because `ImxApiClients` is an internal package. This fixes that by using the existing `imxPublicApiDomain` override to create the client. 

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
