### PR TITLE
chore: Revert husky pre-commit script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+/.husky @immutable/sdk
 /sdk @immutable/sdk
 /packages/x-client @immutable/sdk
 /packages/config @immutable/sdk

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
-yarn test --watchAll=false


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
Remove the Jest test command from the Husky pre-commit hook. It should not have been added.

# Detail and impact of the change

## Removed
- Test command in the pre-commit hook.

# Anything else worth calling out?
SDK team has been added as the owner of the `.husky` folder. Other teams should not be touching those files. 
