### PR TITLE
feat: [WT-2101] Map token icons in Checkout Widgets

### DIFF
--- a/packages/checkout/sdk/src/balances/balances.ts
+++ b/packages/checkout/sdk/src/balances/balances.ts
@@ -1,6 +1,7 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { BigNumber, Contract, utils } from 'ethers';
 import { HttpStatusCode } from 'axios';
+import { Environment } from '@imtbl/config';
 import {
   ChainId,
   GetAllBalancesResult,
@@ -11,7 +12,7 @@ import {
 } from '../types';
 import { CheckoutError, CheckoutErrorType, withCheckoutError } from '../errors';
 import { getNetworkInfo } from '../network';
-import { getERC20TokenInfo, getTokenAllowList } from '../tokens';
+import { getERC20TokenInfo, getTokenAllowList, isNativeToken } from '../tokens';
 import { CheckoutConfiguration, getL1ChainId } from '../config';
 import {
   Blockscout,
@@ -20,10 +21,15 @@ import {
   BlockscoutTokenType,
 } from '../api/blockscout';
 import {
+  CHECKOUT_CDN_BASE_URL,
   DEFAULT_TOKEN_DECIMALS, ERC20ABI, NATIVE,
 } from '../env';
 import { measureAsyncExecution } from '../logger/debugLogger';
 import { isMatchingAddress } from '../utils/utils';
+
+function getTokenImageByAddress(environment: Environment, address: string) {
+  return `${CHECKOUT_CDN_BASE_URL[environment]}/v1/blob/img/tokens/${address.toLowerCase()}.svg`;
+}
 
 export const getBalance = async (
   config: CheckoutConfiguration,
@@ -197,6 +203,8 @@ export const getIndexerBalance = async (
 
     const token = {
       ...tokenData,
+      icon: getTokenImageByAddress(config.environment as Environment, (isNativeToken(tokenData.address)
+        ? tokenData.symbol.toLowerCase() : tokenData.address as string)),
       decimals,
     };
 

--- a/packages/checkout/sdk/src/balances/balances.ts
+++ b/packages/checkout/sdk/src/balances/balances.ts
@@ -1,7 +1,6 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { BigNumber, Contract, utils } from 'ethers';
 import { HttpStatusCode } from 'axios';
-import { Environment } from '@imtbl/config';
 import {
   ChainId,
   GetAllBalancesResult,
@@ -12,7 +11,7 @@ import {
 } from '../types';
 import { CheckoutError, CheckoutErrorType, withCheckoutError } from '../errors';
 import { getNetworkInfo } from '../network';
-import { getERC20TokenInfo, getTokenAllowList, isNativeToken } from '../tokens';
+import { getERC20TokenInfo, getTokenAllowList } from '../tokens';
 import { CheckoutConfiguration, getL1ChainId } from '../config';
 import {
   Blockscout,
@@ -21,15 +20,10 @@ import {
   BlockscoutTokenType,
 } from '../api/blockscout';
 import {
-  CHECKOUT_CDN_BASE_URL,
   DEFAULT_TOKEN_DECIMALS, ERC20ABI, NATIVE,
 } from '../env';
 import { measureAsyncExecution } from '../logger/debugLogger';
 import { isMatchingAddress } from '../utils/utils';
-
-function getTokenImageByAddress(environment: Environment, address: string) {
-  return `${CHECKOUT_CDN_BASE_URL[environment]}/v1/blob/img/tokens/${address.toLowerCase()}.svg`;
-}
 
 export const getBalance = async (
   config: CheckoutConfiguration,
@@ -203,8 +197,6 @@ export const getIndexerBalance = async (
 
     const token = {
       ...tokenData,
-      icon: getTokenImageByAddress(config.environment as Environment, (isNativeToken(tokenData.address)
-        ? tokenData.symbol.toLowerCase() : tokenData.address as string)),
       decimals,
     };
 

--- a/packages/checkout/widgets-lib/src/components/Transactions/TransactionItem.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/TransactionItem.tsx
@@ -19,8 +19,9 @@ type TransactionItemProps = {
     hash: string,
   },
   transaction: Transaction,
-  fiatAmount: string
-  amount: string
+  fiatAmount: string,
+  amount: string,
+  icon: string,
 };
 
 export function TransactionItem({
@@ -29,6 +30,7 @@ export function TransactionItem({
   transaction,
   fiatAmount,
   amount,
+  icon,
 }: TransactionItemProps) {
   const { track } = useAnalytics();
 
@@ -75,7 +77,7 @@ export function TransactionItem({
       >
         <Accordion.TargetLeftSlot sx={{ pr: 'base.spacing.x2' }}>
           <MenuItem size="xSmall">
-            <MenuItem.FramedIcon icon="Coins" circularFrame />
+            <MenuItem.FramedImage imageUrl={icon} circularFrame />
             <MenuItem.Label>
               {label}
             </MenuItem.Label>

--- a/packages/checkout/widgets-lib/src/components/Transactions/TransactionItemWithdrawPending.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/TransactionItemWithdrawPending.tsx
@@ -17,10 +17,11 @@ import { actionsContainerStyles, actionsLayoutStyles, containerStyles } from './
 import { TransactionDetails } from './TransactionDetails';
 
 type TransactionItemWithdrawPendingProps = {
-  label: string
+  label: string,
   transaction: Transaction,
-  fiatAmount: string
-  amount: string
+  fiatAmount: string,
+  amount: string,
+  icon: string,
 };
 
 export function TransactionItemWithdrawPending({
@@ -28,6 +29,7 @@ export function TransactionItemWithdrawPending({
   transaction,
   fiatAmount,
   amount,
+  icon,
 }: TransactionItemWithdrawPendingProps) {
   const { viewDispatch } = useContext(ViewContext);
   const { track } = useAnalytics();
@@ -146,7 +148,7 @@ export function TransactionItemWithdrawPending({
       >
         <Accordion.TargetLeftSlot sx={{ pr: 'base.spacing.x2' }}>
           <MenuItem size="xSmall">
-            <MenuItem.FramedIcon icon="Coins" circularFrame />
+            <MenuItem.FramedImage imageUrl={icon} circularFrame />
             <MenuItem.Label>
               {label}
             </MenuItem.Label>

--- a/packages/checkout/widgets-lib/src/components/Transactions/TransactionList.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/TransactionList.tsx
@@ -4,12 +4,14 @@ import {
 import { Checkout } from '@imtbl/checkout-sdk';
 import {
   useCallback,
-  useContext, useEffect, useState,
+  useContext,
+  useEffect,
+  useState,
 } from 'react';
 import { AXELAR_SCAN_URL } from 'lib';
 import { Transaction, TransactionStatus } from 'lib/clients';
 import { CryptoFiatContext } from 'context/crypto-fiat-context/CryptoFiatContext';
-import { calculateCryptoToFiat } from 'lib/utils';
+import { calculateCryptoToFiat, getTokenImageByAddress, isNativeToken } from 'lib/utils';
 import { formatUnits } from 'ethers/lib/utils';
 import { useTranslation } from 'react-i18next';
 import { TransactionItem } from './TransactionItem';
@@ -17,6 +19,7 @@ import { KnownNetworkMap } from './transactionsType';
 import { containerStyles, transactionsListStyle } from './TransactionListStyles';
 import { TransactionItemWithdrawPending } from './TransactionItemWithdrawPending';
 import { ChangeWallet } from './ChangeWallet';
+import { getNativeSymbolByChainSlug } from '../../lib/chains';
 
 type TransactionListProps = {
   checkout: Checkout,
@@ -50,6 +53,17 @@ export function TransactionList({
 
     return 1;
   }, []);
+
+  const getTransactionItemIcon = useCallback((transaction) => {
+    if (isNativeToken(transaction.details.from_token_address)) {
+      // Map transaction chain slug to native symbol icon asset
+      return getTokenImageByAddress(
+        checkout.config.environment,
+        getNativeSymbolByChainSlug(transaction.details.from_chain),
+      );
+    }
+    return getTokenImageByAddress(checkout.config.environment, transaction.details.from_token_address);
+  }, [checkout]);
 
   return (
     <Box sx={transactionsListStyle(isPassport)}>
@@ -87,6 +101,7 @@ export function TransactionList({
                 transaction={transaction}
                 fiatAmount={`${t('views.TRANSACTIONS.fiatPricePrefix')}${fiat}`}
                 amount={amount}
+                icon={getTransactionItemIcon(transaction)}
               />
             );
           })}

--- a/packages/checkout/widgets-lib/src/components/Transactions/TransactionList.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/TransactionList.tsx
@@ -89,6 +89,7 @@ export function TransactionList({
                   transaction={transaction}
                   fiatAmount={`${t('views.TRANSACTIONS.fiatPricePrefix')}${fiat}`}
                   amount={amount}
+                  icon={getTransactionItemIcon(transaction)}
                 />
               );
             }

--- a/packages/checkout/widgets-lib/src/lib/balance.test.ts
+++ b/packages/checkout/widgets-lib/src/lib/balance.test.ts
@@ -61,8 +61,11 @@ describe('getAllowedBalances', () => {
       tokens: [
         {
           address: '0xQ',
+          symbol: 'QQQ',
         } as unknown as TokenInfo,
-        {} as unknown as TokenInfo, // <<< allows NATIVE -- no address
+        {
+          symbol: 'IMX',
+        } as unknown as TokenInfo, // <<< allows NATIVE -- no address
       ],
     });
 
@@ -75,8 +78,15 @@ describe('getAllowedBalances', () => {
     expect(resp).toEqual({
       allowList: {
         tokens: [
-          { address: tokenInfo.token.address },
-          { address: nativeTokenInfo.token.address },
+          {
+            address: tokenInfo.token.address,
+            symbol: 'QQQ',
+            icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xq.svg',
+          },
+          {
+            symbol: 'IMX',
+            icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/imx.svg',
+          },
         ],
       },
       allowedBalances: [
@@ -189,7 +199,10 @@ describe('getAllowedBalances', () => {
 
     expect(resp).toEqual({
       allowList: {
-        tokens: [{ address: tokenInfo.token.address }],
+        tokens: [{
+          address: tokenInfo.token.address,
+          icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xq.svg',
+        }],
       },
       allowedBalances: [tokenInfo],
     });
@@ -240,6 +253,53 @@ describe('getAllowedBalances', () => {
     expect(error.data.code).toEqual(12);
   });
 
+  it('should map asset icons to erc20 address and native token symbol', async () => {
+    const checkout = new Checkout({
+      baseConfig: { environment: Environment.PRODUCTION },
+    });
+
+    const mockProvider = {
+      getSigner: jest.fn().mockReturnValue({
+        getAddress: jest.fn().mockResolvedValue('0xaddress'),
+      }),
+    };
+    jest.spyOn(checkout, 'getNetworkInfo').mockResolvedValue(
+      { chainId: ChainId.IMTBL_ZKEVM_MAINNET } as unknown as NetworkInfo,
+    );
+    jest.spyOn(checkout, 'getAllBalances').mockResolvedValue({ balances });
+    jest.spyOn(checkout, 'getTokenAllowList').mockResolvedValue({
+      tokens: [
+        {
+          address: '0xA',
+          symbol: 'XAA',
+        } as unknown as TokenInfo,
+        {
+          symbol: 'XBB',
+        } as unknown as TokenInfo,
+      ],
+    });
+
+    const resp = await getAllowedBalances({
+      checkout,
+      provider: mockProvider as unknown as Web3Provider,
+      allowTokenListType: TokenFilterTypes.BRIDGE,
+    });
+
+    expect(resp?.allowList).toEqual({
+      tokens: [
+        {
+          address: '0xA',
+          symbol: 'XAA',
+          icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xa.svg',
+        },
+        {
+          symbol: 'XBB',
+          icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/xbb.svg',
+        },
+      ],
+    });
+  });
+
   it('should not return zero balances', async () => {
     const checkout = new Checkout({
       baseConfig: { environment: Environment.PRODUCTION },
@@ -270,7 +330,10 @@ describe('getAllowedBalances', () => {
 
     expect(resp).toEqual({
       allowList: {
-        tokens: [{ address: '0xA' }],
+        tokens: [{
+          address: '0xA',
+          icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xa.svg',
+        }],
       },
       allowedBalances: [],
     });
@@ -306,7 +369,10 @@ describe('getAllowedBalances', () => {
 
     expect(resp).toEqual({
       allowList: {
-        tokens: [{ address: '0xD' }],
+        tokens: [{
+          address: '0xD',
+          icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xd.svg',
+        }],
       },
       allowedBalances: [{
         balance: BigNumber.from(1),
@@ -346,7 +412,10 @@ describe('getAllowedBalances', () => {
 
     expect(resp).toEqual({
       allowList: {
-        tokens: [{ address: '0xA' }],
+        tokens: [{
+          address: '0xA',
+          icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xa.svg',
+        }],
       },
       allowedBalances: [],
     });

--- a/packages/checkout/widgets-lib/src/lib/balance.test.ts
+++ b/packages/checkout/widgets-lib/src/lib/balance.test.ts
@@ -9,13 +9,22 @@ import { getAllowedBalances } from './balance';
 describe('getAllowedBalances', () => {
   const tokenInfo = {
     balance: BigNumber.from(1),
-    token: { symbol: 'QQQ', name: 'QQQ', address: '0xQ' } as TokenInfo,
+    token: {
+      symbol: 'QQQ',
+      name: 'QQQ',
+      address: '0xQ',
+      icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xq.svg',
+    } as TokenInfo,
     formattedBalance: '12.34',
   };
 
   const nativeTokenInfo = {
     balance: BigNumber.from(2),
-    token: { symbol: 'AAA', name: 'AAA' } as TokenInfo,
+    token: {
+      symbol: 'AAA',
+      name: 'AAA',
+      icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/aaa.svg',
+    } as TokenInfo,
     formattedBalance: '6.34',
   };
 
@@ -376,7 +385,12 @@ describe('getAllowedBalances', () => {
       },
       allowedBalances: [{
         balance: BigNumber.from(1),
-        token: { symbol: 'DDD', name: 'DDD', address: '0xd' } as TokenInfo,
+        token: {
+          symbol: 'DDD',
+          name: 'DDD',
+          address: '0xd',
+          icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xd.svg',
+        } as TokenInfo,
         formattedBalance: '36.34',
       }],
     });

--- a/packages/checkout/widgets-lib/src/lib/balance.ts
+++ b/packages/checkout/widgets-lib/src/lib/balance.ts
@@ -6,6 +6,9 @@ import {
   GetTokenAllowListResult,
   TokenFilterTypes,
 } from '@imtbl/checkout-sdk';
+// import { Environment } from '@imtbl/config';
+// import { isNativeToken } from '@imtbl/checkout-sdk/dist/tokens';
+// import { getTokenImageByAddress } from '@imtbl/checkout-sdk/dist/balances';
 import { RetryType, retry } from './retry';
 import { DEFAULT_BALANCE_RETRY_POLICY, NATIVE } from './constants';
 
@@ -58,6 +61,12 @@ export const getAllowedBalances = async ({
     chainId: currentChainId,
     type: allowTokenListType,
   });
+  // TODO: Map token icon to allow list
+  // allowList.tokens = allowList.tokens.map((token) => ({
+  //   ...token,
+  //   icon: getTokenImageByAddress(checkout.config.environment as Environment, (isNativeToken(token.address)
+  //     ? token.symbol.toLowerCase() : token.address as string)),
+  // }));
 
   const tokensAddresses = new Map();
   allowList.tokens.forEach((token) => tokensAddresses.set(token.address?.toLowerCase() || NATIVE, true));

--- a/packages/checkout/widgets-lib/src/lib/balance.ts
+++ b/packages/checkout/widgets-lib/src/lib/balance.ts
@@ -6,11 +6,10 @@ import {
   GetTokenAllowListResult,
   TokenFilterTypes,
 } from '@imtbl/checkout-sdk';
-// import { Environment } from '@imtbl/config';
-// import { isNativeToken } from '@imtbl/checkout-sdk/dist/tokens';
-// import { getTokenImageByAddress } from '@imtbl/checkout-sdk/dist/balances';
+import { Environment } from '@imtbl/config';
 import { RetryType, retry } from './retry';
 import { DEFAULT_BALANCE_RETRY_POLICY, NATIVE } from './constants';
+import { getTokenImageByAddress, isNativeToken } from './utils';
 
 export type GetAllowedBalancesParamsType = {
   checkout: Checkout,
@@ -61,12 +60,15 @@ export const getAllowedBalances = async ({
     chainId: currentChainId,
     type: allowTokenListType,
   });
-  // TODO: Map token icon to allow list
-  // allowList.tokens = allowList.tokens.map((token) => ({
-  //   ...token,
-  //   icon: getTokenImageByAddress(checkout.config.environment as Environment, (isNativeToken(token.address)
-  //     ? token.symbol.toLowerCase() : token.address as string)),
-  // }));
+
+  // Map token icon assets
+  allowList.tokens = allowList.tokens.map((token) => ({
+    ...token,
+    icon: getTokenImageByAddress(
+      checkout.config.environment as Environment,
+      isNativeToken(token.address) ? token.symbol.toLowerCase() : token.address ?? '',
+    ),
+  }));
 
   const tokensAddresses = new Map();
   allowList.tokens.forEach((token) => tokensAddresses.set(token.address?.toLowerCase() || NATIVE, true));

--- a/packages/checkout/widgets-lib/src/lib/balance.ts
+++ b/packages/checkout/widgets-lib/src/lib/balance.ts
@@ -77,7 +77,7 @@ export const getAllowedBalances = async ({
         icon: getTokenImageByAddress(
           checkout.config.environment as Environment,
           isNativeToken(balanceResult.token.address)
-            ? balanceResult.token.symbol.toLowerCase()
+            ? balanceResult.token.symbol
             : balanceResult.token.address ?? '',
         ),
       },
@@ -88,7 +88,7 @@ export const getAllowedBalances = async ({
     ...token,
     icon: getTokenImageByAddress(
       checkout.config.environment as Environment,
-      isNativeToken(token.address) ? token.symbol.toLowerCase() : token.address ?? '',
+      isNativeToken(token.address) ? token.symbol : token.address ?? '',
     ),
   }));
 

--- a/packages/checkout/widgets-lib/src/lib/chains.ts
+++ b/packages/checkout/widgets-lib/src/lib/chains.ts
@@ -32,3 +32,16 @@ export function getChainIdBySlug(chainSlug: ChainSlug): ChainId {
     default: return 0 as ChainId;
   }
 }
+
+export function getNativeSymbolByChainSlug(chainSlug: ChainSlug): string {
+  switch (chainSlug) {
+    case ChainSlug.ETHEREUM:
+    case ChainSlug.SEPOLIA:
+      return 'ETH';
+    case ChainSlug.IMTBL_ZKEVM_TESTNET:
+    case ChainSlug.IMTBL_ZKEVM_MAINNET:
+    case ChainSlug.IMTBL_ZKEVM_DEVNET:
+      return 'IMX';
+    default: return '';
+  }
+}

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -224,7 +224,7 @@ export function SwapForm({ data }: SwapFromProps) {
         id: formatTokenOptionsId(token.symbol, token.address),
         name: token.name,
         symbol: token.symbol,
-        icon: undefined, // todo: add correct image once available on token info
+        icon: token.icon,
       } as CoinSelectorOptionProps),
     ), [allowedTokens, fromToken]);
 

--- a/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.tsx
@@ -85,7 +85,7 @@ export function BalanceItem({
   return (
     <MenuItem testId={`balance-item-${balanceInfo.symbol}`} emphasized>
       <MenuItem.FramedImage
-        imageUrl={balanceInfo.iconLogo}
+        imageUrl={balanceInfo.icon}
         circularFrame
       />
       <MenuItem.Label>{balanceInfo.symbol}</MenuItem.Label>

--- a/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.tsx
@@ -84,7 +84,10 @@ export function BalanceItem({
 
   return (
     <MenuItem testId={`balance-item-${balanceInfo.symbol}`} emphasized>
-      <MenuItem.FramedIcon icon="Coins" circularFrame />
+      <MenuItem.FramedImage
+        imageUrl={balanceInfo.iconLogo}
+        circularFrame
+      />
       <MenuItem.Label>{balanceInfo.symbol}</MenuItem.Label>
       <MenuItem.Caption>{balanceInfo.description}</MenuItem.Caption>
       <MenuItem.PriceDisplay

--- a/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.test.ts
@@ -58,6 +58,7 @@ describe('token balance tests', () => {
         balance: '26.34',
         symbol: 'AAA',
         fiatAmount: '266.65',
+        icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/aaa.svg',
       },
       {
         id: '11155111-qqq-0xq',
@@ -66,6 +67,7 @@ describe('token balance tests', () => {
         symbol: 'QQQ',
         fiatAmount: '63.24',
         address: '0xQ',
+        icon: 'https://checkout-cdn.immutable.com/v1/blob/img/tokens/0xq.svg',
       },
     ]);
   });

--- a/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.ts
@@ -51,7 +51,7 @@ export const getTokenBalances = async (
       icon: getTokenImageByAddress(
         checkout.config.environment as Environment,
         isNativeToken(balanceResult.token.address)
-          ? balanceResult.token.symbol.toLowerCase()
+          ? balanceResult.token.symbol
           : balanceResult.token.address ?? '',
       ),
     },

--- a/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.ts
@@ -63,4 +63,5 @@ export const mapTokenBalancesWithConversions = (
   symbol: balance.token.symbol,
   address: balance.token.address,
   description: balance.token.name,
+  iconLogo: balance.token.icon,
 }));

--- a/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.ts
@@ -1,6 +1,12 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { Checkout, ChainId, GetBalanceResult } from '@imtbl/checkout-sdk';
-import { calculateCryptoToFiat, sortTokensByAmount } from '../../../lib/utils';
+import { Environment } from '@imtbl/config';
+import {
+  calculateCryptoToFiat,
+  getTokenImageByAddress,
+  isNativeToken,
+  sortTokensByAmount,
+} from '../../../lib/utils';
 import { DEFAULT_BALANCE_RETRY_POLICY } from '../../../lib';
 import { retry } from '../../../lib/retry';
 
@@ -11,7 +17,7 @@ export type BalanceInfo = {
   description?: string;
   balance: string;
   fiatAmount: string;
-  iconLogo?: string;
+  icon?: string;
 };
 
 export const getTokenBalances = async (
@@ -38,7 +44,18 @@ export const getTokenBalances = async (
     checkout.config,
     getAllBalancesResult.balances,
     chainId,
-  );
+  ).map((balanceResult) => ({
+    ...balanceResult,
+    token: {
+      ...balanceResult.token,
+      icon: getTokenImageByAddress(
+        checkout.config.environment as Environment,
+        isNativeToken(balanceResult.token.address)
+          ? balanceResult.token.symbol.toLowerCase()
+          : balanceResult.token.address ?? '',
+      ),
+    },
+  }));
 
   return sortedTokens;
 };
@@ -63,5 +80,5 @@ export const mapTokenBalancesWithConversions = (
   symbol: balance.token.symbol,
   address: balance.token.address,
   description: balance.token.name,
-  iconLogo: balance.token.icon,
+  icon: balance.token.icon,
 }));


### PR DESCRIPTION
Updates to show token icons in Wallet, Bridge, and Swap Widgets.
https://immutable.atlassian.net/browse/WT-2101

# Summary
Checkout Widgets now displays token icons.

## Demo
<img width="435" alt="Screenshot 2024-02-09 at 12 02 26 pm" src="https://github.com/immutable/ts-immutable-sdk/assets/1617003/28c22f4b-4a1e-457d-b055-15d1b09a7500">