### PR TITLE
chore: [DX-2652] Push docs to new repo name

### DIFF
--- a/.github/scripts/push-docs.sh
+++ b/.github/scripts/push-docs.sh
@@ -18,7 +18,7 @@ fi
 # Do not remove the trailing period!!!
 # https://dev.to/ackshaey/macos-vs-linux-the-cp-command-will-trip-you-up-2p00
 INPUT_SOURCE_FOLDER="./docs/."
-INPUT_DESTINATION_REPO="immutable/imx-docs"
+INPUT_DESTINATION_REPO="immutable/docs"
 INPUT_DESTINATION_HEAD_BRANCH="ts-immutable-sdk-docs-$VERSION"
 INPUT_DESTINATION_FOLDER="$CLONE_DIR/api-docs/sdk-references/ts-immutable-sdk/$VERSION"
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Docs Repo
         uses: actions/checkout@v3
         with:
-          repository: immutable/imx-docs
+          repository: immutable/docs
           token: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
           path: imx-docs
           ref: main
@@ -67,8 +67,8 @@ jobs:
       - name: Update version link
         run: ./.github/scripts/update-docs-link.sh
 
-      - name: Push SDK Docs to imx-docs
-        id: docs_push 
+      - name: Push SDK Docs to docs
+        id: docs_push
         run: ./.github/scripts/push-docs.sh
         shell: bash
 


### PR DESCRIPTION
# Summary

Make the Push SDK Reference docs workflow push to the new docs repo name.

# Detail and impact of the change

No changes to SDK code.
