### PR TITLE
fix: globalise metrics functions

### DIFF
--- a/packages/internal/metrics/package.json
+++ b/packages/internal/metrics/package.json
@@ -5,7 +5,9 @@
   "author": "Immutable",
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",
   "dependencies": {
-    "axios": "^1.6.5"
+    "axios": "^1.6.5",
+    "global-const": "^0.1.2",
+    "lru-memorise": "^0.2.1"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.0.0",

--- a/packages/internal/metrics/src/details.ts
+++ b/packages/internal/metrics/src/details.ts
@@ -1,18 +1,25 @@
 import { errorBoundary } from './utils/errorBoundary';
 import { Detail } from './utils/constants';
 import { storeDetail } from './utils/state';
+import { getGlobalisedValue } from './utils/globalise';
 
 const setEnvironmentFn = (env: 'sandbox' | 'production') => {
   storeDetail(Detail.ENVIRONMENT, env);
 };
-export const setEnvironment = errorBoundary(setEnvironmentFn);
+export const setEnvironment = errorBoundary(
+  getGlobalisedValue('setEnvironment', setEnvironmentFn),
+);
 
 const setPassportClientIdFn = (passportClientId: string) => {
   storeDetail(Detail.PASSPORT_CLIENT_ID, passportClientId);
 };
-export const setPassportClientId = errorBoundary(setPassportClientIdFn);
+export const setPassportClientId = errorBoundary(
+  getGlobalisedValue('setPassportClientId', setPassportClientIdFn),
+);
 
 const setPublishableApiKeyFn = (publishableApiKey: string) => {
   storeDetail(Detail.PUBLISHABLE_API_KEY, publishableApiKey);
 };
-export const setPublishableApiKey = errorBoundary(setPublishableApiKeyFn);
+export const setPublishableApiKey = errorBoundary(
+  getGlobalisedValue('setPublishableApiKey', setPublishableApiKeyFn),
+);

--- a/packages/internal/metrics/src/initialise.ts
+++ b/packages/internal/metrics/src/initialise.ts
@@ -6,9 +6,6 @@ import { flattenProperties, getDetail, storeDetail } from './utils/state';
 // WARNING: DO NOT CHANGE THE STRING BELOW. IT GETS REPLACED AT BUILD TIME.
 const SDK_VERSION = '__SDK_VERSION__';
 
-let initialised = false;
-export const isInitialised = () => initialised;
-
 const getReferrer = () => {
   if (isNode()) {
     return '';
@@ -66,23 +63,29 @@ const getRuntimeDetails = (): RuntimeDetails => {
 type InitialiseResponse = {
   runtimeId: string;
 };
+
+let initialised = false;
+export const isInitialised = () => initialised;
+
 export const initialise = async () => {
-  const runtimeDetails = flattenProperties(getRuntimeDetails());
-
-  const existingRuntimeId = getDetail(Detail.RUNTIME_ID);
-
-  const body = {
-    version: 1,
-    data: {
-      runtimeDetails,
-      runtimeId: existingRuntimeId,
-    },
-  };
-
-  const response = await post<InitialiseResponse>('/v1/sdk/initialise', body);
-
-  // Get runtimeId and store it
-  const { runtimeId } = response;
-  storeDetail(Detail.RUNTIME_ID, runtimeId);
   initialised = true;
+  try {
+    const runtimeDetails = flattenProperties(getRuntimeDetails());
+    const existingRuntimeId = getDetail(Detail.RUNTIME_ID);
+
+    const body = {
+      version: 1,
+      data: {
+        runtimeDetails,
+        runtimeId: existingRuntimeId,
+      },
+    };
+    const response = await post<InitialiseResponse>('/v1/sdk/initialise', body);
+
+    // Get runtimeId and store it
+    const { runtimeId } = response;
+    storeDetail(Detail.RUNTIME_ID, runtimeId);
+  } catch (error) {
+    initialised = false;
+  }
 };

--- a/packages/internal/metrics/src/utils/constants.ts
+++ b/packages/internal/metrics/src/utils/constants.ts
@@ -7,10 +7,3 @@ export enum Detail {
   DOMAIN = 'domain',
   SDK_VERSION = 'sdkVersion',
 }
-
-export enum Store {
-  EVENTS = 'events',
-  RUNTIME = 'runtime',
-}
-
-export const POLLING_FREQUENCY = 5000;

--- a/packages/internal/metrics/src/utils/globalise.ts
+++ b/packages/internal/metrics/src/utils/globalise.ts
@@ -1,0 +1,22 @@
+import { memorise } from 'lru-memorise';
+import { getGlobalisedValue as globalise } from 'global-const';
+
+const GLOBALISE_KEY = 'imtbl__metrics';
+const MEMORISE_TIMEFRAME = 1000;
+const MEMORISE_MAX = 1000;
+
+export const getGlobalisedValue = <T>(key: string, value: T): T => globalise<T>(GLOBALISE_KEY, key, value);
+
+export const getGlobalisedCachedFunction = <T extends (...args: any[]) => any>(
+  key: string,
+  fn: T,
+): T => {
+  // Some applications (esp backend, or frontends using the split bundles) can sometimes
+  // initialise the same request multiple times. This will prevent multiple of the
+  // same event,value from being reported in a 1 second period.
+  const memorisedFn = memorise(fn, {
+    lruOptions: { ttl: MEMORISE_TIMEFRAME, max: MEMORISE_MAX },
+  }) as unknown as T;
+
+  return globalise<T>(GLOBALISE_KEY, key, memorisedFn);
+};

--- a/packages/internal/metrics/src/utils/state.ts
+++ b/packages/internal/metrics/src/utils/state.ts
@@ -1,5 +1,10 @@
 import { getItem, setItem } from './localStorage';
-import { Detail, Store } from './constants';
+import { Detail } from './constants';
+
+export enum Store {
+  EVENTS = 'events',
+  RUNTIME = 'runtime',
+}
 
 // In memory storage for events and other data
 let EVENT_STORE: any[];

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -34,6 +34,7 @@
     "i18next": "^23.7.6",
     "i18next-browser-languagedetector": "^7.2.0",
     "jwt-decode": "^3.1.2",
+    "lru-memorise": "^0.2.1",
     "magic-sdk": "^21.2.0",
     "oidc-client-ts": "2.2.1",
     "os-browserify": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3639,8 +3639,10 @@ __metadata:
     "@types/jest": ^29.4.3
     axios: ^1.6.5
     eslint: ^8.40.0
+    global-const: ^0.1.2
     jest: ^29.4.3
     jest-environment-jsdom: ^29.4.3
+    lru-memorise: ^0.2.1
     rollup: ^3.17.2
     ts-jest: ^29.1.0
     typescript: ^4.9.5
@@ -3811,6 +3813,7 @@ __metadata:
     i18next: ^23.7.6
     i18next-browser-languagedetector: ^7.2.0
     jwt-decode: ^3.1.2
+    lru-memorise: ^0.2.1
     magic-sdk: ^21.2.0
     oidc-client-ts: 2.2.1
     os-browserify: ^0.3.0
@@ -16119,6 +16122,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"global-const@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "global-const@npm:0.1.2"
+  checksum: 8dce7181149568fb11f37afe8a98de5ce75ff21f523727dd576bc5fbad62627dd0511f3b9553eb3287a1313ed7de8065a71c2151090201891d7b293681d54a8b
+  languageName: node
+  linkType: hard
+
 "global-dirs@npm:^3.0.0":
   version: 3.0.1
   resolution: "global-dirs@npm:3.0.1"
@@ -19817,6 +19827,15 @@ __metadata:
   version: 10.0.0
   resolution: "lru-cache@npm:10.0.0"
   checksum: 18f101675fe283bc09cda0ef1e3cc83781aeb8373b439f086f758d1d91b28730950db785999cd060d3c825a8571c03073e8c14512b6655af2188d623031baf50
+  languageName: node
+  linkType: hard
+
+"lru-memorise@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "lru-memorise@npm:0.2.1"
+  dependencies:
+    tiny-lru: ^11.2.5
+  checksum: 57b65f96644dd7e80c93cba8e7f21b23b813b27e04f47db2777320f61367646d88b77a5459ab6abc63755a881a0baeba1bc11dc90ca7ab885affcb382b6a9317
   languageName: node
   linkType: hard
 
@@ -25857,6 +25876,13 @@ __metadata:
   version: 1.3.1
   resolution: "tiny-invariant@npm:1.3.1"
   checksum: 872dbd1ff20a21303a2fd20ce3a15602cfa7fcf9b228bd694a52e2938224313b5385a1078cb667ed7375d1612194feaca81c4ecbe93121ca1baebe344de4f84c
+  languageName: node
+  linkType: hard
+
+"tiny-lru@npm:^11.2.5":
+  version: 11.2.5
+  resolution: "tiny-lru@npm:11.2.5"
+  checksum: faced7e5b11936d83b40fb743d1630a52da9f7f7341d6656c139bdea76726bff2318f9b30a722140eec2885ea8bc5ed6507ed5a1acba0fbbe88f2b8fa3660dd3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Currently, customers using the code split might instantiate multiple metrics pollers. To fix this issue, we'd like to globalise the metrics functions and to prevent the same values being noted in one instance.
