### PR TITLE
fix: Move Widget gas estimate flow optimisation

### DIFF
--- a/packages/checkout/widgets-lib/src/components/FormComponents/TextInputForm/TextInputForm.tsx
+++ b/packages/checkout/widgets-lib/src/components/FormComponents/TextInputForm/TextInputForm.tsx
@@ -13,6 +13,7 @@ interface TextInputFormProps {
   onTextInputChange: (value: string) => void;
   onTextInputBlur?: (value: string) => void;
   onTextInputFocus?: (value: string) => void;
+  onTextInputEnter?: () => void;
   maxButtonClick?: () => void;
 }
 
@@ -25,6 +26,7 @@ export function TextInputForm({
   onTextInputChange,
   onTextInputBlur,
   onTextInputFocus,
+  onTextInputEnter,
   textAlign,
   subtext,
   maxButtonClick,
@@ -54,6 +56,13 @@ export function TextInputForm({
     onTextInputFocus(inputValue);
   };
 
+  const handleOnKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!onTextInputEnter) return;
+    if (event.key === 'Enter') {
+      onTextInputEnter();
+    }
+  };
+
   return (
     <FormControlWrapper
       testId={`${testId}-text-control`}
@@ -72,6 +81,7 @@ export function TextInputForm({
         placeholder={placeholder}
         onBlur={handleOnBlur}
         onFocus={handleOnFocus}
+        onKeyDown={handleOnKeyDown}
         disabled={disabled}
         hideClearValueButton
         sx={{ minWidth: '100%' }}


### PR DESCRIPTION
# Summary
Removed the initial gas estimates in the Move Widget amount view. 
Added `enter` key down event to speed up form submission.

# Detail and impact of the change
## Removed
The Move Widget amount input view no longer includes a gas fee estimate.