### PR TITLE
chore: add codeowners for metrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 /packages/x-client @immutable/sdk
 /packages/config @immutable/sdk
 /packages/internal/version-check @immutable/sdk
+/packages/internal/metrics @immutable/sdk
 /packages/internal/generated-clients @immutable/sdk
 /packages/internal/generated-clients/src/blockchain-data @immutable/assets
 /packages/internal/toolkit @immutable/wallets


### PR DESCRIPTION
# Summary
Adds the code owners for the metrics package
