### PR TITLE
fix: Revert "feat: EXP add cross product identity matching"

### DIFF
--- a/packages/internal/metrics/src/details.ts
+++ b/packages/internal/metrics/src/details.ts
@@ -1,6 +1,6 @@
 import { errorBoundary } from './utils/errorBoundary';
 import { Detail } from './utils/constants';
-import { storeDetail, getDetail as getDetailFn } from './utils/state';
+import { storeDetail } from './utils/state';
 import { getGlobalisedValue } from './utils/globalise';
 
 const setEnvironmentFn = (env: 'sandbox' | 'production') => {
@@ -23,9 +23,3 @@ const setPublishableApiKeyFn = (publishableApiKey: string) => {
 export const setPublishableApiKey = errorBoundary(
   getGlobalisedValue('setPublishableApiKey', setPublishableApiKeyFn),
 );
-
-export const getDetail = errorBoundary(
-  getGlobalisedValue('getDetail', getDetailFn),
-);
-
-export { Detail };

--- a/packages/internal/metrics/src/index.ts
+++ b/packages/internal/metrics/src/index.ts
@@ -4,6 +4,4 @@ export {
   setEnvironment,
   setPassportClientId,
   setPublishableApiKey,
-  getDetail,
-  Detail,
 } from './details';


### PR DESCRIPTION
# Summary
This PR reverts immutable/ts-immutable-sdk#1475 to fix an issue with the `access_token` being returned from the `token` endpoint being invalid.


# Detail and impact of the change
## Fixed
Fixed an issue with the `access_token` that was returned from the `token` endpoint being invalid.