### PR TITLE
update publish workflow, only push tags when creating github release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -99,11 +99,12 @@ jobs:
       - name: Test
         run: yarn test
 
-      - name: Push tags
-        # Boolean inputs are not actually booleans, see https://github.com/actions/runner/issues/1483
-        if: github.event.inputs.dry_run == 'false'
-        run: |
-          echo "$(git push --tags)"
+      # [DX-2633]: Disabled for now, check the JIRA issue for more details
+      # - name: Push tags
+      #   # Boolean inputs are not actually booleans, see https://github.com/actions/runner/issues/1483
+      #   if: github.event.inputs.dry_run == 'false'
+      #   run: |
+      #     echo "$(git push --tags)"
 
       - name: Pre Release Step
         if: contains(github.event.inputs.release_type, 'alpha')
@@ -140,7 +141,7 @@ jobs:
       - name: Create GitHub Release
         id: gh_release
         if: contains(github.event.inputs.release_type, 'release') && github.event.inputs.dry_run == 'false'
-        run: gh release create ${{ steps.version.outputs.NEXT_VERSION }} --title ${{ steps.version.outputs.NEXT_VERSION }} --draft=false --prerelease=false --generate-notes --repo immutable/ts-immutable-sdk
+        run: gh release create ${{ steps.version.outputs.NEXT_VERSION }} --title ${{ steps.version.outputs.NEXT_VERSION }} --draft=false --prerelease=false --generate-notes --repo immutable/ts-immutable-sdk --target main
 
       - name: Get GitHub Release Name and URL
         if: contains(github.event.inputs.release_type, 'release') && github.event.inputs.dry_run == 'false'


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Update the `Publish to NPM` workflow to use the `gh` token to create/push git tags when the GitHub release is created.

# Detail and impact of the change
- This change will have no impact on external customers

## Changed
- How tags are created in the Publish workflow

# Anything else worth calling out?
- A tag ruleset will be added along side this PR to prevent non-admins from creating tags in the repo.
