### PR TITLE
fix: revert push tags step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,11 +44,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
 
       - name: Setup Github
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "platform-sa"
+          git config user.email "platform-sa@users.noreply.github.com"
 
       - name: Get tags
         run: git fetch --tags
@@ -99,12 +100,11 @@ jobs:
       - name: Test
         run: yarn test
 
-      # [DX-2633]: Disabled for now, check the JIRA issue for more details
-      # - name: Push tags
-      #   # Boolean inputs are not actually booleans, see https://github.com/actions/runner/issues/1483
-      #   if: github.event.inputs.dry_run == 'false'
-      #   run: |
-      #     echo "$(git push --tags)"
+      - name: Push tags
+        # Boolean inputs are not actually booleans, see https://github.com/actions/runner/issues/1483
+        if: github.event.inputs.dry_run == 'false'
+        run: |
+          echo "$(git push --tags)"
 
       - name: Pre Release Step
         if: contains(github.event.inputs.release_type, 'alpha')


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Revert [this PR](https://github.com/immutable/ts-immutable-sdk/pull/1506) to stop pushing alpha tags.

Alpha tags are required for the workflow to correctly figure out the next alpha version.

Also used the `platform-sa` token to checkout the repo which gets stored in the local git config and should be used later on to push the tags to GitHub.
