### PR TITLE
Fix: [Sale Widget] Display footer across all loading screens

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -127,7 +127,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
       >
         <CryptoFiatProvider environment={config.environment}>
           {viewState.view.type === SharedViews.LOADING_VIEW && (
-            <LoadingView loadingText={loadingText} />
+            <LoadingView loadingText={loadingText} showFooterLogo />
           )}
           {viewState.view.type === SaleWidgetViews.PAYMENT_METHODS && (
             <PaymentMethods />

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
@@ -113,7 +113,7 @@ export class Sale extends Base<WidgetType.SALE> {
                 sendSaleWidgetCloseEvent(window);
               }}
             >
-              <Suspense fallback={<LoadingView loadingText={t('views.LOADING_VIEW.text')} />}>
+              <Suspense fallback={<LoadingView loadingText={t('views.LOADING_VIEW.text')} showFooterLogo />}>
                 <SaleWidget
                   config={this.strongConfig()}
                   amount={this.parameters.amount!}

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/FundingRouteExecute/FundingRouteExecute.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/FundingRouteExecute/FundingRouteExecute.tsx
@@ -229,7 +229,7 @@ export function FundingRouteExecute({ fundingRouteStep, onFundingRouteExecuted }
   return (
     <EventTargetContext.Provider value={eventTargetReducerValues}>
       {view === FundingRouteExecuteViews.LOADING && (
-        <LoadingView loadingText={t('views.FUND_WITH_SMART_CHECKOUT.loading.checkingBalances')} />
+        <LoadingView loadingText={t('views.FUND_WITH_SMART_CHECKOUT.loading.checkingBalances')} showFooterLogo />
       )}
       {view === FundingRouteExecuteViews.EXECUTE_BRIDGE && (
         <BridgeWidget

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/FundWithSmartCheckout.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/FundWithSmartCheckout.tsx
@@ -106,7 +106,7 @@ export function FundWithSmartCheckout({ subView }: FundWithSmartCheckoutProps) {
   return (
     <Box>
       {subView === FundWithSmartCheckoutSubViews.INIT && (
-        <LoadingView loadingText={t('views.FUND_WITH_SMART_CHECKOUT.loading.checkingBalances')} />
+        <LoadingView loadingText={t('views.FUND_WITH_SMART_CHECKOUT.loading.checkingBalances')} showFooterLogo />
       )}
       {subView === FundWithSmartCheckoutSubViews.FUNDING_ROUTE_SELECT && (
         <FundingRouteSelect


### PR DESCRIPTION
# Summary
Ensure loading screen footer is shown across entire Sale Widget flow
