### PR TITLE
feat: WT-2158 handle wallet disconnect

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/configurations/wallet.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/configurations/wallet.ts
@@ -3,6 +3,10 @@ import { WidgetConfiguration } from './widget';
 
 /**
  * Wallet Widget Configuration represents the configuration options for the Wallet Widget.
+ * @property {boolean | undefined} showDisconnectButton - show/hide the disconnect button in the Wallet Widget (defaults to true)
+ * @property {boolean | undefined} showNetworkMenu - show/hide the network menu in the Wallet Widget (defaults to true)
  */
 export type WalletWidgetConfiguration = {
+  showDisconnectButton?: boolean;
+  showNetworkMenu?: boolean;
 } & WidgetConfiguration;

--- a/packages/checkout/sdk/src/widgets/definitions/configurations/widget.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/configurations/widget.ts
@@ -29,6 +29,6 @@ export type WalletConnectConfig = {
     name: string;
     description: string;
     url: string;
-    icons: [];
+    icons: string[];
   };
 };

--- a/packages/checkout/widgets-lib/src/factory.ts
+++ b/packages/checkout/widgets-lib/src/factory.ts
@@ -5,6 +5,7 @@ import {
   IWidgetsFactory,
   WidgetConfiguration,
   WidgetProperties,
+  WidgetConfigurations,
 } from '@imtbl/checkout-sdk';
 import { Connect } from 'widgets/connect/ConnectWidgetRoot';
 import { Swap } from 'widgets/swap/SwapWidgetRoot';
@@ -50,7 +51,8 @@ export class WidgetsFactory implements IWidgetsFactory {
   }
 
   create<T extends WidgetType>(type: T, props?: WidgetProperties<T>): Widget<T> {
-    const { config = {}, provider } = props ?? {};
+    const { provider } = props ?? {};
+    const config = props?.config as WidgetConfigurations[T] || {};
 
     switch (type) {
       case WidgetType.CONNECT: {

--- a/packages/checkout/widgets-lib/src/views/top-up/TopUpView.cy.tsx
+++ b/packages/checkout/widgets-lib/src/views/top-up/TopUpView.cy.tsx
@@ -308,6 +308,10 @@ describe('Top Up View', () => {
           isBridgeEnabled: true,
           isSwapAvailable: true,
         },
+        walletConfig: {
+          showNetworkMenu: true,
+          showDisconnectButton: true,
+        },
       };
       cy.stub(Checkout.prototype, 'getExchangeFeeEstimate')
         .as('getExchangeFeeEstimateStub')
@@ -366,6 +370,10 @@ describe('Top Up View', () => {
           isSwapEnabled: true,
           isBridgeEnabled: true,
           isSwapAvailable: true,
+        },
+        walletConfig: {
+          showNetworkMenu: true,
+          showDisconnectButton: true,
         },
       };
 

--- a/packages/checkout/widgets-lib/src/widgets/BaseWidgetRoot.ts
+++ b/packages/checkout/widgets-lib/src/widgets/BaseWidgetRoot.ts
@@ -10,6 +10,7 @@ import {
   ProviderEventType,
   ProviderUpdated,
   WidgetParameters,
+  WalletEventType,
 } from '@imtbl/checkout-sdk';
 import { Web3Provider } from '@ethersproject/providers';
 import i18next from 'i18next';
@@ -48,6 +49,7 @@ export abstract class Base<T extends WidgetType> implements Widget<T> {
       addProviderListenersForWidgetRoot(this.web3Provider);
     }
     this.setupProviderUpdatedListener();
+    this.setupDisconnectProviderListener();
   }
 
   unmount() {
@@ -177,6 +179,13 @@ export abstract class Base<T extends WidgetType> implements Widget<T> {
     window.addEventListener(baseWidgetProviderEvent, () => widgetRoot.handleEIP1193ProviderEvents(widgetRoot));
   }
 
+  private setupDisconnectProviderListener() {
+    window.addEventListener(
+      IMTBLWidgetEvents.IMTBL_WALLET_WIDGET_EVENT,
+      this.handleDisconnectEvent,
+    );
+  }
+
   private handleEIP1193ProviderEvents(widgetRoot: Base<T>) {
     if (widgetRoot.web3Provider) {
       // eslint-disable-next-line no-param-reassign
@@ -197,6 +206,22 @@ export abstract class Base<T extends WidgetType> implements Widget<T> {
       case ProviderEventType.PROVIDER_UPDATED: {
         const eventData = event.detail.data as ProviderUpdated;
         widgetRoot.web3Provider = eventData.provider;
+        this.render();
+        break;
+      }
+      default:
+    }
+  }) as EventListener;
+
+  /**
+   * Handles disconnect event from the wallet widget
+   */
+  private handleDisconnectEvent = ((event: CustomEvent) => {
+    const widgetRoot = this;
+
+    switch (event.detail.type) {
+      case WalletEventType.DISCONNECT_WALLET: {
+        widgetRoot.web3Provider = undefined;
         this.render();
         break;
       }

--- a/packages/checkout/widgets-lib/src/widgets/wallet/WalletWidget.cy.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/WalletWidget.cy.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../context/connect-loader-context/test-components/ConnectLoaderTestComponent';
 import { ConnectionStatus } from '../../context/connect-loader-context/ConnectLoaderContext';
 import { NATIVE } from '../../lib';
+import { WalletConfiguration } from './context/WalletContext';
 
 describe('WalletWidget tests', () => {
   beforeEach(() => {
@@ -44,6 +45,11 @@ describe('WalletWidget tests', () => {
     provider: mockProvider,
     connectionStatus: ConnectionStatus.CONNECTED_WITH_NETWORK,
   };
+
+  const walletConfig = {
+    showDisconnectButton: true,
+    showNetworkMenu: true,
+  } as WalletConfiguration;
 
   describe('WalletWidget initialisation', () => {
     beforeEach(() => {
@@ -85,6 +91,7 @@ describe('WalletWidget tests', () => {
         >
           <WalletWidget
             config={widgetConfig}
+            walletConfig={walletConfig}
           />
         </ConnectLoaderTestComponent>,
       );
@@ -138,6 +145,7 @@ describe('WalletWidget tests', () => {
         >
           <WalletWidget
             config={widgetConfig}
+            walletConfig={walletConfig}
           />
         </ConnectLoaderTestComponent>,
       );
@@ -316,6 +324,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
             ,
           </ConnectLoaderTestComponent>,
@@ -356,6 +365,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
             ,
           </ConnectLoaderTestComponent>,
@@ -417,6 +427,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
           </ConnectLoaderTestComponent>,
         );
@@ -471,6 +482,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
             ,
           </ConnectLoaderTestComponent>,
@@ -497,6 +509,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
             ,
           </ConnectLoaderTestComponent>,
@@ -523,6 +536,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
             ,
           </ConnectLoaderTestComponent>,
@@ -553,6 +567,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
             ,x
           </ConnectLoaderTestComponent>,
@@ -593,6 +608,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
           </ConnectLoaderTestComponent>,
         );
@@ -603,6 +619,38 @@ describe('WalletWidget tests', () => {
         );
         cySmartGet('disconnect-button').click();
         cySmartGet('@disconnectEvent').should('have.been.calledOnce');
+      });
+
+      it('should NOT show a disconnect button when wallet config showDisconnectButton is false', () => {
+        cy.window().then((window) => {
+          window.addEventListener(
+            IMTBLWidgetEvents.IMTBL_WALLET_WIDGET_EVENT,
+            cy.stub().as('disconnectEvent'),
+          );
+        });
+
+        const widgetConfig = {
+          theme: WidgetTheme.DARK,
+          environment: Environment.SANDBOX,
+          isBridgeEnabled: false,
+          isSwapEnabled: false,
+          isOnRampEnabled: false,
+        } as StrongCheckoutWidgetsConfig;
+
+        mount(
+          <ConnectLoaderTestComponent
+            initialStateOverride={connectLoaderState}
+          >
+            <WalletWidget
+              config={widgetConfig}
+              walletConfig={{ ...walletConfig, showDisconnectButton: false }}
+            />
+            ,x
+          </ConnectLoaderTestComponent>,
+        );
+        cySmartGet('settings-button').click();
+        cySmartGet('disconnect-button').should('not.exist');
+        cySmartGet('@disconnectEvent').should('not.have.been.called');
       });
     });
 
@@ -628,6 +676,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
             ,
           </ConnectLoaderTestComponent>,
@@ -660,6 +709,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
             ,
           </ConnectLoaderTestComponent>,
@@ -672,6 +722,32 @@ describe('WalletWidget tests', () => {
         cy.get('body').contains('Visit our FAQs');
         cy.get('body').contains('Coins and collectibles are native to networks');
         cySmartGet('back-button').should('be.visible');
+      });
+    });
+
+    describe('Network menu', () => {
+      it('should not show the Network Menu when wallet config showNetworkMenu is false', () => {
+        const widgetConfig = {
+          theme: WidgetTheme.DARK,
+          environment: Environment.SANDBOX,
+          isBridgeEnabled: false,
+          isSwapEnabled: false,
+          isOnRampEnabled: false,
+        } as StrongCheckoutWidgetsConfig;
+
+        mount(
+          <ConnectLoaderTestComponent
+            initialStateOverride={connectLoaderState}
+          >
+            <WalletWidget
+              config={widgetConfig}
+              walletConfig={{ ...walletConfig, showNetworkMenu: false }}
+            />
+          </ConnectLoaderTestComponent>,
+        );
+
+        cySmartGet('wallet-balances').should('exist');
+        cySmartGet('network-menu').should('not.exist');
       });
     });
 
@@ -699,6 +775,7 @@ describe('WalletWidget tests', () => {
           >
             <WalletWidget
               config={widgetConfig}
+              walletConfig={walletConfig}
             />
           </ConnectLoaderTestComponent>,
         );

--- a/packages/checkout/widgets-lib/src/widgets/wallet/WalletWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/WalletWidget.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import {
   initialWalletState,
   WalletActions,
+  WalletConfiguration,
   WalletContext,
   walletReducer,
 } from './context/WalletContext';
@@ -35,7 +36,8 @@ import { EventTargetContext } from '../../context/event-target-context/EventTarg
 import { useBalance } from '../../lib/hooks/useBalance';
 
 export type WalletWidgetInputs = WalletWidgetParams & {
-  config: StrongCheckoutWidgetsConfig
+  config: StrongCheckoutWidgetsConfig,
+  walletConfig: WalletConfiguration
 };
 
 export default function WalletWidget(props: WalletWidgetInputs) {
@@ -54,6 +56,10 @@ export default function WalletWidget(props: WalletWidgetInputs) {
       isBridgeEnabled,
       theme,
     },
+    walletConfig: {
+      showDisconnectButton,
+      showNetworkMenu,
+    },
   } = props;
 
   const {
@@ -66,7 +72,7 @@ export default function WalletWidget(props: WalletWidgetInputs) {
 
   const [walletState, walletDispatch] = useReducer(
     walletReducer,
-    initialWalletState,
+    { ...initialWalletState, walletConfig: { showDisconnectButton, showNetworkMenu } },
   );
 
   const walletReducerValues = useMemo(
@@ -200,9 +206,12 @@ export default function WalletWidget(props: WalletWidgetInputs) {
             <LoadingView loadingText={loadingText} />
           )}
           {viewState.view.type === WalletWidgetViews.WALLET_BALANCES && (
-            <WalletBalances balancesLoading={balancesLoading} theme={theme} />
+            <WalletBalances balancesLoading={balancesLoading} theme={theme} showNetworkMenu={showNetworkMenu} />
           )}
-          {viewState.view.type === WalletWidgetViews.SETTINGS && <Settings />}
+          {viewState.view.type === WalletWidgetViews.SETTINGS
+          && (
+          <Settings showDisconnectButton={showDisconnectButton} />
+          )}
           {viewState.view.type === WalletWidgetViews.COIN_INFO && (
             <CoinInfo />
           )}

--- a/packages/checkout/widgets-lib/src/widgets/wallet/WalletWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/WalletWidgetRoot.tsx
@@ -2,8 +2,8 @@ import React, { Suspense } from 'react';
 import {
   ConnectTargetLayer,
   IMTBLWidgetEvents,
+  WalletWidgetConfiguration,
   WalletWidgetParams,
-  WidgetConfiguration,
   WidgetProperties,
   WidgetTheme,
   WidgetType,
@@ -26,12 +26,24 @@ export class Wallet extends Base<WidgetType.WALLET> {
   protected getValidatedProperties(
     { config }: WidgetProperties<WidgetType.WALLET>,
   ): WidgetProperties<WidgetType.WALLET> {
-    let validatedConfig: WidgetConfiguration | undefined;
+    let validatedConfig: WalletWidgetConfiguration | undefined;
 
     if (config) {
       validatedConfig = config;
       if (config.theme === WidgetTheme.LIGHT) validatedConfig.theme = WidgetTheme.LIGHT;
       else validatedConfig.theme = WidgetTheme.DARK;
+
+      if (config?.showDisconnectButton === undefined) {
+        validatedConfig.showDisconnectButton = true;
+      } else {
+        validatedConfig.showDisconnectButton = config.showDisconnectButton;
+      }
+
+      if (config?.showNetworkMenu === undefined) {
+        validatedConfig.showNetworkMenu = true;
+      } else {
+        validatedConfig.showNetworkMenu = config.showNetworkMenu;
+      }
     }
 
     return {
@@ -74,6 +86,10 @@ export class Wallet extends Base<WidgetType.WALLET> {
               <Suspense fallback={<LoadingView loadingText={t('views.LOADING_VIEW.text')} />}>
                 <WalletWidget
                   config={this.strongConfig()}
+                  walletConfig={{
+                    showDisconnectButton: this.properties.config?.showDisconnectButton!,
+                    showNetworkMenu: this.properties.config?.showNetworkMenu!,
+                  }}
                 />
               </Suspense>
             </ConnectLoader>

--- a/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.cy.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.cy.tsx
@@ -50,6 +50,10 @@ describe('BalanceItem', () => {
     walletProviderName: WalletProviderName.METAMASK,
     tokenBalances: testTokenBalances,
     supportedTopUps: null,
+    walletConfig: {
+      showNetworkMenu: true,
+      showDisconnectButton: true,
+    },
   };
 
   const testBalanceInfo: BalanceInfo = {

--- a/packages/checkout/widgets-lib/src/widgets/wallet/components/NetworkMenu/NetworkMenu.cy.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/components/NetworkMenu/NetworkMenu.cy.tsx
@@ -63,6 +63,10 @@ describe('Network Menu', () => {
       walletProviderName: WalletProviderName.METAMASK,
       tokenBalances: [],
       supportedTopUps: null,
+      walletConfig: {
+        showNetworkMenu: true,
+        showDisconnectButton: true,
+      },
     };
     mount(
       <ViewContextTestComponent>
@@ -107,6 +111,10 @@ describe('Network Menu', () => {
       walletProviderName: WalletProviderName.METAMASK,
       tokenBalances: [],
       supportedTopUps: null,
+      walletConfig: {
+        showNetworkMenu: true,
+        showDisconnectButton: true,
+      },
     };
     mount(
       <ViewContextTestComponent>

--- a/packages/checkout/widgets-lib/src/widgets/wallet/context/WalletContext.ts
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/context/WalletContext.ts
@@ -5,11 +5,17 @@ import {
 } from '@imtbl/checkout-sdk';
 import { createContext } from 'react';
 
+export type WalletConfiguration = {
+  showDisconnectButton: boolean;
+  showNetworkMenu: boolean;
+};
+
 export interface WalletState {
   walletProviderName: WalletProviderName | null;
   network: NetworkInfo | null;
   tokenBalances: GetBalanceResult[];
   supportedTopUps: TopUpFeature | null;
+  walletConfig: WalletConfiguration;
 }
 
 export interface TopUpFeature {
@@ -24,6 +30,11 @@ export const initialWalletState: WalletState = {
   network: null,
   tokenBalances: [],
   supportedTopUps: null,
+  /** initial state gets overriden when reducer set up in WalletWidget.tsx */
+  walletConfig: {
+    showDisconnectButton: true,
+    showNetworkMenu: true,
+  },
 };
 
 export interface WalletContextState {
@@ -71,7 +82,7 @@ export interface SetSupportedTopUpPayload {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const WalletContext = createContext<WalletContextState>({
   walletState: initialWalletState,
-  walletDispatch: () => {},
+  walletDispatch: () => { },
 });
 
 WalletContext.displayName = 'WalletContext'; // help with debugging Context in browser

--- a/packages/checkout/widgets-lib/src/widgets/wallet/views/Settings.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/views/Settings.tsx
@@ -13,7 +13,13 @@ import { ConnectLoaderContext } from '../../../context/connect-loader-context/Co
 import { EventTargetContext } from '../../../context/event-target-context/EventTargetContext';
 import { UserJourney, useAnalytics } from '../../../context/analytics-provider/SegmentAnalyticsProvider';
 
-export function Settings() {
+export interface SettingsProps {
+  showDisconnectButton: boolean;
+}
+
+export function Settings({
+  showDisconnectButton,
+}: SettingsProps) {
   const { t } = useTranslation();
   const { connectLoaderState } = useContext(ConnectLoaderContext);
   const { checkout, provider } = connectLoaderState;
@@ -78,6 +84,7 @@ export function Settings() {
         sx={settingsBoxStyle}
       >
         <WalletAddress provider={provider} />
+        {showDisconnectButton && (
         <Button
           testId="disconnect-button"
           variant="secondary"
@@ -89,6 +96,7 @@ export function Settings() {
         >
           {t('views.SETTINGS.disconnectButton.label')}
         </Button>
+        )}
       </Box>
     </SimpleLayout>
   );

--- a/packages/checkout/widgets-lib/src/widgets/wallet/views/Settings.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/views/Settings.tsx
@@ -1,6 +1,8 @@
 import { Box, Button } from '@biom3/react';
 import { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useWalletConnect } from 'lib/hooks/useWalletConnect';
+import { isMetaMaskProvider, isPassportProvider, isWalletConnectProvider } from 'lib/providerUtils';
 import { FooterLogo } from '../../../components/Footer/FooterLogo';
 import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
 import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
@@ -14,8 +16,10 @@ import { UserJourney, useAnalytics } from '../../../context/analytics-provider/S
 export function Settings() {
   const { t } = useTranslation();
   const { connectLoaderState } = useContext(ConnectLoaderContext);
-  const { provider } = connectLoaderState;
+  const { checkout, provider } = connectLoaderState;
   const { eventTargetState: { eventTarget } } = useContext(EventTargetContext);
+
+  const { ethereumProvider } = useWalletConnect({ checkout: checkout! });
 
   const { page } = useAnalytics();
 
@@ -25,6 +29,36 @@ export function Settings() {
       screen: 'Settings',
     });
   }, []);
+
+  const handleWCDisconnect = async () => {
+    if (isPassportProvider(provider)) {
+      console.log('disconnecting passport provider by calling logout on Passport');
+      await checkout?.passport?.logout();
+      console.log('disconnected');
+      return;
+    }
+
+    if (isMetaMaskProvider(provider)) {
+      console.log('disconnecting MetaMask provider by revoking permissions');
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      await (provider?.provider as any).request({ method: 'wallet_revokePermissions', params: [{ eth_accounts: {} }] });
+      console.log('disconnected');
+      return;
+    }
+
+    if (isWalletConnectProvider(provider)) {
+      console.log('disconnecting WalletConnect by disconnecting all pairings and then provider disconnect');
+      if (ethereumProvider?.session) {
+        const pairings = ethereumProvider?.signer.client.core.pairing.getPairings();
+        console.log('pairings', pairings);
+        // eslint-disable-next-line max-len
+        const pairingsToDisconnect = pairings.map((pairing) => ethereumProvider?.signer.client.core.pairing.disconnect({ topic: pairing.topic }));
+        await Promise.allSettled(pairingsToDisconnect);
+        await ethereumProvider.disconnect();
+        console.log('disconnected');
+      }
+    }
+  };
 
   return (
     <SimpleLayout
@@ -46,7 +80,10 @@ export function Settings() {
           testId="disconnect-button"
           variant="secondary"
           sx={settingsDisconnectButtonStyle}
-          onClick={() => sendDisconnectWalletEvent(eventTarget)}
+          onClick={() => {
+            handleWCDisconnect();
+            sendDisconnectWalletEvent(eventTarget);
+          }}
         >
           {t('views.SETTINGS.disconnectButton.label')}
         </Button>

--- a/packages/checkout/widgets-lib/src/widgets/wallet/views/WalletBalances.cy.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/views/WalletBalances.cy.tsx
@@ -89,6 +89,10 @@ describe('WalletBalances', () => {
       walletProviderName: WalletProviderName.METAMASK,
       tokenBalances: balancesMock,
       supportedTopUps: null,
+      walletConfig: {
+        showNetworkMenu: true,
+        showDisconnectButton: true,
+      },
     };
 
     it('should show balances', () => {
@@ -101,7 +105,7 @@ describe('WalletBalances', () => {
               initialStateOverride={baseWalletState}
               cryptoConversionsOverride={cryptoConversions}
             >
-              <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} />
+              <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} showNetworkMenu />
             </WalletWidgetTestComponent>
           </ConnectLoaderTestComponent>
         </ViewContextTestComponent>,
@@ -121,7 +125,7 @@ describe('WalletBalances', () => {
               initialStateOverride={baseWalletState}
               cryptoConversionsOverride={cryptoConversions}
             >
-              <WalletBalances balancesLoading theme={WidgetTheme.DARK} />
+              <WalletBalances balancesLoading theme={WidgetTheme.DARK} showNetworkMenu />
             </WalletWidgetTestComponent>
           </ConnectLoaderTestComponent>
         </ViewContextTestComponent>,
@@ -143,7 +147,7 @@ describe('WalletBalances', () => {
               initialStateOverride={baseWalletState}
               cryptoConversionsOverride={cryptoConversions}
             >
-              <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} />
+              <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} showNetworkMenu />
             </WalletWidgetTestComponent>
           </ConnectLoaderTestComponent>
         </ViewContextTestComponent>,
@@ -165,7 +169,7 @@ describe('WalletBalances', () => {
               initialStateOverride={{ ...baseWalletState, tokenBalances: [] }}
               cryptoConversionsOverride={cryptoConversions}
             >
-              <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} />
+              <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} showNetworkMenu />
             </WalletWidgetTestComponent>
           </ConnectLoaderTestComponent>
         </ViewContextTestComponent>,
@@ -186,6 +190,10 @@ describe('WalletBalances', () => {
       walletProviderName: WalletProviderName.METAMASK,
       tokenBalances: [],
       supportedTopUps: null,
+      walletConfig: {
+        showNetworkMenu: true,
+        showDisconnectButton: true,
+      },
     };
 
     it('should show add coins button on zkEVM when topUps are supported', () => {
@@ -222,7 +230,7 @@ describe('WalletBalances', () => {
                 <WalletContext.Provider
                   value={{ walletState: testWalletState, walletDispatch: () => {} }}
                 >
-                  <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} />
+                  <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} showNetworkMenu />
                 </WalletContext.Provider>
               </ConnectLoaderTestComponent>
             </ViewContextTestComponent>
@@ -250,7 +258,7 @@ describe('WalletBalances', () => {
               <WalletContext.Provider
                 value={{ walletState: testWalletState, walletDispatch: () => {} }}
               >
-                <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} />
+                <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} showNetworkMenu />
               </WalletContext.Provider>
             </ConnectLoaderTestComponent>
           </ViewContextTestComponent>
@@ -274,6 +282,10 @@ describe('WalletBalances', () => {
           isSwapEnabled: true,
           isBridgeEnabled: true,
         },
+        walletConfig: {
+          showNetworkMenu: true,
+          showDisconnectButton: true,
+        },
       };
       mount(
         <ViewContextTestComponent>
@@ -284,7 +296,7 @@ describe('WalletBalances', () => {
               <WalletContext.Provider
                 value={{ walletState, walletDispatch: () => {} }}
               >
-                <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} />
+                <WalletBalances balancesLoading={false} theme={WidgetTheme.DARK} showNetworkMenu />
               </WalletContext.Provider>
             </ConnectLoaderTestComponent>
           </ViewContextTestComponent>

--- a/packages/checkout/widgets-lib/src/widgets/wallet/views/WalletBalances.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/views/WalletBalances.tsx
@@ -38,10 +38,12 @@ import { BalanceInfo, mapTokenBalancesWithConversions } from '../functions/token
 type WalletBalancesProps = {
   balancesLoading: boolean;
   theme: WidgetTheme;
+  showNetworkMenu: boolean;
 };
 export function WalletBalances({
   balancesLoading,
   theme,
+  showNetworkMenu,
 }: WalletBalancesProps) {
   const { t } = useTranslation();
   const { connectLoaderState } = useContext(ConnectLoaderContext);
@@ -59,7 +61,7 @@ export function WalletBalances({
   } = walletState;
   const { conversions } = cryptoFiatState;
   const isPassport = isPassportProvider(provider);
-  const showNetworkMenu = !isPassport;
+  const enableNetworkMenu = !isPassport && showNetworkMenu;
 
   const { track, page } = useAnalytics();
 
@@ -174,10 +176,10 @@ export function WalletBalances({
         sx={walletBalanceOuterContainerStyles}
       >
         <Box sx={walletBalanceContainerStyles}>
-          {showNetworkMenu && <NetworkMenu />}
+          {enableNetworkMenu && <NetworkMenu />}
           <TotalTokenBalance totalBalance={totalFiatAmount} loading={balancesLoading} />
           <Box
-            sx={walletBalanceListContainerStyles(showNetworkMenu, showAddCoins)}
+            sx={walletBalanceListContainerStyles(enableNetworkMenu, showAddCoins)}
           >
             {balancesLoading && (
               <Box sx={walletBalanceLoadingIconStyles}>


### PR DESCRIPTION


# Summary

Adding functionality into the Disconnect Wallet button in the Wallet Widget. If the current provider is a WalletConnect provider, we make sure to disconnect all existing pairings and disconnect the provider. This enables reconnection in the connect widget with a different mobile wallet.

Wallet Widget Configurations

When creating the Wallet Widget through the factory, you can now pass in flags to show/hide

* Disconnect Button
* Network Menu

Both of these configurations default to true.
