### PR TITLE
fix: handle process not defined in browser bundle

### DIFF
--- a/packages/internal/metrics/src/utils/checkEnv.ts
+++ b/packages/internal/metrics/src/utils/checkEnv.ts
@@ -1,4 +1,11 @@
-export function isTestEnvironment() {
+import { isBrowser } from './browser';
+import { errorBoundary } from './errorBoundary';
+
+function isTestEnvironmentFn() {
+  if (isBrowser()) {
+    return false;
+  }
+
   if (typeof process === 'undefined') {
     return false;
   }
@@ -7,3 +14,5 @@ export function isTestEnvironment() {
   // Just use process.env.CI for now.
   return process.env.JEST_WORKER_ID !== undefined;
 }
+
+export const isTestEnvironment = errorBoundary(isTestEnvironmentFn, false);

--- a/packages/internal/metrics/src/utils/errorBoundary.test.ts
+++ b/packages/internal/metrics/src/utils/errorBoundary.test.ts
@@ -26,4 +26,16 @@ describe('errorBoundary', () => {
     };
     expect(errorBoundary(testFn)).not.toThrowError();
   });
+  it('should return the fallback result for a function that throws', () => {
+    const testFn = (): number => {
+      throw new Error('test');
+    };
+    expect(errorBoundary(testFn, 3)()).toEqual(3);
+  });
+  it('should return the fallback result for an async function that throws', () => {
+    const testFn = async (): Promise<number> => {
+      throw new Error('test');
+    };
+    expect(errorBoundary(testFn, Promise.resolve(3))()).resolves.toEqual(3);
+  });
 });

--- a/packages/internal/metrics/src/utils/errorBoundary.ts
+++ b/packages/internal/metrics/src/utils/errorBoundary.ts
@@ -1,4 +1,8 @@
-export function errorBoundary<T extends (...args: any[]) => any>(fn: T): T {
+export function errorBoundary<T extends (
+  ...args: any[]) => any>(
+  fn: T,
+  fallbackResult?: ReturnType<T>,
+): T {
   const wrappedFunction = ((...args: Parameters<T>): ReturnType<T> => {
     try {
       // Execute the original function
@@ -7,13 +11,13 @@ export function errorBoundary<T extends (...args: any[]) => any>(fn: T): T {
       if (result instanceof Promise) {
         // Silent fail for now, in future
         // we can send errors to a logging service
-        return result.catch(() => undefined) as ReturnType<T>;
+        return result.catch(() => fallbackResult) as ReturnType<T>;
       }
 
       return result;
     } catch (error) {
       // As above, fail silently for now
-      return undefined as ReturnType<T>;
+      return fallbackResult as ReturnType<T>;
     }
   }) as T;
 

--- a/packages/internal/metrics/src/utils/request.ts
+++ b/packages/internal/metrics/src/utils/request.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const IMTBL_API = 'https://api.x.immutable.com';
+const IMTBL_API = 'https://api.immutable.com';
 
 export async function post<T = any>(path: string, data: any) {
   const client = axios.create({

--- a/packages/passport/sdk/package.json
+++ b/packages/passport/sdk/package.json
@@ -31,7 +31,6 @@
     "@types/axios": "^0.14.0",
     "@types/jest": "^29.4.3",
     "@types/jwt-encode": "^1.0.1",
-    "@types/node": "^18.14.2",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.57.1",

--- a/packages/passport/sdk/src/utils/logger.ts
+++ b/packages/passport/sdk/src/utils/logger.ts
@@ -1,6 +1,9 @@
-const shouldLog: boolean = process?.env?.JEST_WORKER_ID === undefined;
-
 const warn = (...args: any[]) => {
+  if (typeof process === 'undefined') {
+    return;
+  }
+
+  const shouldLog: boolean = process?.env?.JEST_WORKER_ID === undefined;
   if (shouldLog) {
     // eslint-disable-next-line no-console
     console.warn(...args);

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -132,7 +132,8 @@ export default [
         __SDK_VERSION__: pkg.version,
         
         // This breaks in a dex dependency, so manually replacing it.
-        'process.env.NODE_ENV': '"production"'
+        'process.env.NODE_ENV': '"production"',
+        'process': 'undefined'
       }),
       terser(),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,7 +3719,6 @@ __metadata:
     "@types/axios": ^0.14.0
     "@types/jest": ^29.4.3
     "@types/jwt-encode": ^1.0.1
-    "@types/node": ^18.14.2
     "@types/react": ^18.0.28
     "@types/react-dom": ^18.0.11
     "@typescript-eslint/eslint-plugin": ^5.57.1


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Fixes an issue where users have monkey-patched their browser environment to have a `process` global value, causing issues with test-env detection code.

It also adds an error boundary and changes the API URL to the new unified API url. (Both work, just proxies)
