### PR TITLE
fix: check axios error on isRegisteredOffChain function

### DIFF
--- a/packages/x-provider/src/signable-actions/registration.ts
+++ b/packages/x-provider/src/signable-actions/registration.ts
@@ -6,7 +6,7 @@ import {
   UsersApi,
 } from '@imtbl/core-sdk';
 import { signRaw } from '@imtbl/toolkit';
-import { AxiosError } from 'axios';
+import { isAxiosError } from 'axios';
 import { Signers } from './types';
 import { validateChain } from './helpers';
 import { ProviderConfiguration } from '../config';
@@ -56,7 +56,7 @@ export async function isRegisteredOffchain(ethAddress: string, config: ProviderC
 
     return accounts?.length > 0;
   } catch (ex) {
-    if (ex instanceof AxiosError && ex.response?.status === 404) {
+    if (isAxiosError(ex) && ex.response?.status === 404) {
       return false;
     }
     throw ex;


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
The IMX provider `isRegisteredOffChain` function was throwing a `404` error when checking if a unregistered user was registered instead of returning the expected `false` value.

The fix was tested in SDK version [1.14.0-alpha.1](https://www.npmjs.com/package/@imtbl/sdk/v/1.14.0-alpha.1).

## Fixed
- IMX provider `isRegisteredOffChain` function should return a boolean instead of throwing when the user is not registered.
