### PR TITLE
fix: IMXClient not sending API keys

### DIFF
--- a/packages/x-client/src/IMXClient.ts
+++ b/packages/x-client/src/IMXClient.ts
@@ -68,6 +68,8 @@ import { Workflows } from './workflows';
 export class IMXClient {
   private immutableX: ImxApiClients;
 
+  public imxConfig: ImxConfiguration;
+
   public assetApi: AssetsApi;
 
   public balanceApi: BalancesApi;
@@ -107,8 +109,8 @@ export class IMXClient {
   public workflows: Workflows;
 
   constructor(config: ImxModuleConfiguration) {
-    const imxConfig = new ImxConfiguration(config);
-    this.immutableX = new ImxApiClients(imxConfig.immutableXConfig.apiConfiguration);
+    this.imxConfig = new ImxConfiguration(config);
+    this.immutableX = new ImxApiClients(this.imxConfig.immutableXConfig.apiConfiguration);
     this.assetApi = this.immutableX.assetApi;
     this.balanceApi = this.immutableX.balanceApi;
     this.collectionApi = this.immutableX.collectionApi;
@@ -128,7 +130,7 @@ export class IMXClient {
     this.usersApi = this.immutableX.usersApi;
     this.withdrawalsApi = this.immutableX.withdrawalsApi;
     this.workflows = new Workflows(
-      imxConfig.immutableXConfig,
+      this.imxConfig.immutableXConfig,
       this.immutableX.collectionApi,
       this.immutableX.exchangeApi,
       this.immutableX.metadataApi,

--- a/packages/x-client/src/config/config.test.ts
+++ b/packages/x-client/src/config/config.test.ts
@@ -3,6 +3,7 @@ import { imx } from '@imtbl/generated-clients';
 import {
   createConfig,
   ImmutableXConfiguration,
+  ImxConfiguration,
   Environment,
   imxClientConfig,
 } from './index';
@@ -119,5 +120,51 @@ describe('imxClientConfig', () => {
     // @ts-expect-error
     expect(() => imxClientConfig({ environment: 'invalid' }))
       .toThrowError('Invalid environment: invalid');
+  });
+
+  it('should set the APIs keys in the ImmutableConfiguration base config', () => {
+    const apiKey = 'api-key';
+    const publishableKey = 'publishable-key';
+    const rateLimitingKey = 'rate-limit-key';
+
+    const config = imxClientConfig({
+      environment: Environment.SANDBOX,
+      apiKey,
+      publishableKey,
+      rateLimitingKey,
+    });
+
+    expect(config.baseConfig.apiKey).toBe(apiKey);
+    expect(config.baseConfig.publishableKey).toBe(publishableKey);
+    expect(config.baseConfig.rateLimitingKey).toBe(rateLimitingKey);
+  });
+});
+
+describe('ImxConfiguration', () => {
+  it('should set apiConfiguration basePath, baseOptions, and headers when used with imxClientConfig', () => {
+    const apiKey = 'api-key';
+    const publishableKey = 'publishable-key';
+    const rateLimitingKey = 'rate-limit-key';
+
+    const config = imxClientConfig({
+      environment: Environment.SANDBOX,
+      apiKey,
+      publishableKey,
+      rateLimitingKey,
+    });
+
+    const imxConfig = new ImxConfiguration(config);
+
+    expect(imxConfig.immutableXConfig.apiConfiguration).toMatchObject({
+      basePath: 'https://api.sandbox.x.immutable.com',
+      baseOptions: {
+        headers: {
+          'x-sdk-version': 'ts-immutable-sdk-__SDK_VERSION__',
+          'x-immutable-api-key': apiKey,
+          'x-immutable-publishable-key': publishableKey,
+          'x-api-key': rateLimitingKey,
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

The underlying API clients in the `IMXClient` class were not correctly setting the API keys from Hub in request headers.

`IMXClient` methods should now send the API keys.

# Detail and impact of the change

## Fixed
- IMXClient methods were not sending Hub API keys with requests

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
