### PR TITLE
fix: [GPR-439][Sale Widget] Include tokenId on the success event payload

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetEvents.ts
@@ -26,6 +26,7 @@ export const sendSaleSuccessEvent = (
   eventTarget: Window | EventTarget,
   paymentMethod: SalePaymentTypes | undefined,
   transactions: ExecutedTransaction[] = [],
+  tokenIds: string[] = [],
 ) => {
   const event = new CustomEvent<
   WidgetEvent<WidgetType.SALE, SaleEventType.SUCCESS>
@@ -35,6 +36,7 @@ export const sendSaleSuccessEvent = (
       data: {
         paymentMethod,
         transactions,
+        tokenIds,
       },
     },
   });

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -199,6 +199,7 @@ export function SaleContextProvider(props: {
     signResponse,
     signError,
     executeResponse,
+    tokenIds,
   } = useSignOrder({
     items,
     provider,
@@ -259,13 +260,14 @@ export function SaleContextProvider(props: {
             data: {
               paymentMethod,
               transactions: executeResponse.transactions,
+              tokenIds,
               ...data,
             },
           },
         },
       });
     },
-    [[paymentMethod, executeResponse]],
+    [[paymentMethod, executeResponse, tokenIds]],
   );
 
   useEffect(() => {

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
@@ -66,6 +66,7 @@ export const useSaleEvent = () => {
   const sendSuccessEvent = (
     screen: string = defaultView,
     transactions: ExecutedTransaction[] = [],
+    tokenIds: string[] = [],
     details?: Record<string, unknown>,
   ) => {
     track({
@@ -80,9 +81,10 @@ export const useSaleEvent = () => {
         transactions: toStringifyTransactions(transactions),
         ...orderProps,
         paymentMethod,
+        tokenIds,
       },
     });
-    sendSaleSuccessEvent(eventTarget, paymentMethod, transactions);
+    sendSaleSuccessEvent(eventTarget, paymentMethod, transactions, tokenIds);
   };
 
   const sendFailedEvent = (

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
@@ -157,6 +157,7 @@ export const useSignOrder = (input: SignOrderInput) => {
     done: false,
     transactions: [],
   });
+  const [tokenIds, setTokenIds] = useState<string[]>([]);
 
   const setExecuteTransactions = (transaction: ExecutedTransaction) => {
     setExecuteResponse((prev) => ({
@@ -284,7 +285,14 @@ export const useSignOrder = (input: SignOrderInput) => {
           return undefined;
         }
 
-        const responseData = toSignResponse(await response.json(), items);
+        const apiResponse: SignApiResponse = await response.json();
+        const apiTokenIds = apiResponse.order.products
+          .map((product) => product.detail.map(({ token_id }) => token_id))
+          .flat();
+
+        const responseData = toSignResponse(apiResponse, items);
+
+        setTokenIds(apiTokenIds);
         setSignResponse(responseData);
 
         return responseData;
@@ -348,5 +356,6 @@ export const useSignOrder = (input: SignOrderInput) => {
     signError,
     execute,
     executeResponse,
+    tokenIds,
   };
 };

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
@@ -192,7 +192,6 @@ export const useSignOrder = (input: SignOrderInput) => {
         });
 
         setExecuteTransactions({ method, hash: txnResponse?.hash });
-        await txnResponse?.wait();
 
         transactionHash = txnResponse?.hash || '';
         return [transactionHash, undefined];

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/SaleSuccessView.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/SaleSuccessView.tsx
@@ -20,8 +20,8 @@ export function SaleSuccessView({ data }: SaleSuccessViewProps) {
       statusText={t('views.SALE_SUCCESS.text')}
       actionText={t('views.SALE_SUCCESS.actionText')}
       onRenderEvent={() => {
-        const { transactions, ...rest } = data;
-        sendSuccessEvent(SaleWidgetViews.SALE_SUCCESS, transactions, rest);
+        const { transactions, tokenIds, ...details } = data;
+        sendSuccessEvent(SaleWidgetViews.SALE_SUCCESS, transactions, tokenIds, details);
       }}
       onActionClick={() => closeWidget()}
       statusType={StatusType.SUCCESS}


### PR DESCRIPTION
# Summary
Improve the integration of the sale widget by:
- Including the tokenIds from order on the success event payload, and
- Removing the transaction settlement waits
