### PR TITLE
fix: [Sale widget] Loading copy and missing type field

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/events/sale.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/events/sale.ts
@@ -21,6 +21,8 @@ export enum SaleEventType {
 export type SaleSuccess = {
   /** Chosen payment method */
   paymentMethod: SalePaymentTypes | undefined;
+  /** The minted items token ids  */
+  tokenIds: string[];
   /** The executed transactions */
   transactions: {
     method: string;

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
@@ -63,7 +63,7 @@ export function PaymentMethods() {
           type: ViewActions.UPDATE_VIEW,
           view: {
             type: SharedViews.LOADING_VIEW,
-            data: { loadingText: t('views.PAYMENT_METHODS.loading.ready') },
+            data: { loadingText: t('views.PAYMENT_METHODS.loading.ready1') },
           },
         },
       });


### PR DESCRIPTION
# Summary
Fixes broken copy path and missing type definition