### PR TITLE
chore: [DX-2714] remove unused core sdk dependencies

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,6 @@
   "author": "Immutable",
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",
   "dependencies": {
-    "@imtbl/core-sdk": "^2.4.0",
     "@imtbl/metrics": "0.0.0",
     "@magic-ext/oidc": "4.2.0",
     "@metamask/detect-provider": "^2.0.0",

--- a/packages/x-client/package.json
+++ b/packages/x-client/package.json
@@ -12,7 +12,6 @@
     "@ethersproject/strings": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
     "@imtbl/config": "0.0.0",
-    "@imtbl/core-sdk": "^2.4.0",
     "@imtbl/generated-clients": "0.0.0",
     "axios": "^1.6.5",
     "bn.js": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3922,7 +3922,6 @@ __metadata:
     "@ethersproject/strings": ^5.7.0
     "@ethersproject/wallet": ^5.7.0
     "@imtbl/config": 0.0.0
-    "@imtbl/core-sdk": ^2.4.0
     "@imtbl/generated-clients": 0.0.0
     "@rollup/plugin-typescript": ^11.0.0
     "@swc/jest": ^0.2.24

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,7 +3483,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@imtbl/config@workspace:packages/config"
   dependencies:
-    "@imtbl/core-sdk": ^2.4.0
     "@imtbl/metrics": 0.0.0
     "@magic-ext/oidc": 4.2.0
     "@metamask/detect-provider": ^2.0.0


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
Remove Core SDK as a dependency from the x-client and config packages, since it is not used.

# Detail and impact of the change
No impact.

# Anything else worth calling out?
No code changes