### PR TITLE
feat: Hook up error drawers to connect widget

### DIFF
--- a/packages/checkout/widgets-lib/src/lib/hooks/useWalletConnect.ts
+++ b/packages/checkout/widgets-lib/src/lib/hooks/useWalletConnect.ts
@@ -22,7 +22,7 @@ export const useWalletConnect = () => {
       (async () => setEthereumProvider(await WalletConnectManager.getInstance().getProvider()))();
       setWalletConnectModal(WalletConnectManager.getInstance().getModal());
     }
-  }, []);
+  }, [isWalletConnectEnabled]);
 
   const openWalletConnectModal = useCallback(async ({
     connectCallback,

--- a/packages/checkout/widgets-lib/src/lib/hooks/useWalletConnect.ts
+++ b/packages/checkout/widgets-lib/src/lib/hooks/useWalletConnect.ts
@@ -133,6 +133,14 @@ export const useWalletConnect = () => {
   ), [ethereumProvider, walletConnectModal]);
 
   const getWalletLogoUrl = useCallback(async () => await WalletConnectManager.getInstance().getWalletLogoUrl(), []);
+  const getWalletName = useCallback(() => {
+    if (!ethereumProvider || !ethereumProvider.session) return 'Other';
+    let peerName = ethereumProvider.session.peer.metadata.name;
+    peerName = peerName.replace('Wallet', '');
+    peerName = peerName.replace('wallet', '');
+    peerName = peerName.trim();
+    return peerName;
+  }, [ethereumProvider]);
 
   return {
     isWalletConnectEnabled,
@@ -141,5 +149,6 @@ export const useWalletConnect = () => {
     walletConnectModal,
     openWalletConnectModal,
     getWalletLogoUrl,
+    getWalletName,
   };
 };

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletNetworkButton.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletNetworkButton.tsx
@@ -5,7 +5,7 @@ import { ChainId, WalletProviderRdns } from '@imtbl/checkout-sdk';
 import { getChainNameById } from 'lib/chains';
 import { networkIcon } from 'lib';
 import { Web3Provider } from '@ethersproject/providers';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useWalletConnect } from 'lib/hooks/useWalletConnect';
 import {
   networkButtonStyles,
@@ -44,8 +44,21 @@ export function WalletNetworkButton({
   const [walletLogoUrl, setWalletLogoUrl] = useState<string | undefined>(
     undefined,
   );
+  const [walletConnectPeerName, setWalletConnectPeerName] = useState('Other');
   const [isWalletConnect, setIsWalletConnect] = useState<boolean>(false);
-  const { isWalletConnectEnabled, getWalletLogoUrl } = useWalletConnect();
+  const { isWalletConnectEnabled, getWalletLogoUrl, getWalletName } = useWalletConnect();
+
+  const walletDisplayName = useMemo(() => {
+    if (walletProviderDetail?.info.rdns === WalletProviderRdns.PASSPORT) {
+      return walletName;
+    }
+
+    if (isWalletConnectProvider(walletProvider)) {
+      return walletConnectPeerName;
+    }
+
+    return walletProviderDetail?.info.name;
+  }, [walletProviderDetail, walletConnectPeerName, walletProvider]);
 
   useEffect(() => {
     if (isWalletConnectEnabled) {
@@ -55,9 +68,10 @@ export function WalletNetworkButton({
         (async () => {
           setWalletLogoUrl(await getWalletLogoUrl());
         })();
+        setWalletConnectPeerName(getWalletName());
       }
     }
-  }, [isWalletConnectEnabled, walletProvider]);
+  }, [isWalletConnectEnabled, walletProvider, getWalletLogoUrl, getWalletName]);
 
   return (
     <Box
@@ -87,10 +101,7 @@ export function WalletNetworkButton({
           flex: 1,
         }}
       >
-        <Heading size="xSmall" sx={{ textTransform: 'capitalize' }}>
-          {walletProviderDetail?.info.rdns === WalletProviderRdns.PASSPORT
-            ? walletName : walletProviderDetail?.info.name}
-        </Heading>
+        <Heading size="xSmall" sx={{ textTransform: 'capitalize' }}>{walletDisplayName}</Heading>
         <Body size="xSmall" sx={walletCaptionStyles}>
           {walletAddress}
         </Body>


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

## **User rejected/ ChangedYourMindDrawer flow**

**_MetaMask_**

https://github.com/immutable/ts-immutable-sdk/assets/37326128/03e9d475-1eff-4aeb-b334-80d712bfcb1a



**_Passport_**

https://github.com/immutable/ts-immutable-sdk/assets/37326128/df9cf426-5d66-4897-a1aa-f33cc7aaa12e



## **Other errors / UnableToConnectDrawer flow**

https://github.com/immutable/ts-immutable-sdk/assets/37326128/f541c35b-2c90-4d66-a0d5-3a68d18ba298



# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->

## Changed
<!-- Section for changes in existing functionality. -->

- showing ChangedYourMind drawer when user rejects connection, all other errors will show UnableToConnect drawer

## Removed
<!-- Section for now removed features. -->

- replaced generic error view with unable to connect drawer

## Fixed
<!-- Section for any bug fixes. -->

- add `isWalletConnectEnabled` as dependency to avoid multiple errors for WC initialisation

