### PR TITLE
[GASBT-10][Sale Widget] Delay calls to smart checkout until token address is set

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/views/FundWithSmartCheckout.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/FundWithSmartCheckout.tsx
@@ -32,7 +32,7 @@ export function FundWithSmartCheckout({ subView }: FundWithSmartCheckoutProps) {
   >(undefined);
   const [fundingRouteStepIndex, setFundingRouteStepIndex] = useState<number>(0);
   const {
-    querySmartCheckout, fundingRoutes, smartCheckoutResult, collectionName,
+    querySmartCheckout, fundingRoutes, smartCheckoutResult, collectionName, fromTokenAddress,
   } = useSaleContext();
   const { cryptoFiatDispatch } = useContext(CryptoFiatContext);
 
@@ -41,9 +41,9 @@ export function FundWithSmartCheckout({ subView }: FundWithSmartCheckoutProps) {
   };
 
   useEffect(() => {
-    if (subView !== FundWithSmartCheckoutSubViews.INIT) return;
+    if (subView !== FundWithSmartCheckoutSubViews.INIT || !fromTokenAddress) return;
     querySmartCheckout();
-  }, [subView]);
+  }, [subView, fromTokenAddress]);
 
   useEffect(() => {
     if (!cryptoFiatDispatch || !smartCheckoutResult) return;


### PR DESCRIPTION
# Summary
Delay calls to smart checkout until token address was set

# Fixes bug
Sale widget was throwing error `Can't check wallet balances` on first time, given that calls to get `client-config` were running slow in sandbox.
