### PR TITLE
fix: jsdoc for WalletWidgetConfiguration

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/configurations/wallet.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/configurations/wallet.ts
@@ -3,10 +3,12 @@ import { WidgetConfiguration } from './widget';
 
 /**
  * Wallet Widget Configuration represents the configuration options for the Wallet Widget.
- * @property {boolean | undefined} showDisconnectButton - show/hide the disconnect button in the Wallet Widget (defaults to true)
- * @property {boolean | undefined} showNetworkMenu - show/hide the network menu in the Wallet Widget (defaults to true)
+ * @property {boolean | undefined} showDisconnectButton
+ * @property {boolean | undefined} showNetworkMenu
  */
 export type WalletWidgetConfiguration = {
+  /** Show/hide the disconnect button in the Wallet Widget (defaults to true) */
   showDisconnectButton?: boolean;
+  /** Show/hide the network menu in the Wallet Widget (defaults to true) */
   showNetworkMenu?: boolean;
 } & WidgetConfiguration;


### PR DESCRIPTION
Fix up jsdocs for WalletWidgetConfiguration so that it'll appear in the sdk reference site.