### PR TITLE
[ID-1456]send confirmation start post message to confirmation screen

### DIFF
--- a/packages/passport/sdk/src/confirmation/confirmation.ts
+++ b/packages/passport/sdk/src/confirmation/confirmation.ts
@@ -3,6 +3,7 @@ import {
   ConfirmationResult,
   PASSPORT_EVENT_TYPE,
   ReceiveMessage,
+  SendMessage,
 } from './types';
 import { openPopupCenter } from './popup';
 import { PassportConfiguration } from '../config';
@@ -58,6 +59,10 @@ export default class ConfirmationScreen {
         }
         switch (data.messageType as ReceiveMessage) {
           case ReceiveMessage.CONFIRMATION_WINDOW_READY: {
+            this.confirmationWindow?.postMessage({
+              eventType: PASSPORT_EVENT_TYPE,
+              messageType: SendMessage.CONFIRMATION_START,
+            }, this.config.passportDomain);
             break;
           }
           case ReceiveMessage.TRANSACTION_CONFIRMED: {
@@ -101,6 +106,10 @@ export default class ConfirmationScreen {
         }
         switch (data.messageType as ReceiveMessage) {
           case ReceiveMessage.CONFIRMATION_WINDOW_READY: {
+            this.confirmationWindow?.postMessage({
+              eventType: PASSPORT_EVENT_TYPE,
+              messageType: SendMessage.CONFIRMATION_START,
+            }, this.config.passportDomain);
             break;
           }
           case ReceiveMessage.MESSAGE_CONFIRMED: {

--- a/packages/passport/sdk/src/confirmation/types.ts
+++ b/packages/passport/sdk/src/confirmation/types.ts
@@ -1,3 +1,7 @@
+export enum SendMessage {
+  CONFIRMATION_START = 'confirmation_start',
+}
+
 export enum ReceiveMessage {
   CONFIRMATION_WINDOW_READY = 'confirmation_window_ready',
   TRANSACTION_CONFIRMED = 'transaction_confirmed',


### PR DESCRIPTION

### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

https://github.com/immutable/ts-immutable-sdk/assets/3668156/5853e32f-119e-45a5-acd8-ad031fc817d1



# Detail and impact of the change
## Added 
* send Post message to popup window when received the window is ready event.

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
