### PR TITLE
chore: [DX-2725] fix update docs link script

### DIFF
--- a/.github/scripts/update-docs-link.sh
+++ b/.github/scripts/update-docs-link.sh
@@ -27,18 +27,18 @@ fi
 
   # Update versions in the browserBundle docs (https://docs.immutable.com/docs/x/sdks/typescript/#browser-bundle)
   FILE=docs/main/sdks/_typescript.mdx
-  major=$(awk '{ 
+  major=$(echo $VERSION | awk '{ 
     split($0, a, ".");
     print a[1];
-  }' <<< $VERSION)
-  minor=$(awk '{ 
+  }')
+  minor=$(echo $VERSION | awk '{ 
     split($0, a, ".");
     print a[2];
-  }' <<< $VERSION)
-  patch=$(awk '{ 
+  }')
+  patch=$(echo $VERSION | awk '{ 
     split($0, a, ".");
     print a[3];
-  }' <<< $VERSION)
+  }')
   echo "major: $major minor: $minor patch: $patch"
 
   # On Mac OS, sed requires an empty string as an argument to -i to avoid creating a backup file


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
Fix the update docs link script ["redirection unexpected" error](https://github.com/immutable/ts-immutable-sdk/actions/runs/8366243195/job/22906013440) which occurred when publishing a release.

# Anything else worth calling out?
There are no functional changes to the `@imtbl/sdk` code.

The previous version of the script used [here strings](https://unix.stackexchange.com/a/80372/7684) (`<<< $VERSION`), which didn't work on the Github runners. Therefore, fall back to the more traditional `echo $VERSION |`