### PR TITLE
chore: upgrade to seaport-js v4

### DIFF
--- a/packages/orderbook/package.json
+++ b/packages/orderbook/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",
   "dependencies": {
     "@imtbl/config": "0.0.0",
-    "@opensea/seaport-js": "3.0.2",
+    "@opensea/seaport-js": "4.0.0",
     "axios": "^1.6.5",
     "ethers": "^5.7.2",
     "ethers-v6": "npm:ethers@6.11.1"

--- a/packages/orderbook/src/seaport/seaport-lib-factory.ts
+++ b/packages/orderbook/src/seaport/seaport-lib-factory.ts
@@ -48,11 +48,9 @@ export class SeaportLibFactory {
   ) { }
 
   create(orderSeaportVersion?: SeaportVersion, orderSeaportAddress?: string): SeaportLib {
-    const seaportVersion = orderSeaportVersion ?? SEAPORT_CONTRACT_VERSION_V1_5;
     const seaportContractAddress = orderSeaportAddress ?? this.defaultSeaportContractAddress;
 
     return new SeaportLib(convertToV6Provider(this.provider), {
-      seaportVersion,
       balanceAndApprovalChecksOnOrderCreation: true,
       overrides: {
         contractAddress: seaportContractAddress,

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -20,7 +20,7 @@
     "@jest/globals": "^29.5.0",
     "@magic-ext/oidc": "4.2.0",
     "@metamask/detect-provider": "^2.0.0",
-    "@opensea/seaport-js": "3.0.2",
+    "@opensea/seaport-js": "4.0.0",
     "@rive-app/react-canvas": "^4.8.3",
     "@uniswap/router-sdk": "^1.4.0",
     "@uniswap/sdk-core": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,7 +3856,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@magic-ext/oidc": 4.2.0
     "@metamask/detect-provider": ^2.0.0
-    "@opensea/seaport-js": 3.0.2
+    "@opensea/seaport-js": 4.0.0
     "@rive-app/react-canvas": ^4.8.3
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^24.0.1
@@ -5315,16 +5315,6 @@ __metadata:
   version: 1.0.3
   resolution: "@open-draft/until@npm:1.0.3"
   checksum: 323e92ebef0150ed0f8caedc7d219b68cdc50784fa4eba0377eef93533d3f46514eb2400ced83dda8c51bddc3d2c7b8e9cf95e5ec85ab7f62dfc015d174f62f2
-  languageName: node
-  linkType: hard
-
-"@opensea/seaport-js@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@opensea/seaport-js@npm:3.0.2"
-  dependencies:
-    ethers: ^6.9.0
-    merkletreejs: ^0.3.11
-  checksum: a1bb99e86ce26e01c554133c91e521d0ac63422d3ae77a32ab903f7e218fe32fc2f9b7884c0b96d2c88ea4396e3a891d02e978e222743648051c1ca970df97f7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,7 +3719,7 @@ __metadata:
   resolution: "@imtbl/orderbook@workspace:packages/orderbook"
   dependencies:
     "@imtbl/config": 0.0.0
-    "@opensea/seaport-js": 3.0.2
+    "@opensea/seaport-js": 4.0.0
     "@rollup/plugin-typescript": ^11.0.0
     "@swc/jest": ^0.2.24
     "@typechain/ethers-v5": ^10.2.0
@@ -5325,6 +5325,16 @@ __metadata:
     ethers: ^6.9.0
     merkletreejs: ^0.3.11
   checksum: a1bb99e86ce26e01c554133c91e521d0ac63422d3ae77a32ab903f7e218fe32fc2f9b7884c0b96d2c88ea4396e3a891d02e978e222743648051c1ca970df97f7
+  languageName: node
+  linkType: hard
+
+"@opensea/seaport-js@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@opensea/seaport-js@npm:4.0.0"
+  dependencies:
+    ethers: ^6.9.0
+    merkletreejs: ^0.3.11
+  checksum: dcc921db35818da0111c7884e7aeb26a3b2e1909ad9395fd467ae429dbdca319e4673115d91c378fc7b6bf422c80fb0f56477813c7c45c3f0d66e7dfbc0ad02b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
Upgrade from seaport-js v3 to v4. There are no interface differences between these versions, however v4 fixes partial fill bugs and adds support for Seaport 1.6, while retaining support for Seaport 1.5
