### PR TITLE
feat: [GPR-521] Swap widget implementation of fee breakdown

### DIFF
--- a/packages/checkout/widgets-lib/src/locales/en.json
+++ b/packages/checkout/widgets-lib/src/locales/en.json
@@ -598,7 +598,7 @@
       "fees": {
         "fiatPricePrefix": "USD $",
         "gasFeeSwap": {
-          "label": "Gas fee swap"
+          "label": "Gas fee"
         },
         "gasFeeMove": {
           "label": "Gas fee move"
@@ -608,6 +608,9 @@
         },
         "serviceFee": {
           "label": "Service fee"
+        },
+        "secondarySwapFee": {
+          "label": "Swap service fee"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -604,8 +604,21 @@
       "heading": "手数料の内訳",
       "total": "総手数料",
       "fees": {
-        "gas": {
-          "label": "ガス手数料"
+        "fiatPricePrefix": "USD $",
+        "gasFeeSwap": {
+          "label": "ガス料金"
+        },
+        "gasFeeMove": {
+          "label": "ガス料金移動"
+        },
+        "gasFeeApproval": {
+          "label": "ガス料金承認"
+        },
+        "serviceFee": {
+          "label": "手数料"
+        },
+        "secondarySwapFee": {
+          "label": "スワップ手数料"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -597,8 +597,21 @@
       "heading": "수수료 내역",
       "total": "수수료 총액",
       "fees": {
-        "gas": {
+        "fiatPricePrefix": "USD $",
+        "gasFeeSwap": {
           "label": "가스 수수료"
+        },
+        "gasFeeMove": {
+          "label": "가스 수수료 이동"
+        },
+        "gasFeeApproval": {
+          "label": "가스 수수료 승인"
+        },
+        "serviceFee": {
+          "label": "서비스 수수료"
+        },
+        "secondarySwapFee": {
+          "label": "스왑 수수료"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -600,8 +600,21 @@
       "heading": "费用分解",
       "total": "费用总计",
       "fees": {
-        "gas": {
+        "fiatPricePrefix": "USD $",
+        "gasFeeSwap": {
           "label": "燃气费"
+        },
+        "gasFeeMove": {
+          "label": "燃气费转移"
+        },
+        "gasFeeApproval": {
+          "label": "燃气费批准"
+        },
+        "serviceFee": {
+          "label": "服务费"
+        },
+        "secondarySwapFee": {
+          "label": "交换服务费"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
@@ -173,8 +173,6 @@ export function BridgeReviewSummary() {
     setApproveTransaction(unsignedApproveTransaction);
     setTransaction(unsignedTransaction);
 
-    // todo: add approval gas fees
-
     const transactionFeeData = unsignedTransaction.feeData;
 
     const { totalFees, approvalFee } = transactionFeeData;

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapButton.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapButton.tsx
@@ -23,7 +23,7 @@ export interface SwapButtonProps {
   loading: boolean
   updateLoading: (value: boolean) => void
   validator: () => boolean
-  transaction: TransactionResponse | null;
+  transaction: TransactionResponse | undefined;
   data?: SwapFormData;
   insufficientFundsForGas: boolean;
   openNotEnoughImxDrawer: () => void;

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -45,6 +45,7 @@ import { UnableToSwap } from './UnableToSwap';
 import { ConnectLoaderContext } from '../../../context/connect-loader-context/ConnectLoaderContext';
 import useDebounce from '../../../lib/hooks/useDebounce';
 import { CancellablePromise } from '../../../lib/async/cancellablePromise';
+import { formatSwapFees } from '../functions/SwapFees';
 
 enum SwapDirection {
   FROM = 'FROM',
@@ -145,7 +146,7 @@ export function SwapForm({ data, theme }: SwapFromProps) {
   const [fromFiatValue, setFromFiatValue] = useState('');
 
   // Quote
-  const [quote, setQuote] = useState<TransactionResponse | null>(null);
+  const [quote, setQuote] = useState<TransactionResponse | undefined>(undefined);
   const [gasFeeValue, setGasFeeValue] = useState<string>('');
   const [gasFeeToken, setGasFeeToken] = useState<TokenInfo | undefined>(undefined);
   const [gasFeeFiatValue, setGasFeeFiatValue] = useState<string>('');
@@ -253,7 +254,7 @@ export function SwapForm({ data, theme }: SwapFromProps) {
     }
     setSwapFromToConversionText('');
     setGasFeeFiatValue('');
-    setQuote(null);
+    setQuote(undefined);
   };
 
   const processFetchQuoteFrom = async (silently: boolean = false) => {
@@ -296,12 +297,17 @@ export function SwapForm({ data, theme }: SwapFromProps) {
       if (quoteResult.approval?.gasFeeEstimate) {
         gasFeeTotal = gasFeeTotal.add(quoteResult.approval.gasFeeEstimate.value);
       }
+      gasFeeTotal = quoteResult.quote?.fees?.reduce((previous, currentFee) => {
+        const previousFeeAmount = BigNumber.from(previous);
+        const currentFeeAmount = BigNumber.from(currentFee.amount.value);
+        return previousFeeAmount.add(currentFeeAmount);
+      }, gasFeeTotal) ?? gasFeeTotal;
+
       const gasFee = utils.formatUnits(
         gasFeeTotal,
-        DEFAULT_TOKEN_DECIMALS,
+        estimate?.token?.decimals ?? DEFAULT_TOKEN_DECIMALS,
       );
       const estimateToken = estimate?.token;
-
       const gasToken = allowedTokens.find(
         (token) => token.address?.toLocaleLowerCase() === estimateToken?.address?.toLocaleLowerCase(),
       );
@@ -387,9 +393,15 @@ export function SwapForm({ data, theme }: SwapFromProps) {
       if (quoteResult.approval?.gasFeeEstimate) {
         gasFeeTotal = gasFeeTotal.add(quoteResult.approval.gasFeeEstimate.value);
       }
+      gasFeeTotal = quoteResult.quote?.fees?.reduce((previous, currentFee) => {
+        const previousFeeAmount = BigNumber.from(previous);
+        const currentFeeAmount = BigNumber.from(currentFee.amount.value);
+        return previousFeeAmount.add(currentFeeAmount);
+      }, gasFeeTotal) ?? gasFeeTotal;
+
       const gasFee = utils.formatUnits(
         gasFeeTotal,
-        DEFAULT_TOKEN_DECIMALS,
+        estimate?.token?.decimals ?? DEFAULT_TOKEN_DECIMALS,
       );
       const estimateToken = estimate?.token;
 
@@ -633,6 +645,11 @@ export function SwapForm({ data, theme }: SwapFromProps) {
     setShowNotEnoughImxDrawer(true);
   };
 
+  const formatFeeBreakdown = useCallback(
+    (): any => formatSwapFees(quote, cryptoFiatState, t),
+    [quote, cryptoFiatState, t],
+  );
+
   const SwapFormValidator = (): boolean => {
     const validateFromTokenError = validateFromToken(fromToken);
     const validateFromAmountError = validateFromAmount(fromAmount, fromBalance);
@@ -801,17 +818,10 @@ export function SwapForm({ data, theme }: SwapFromProps) {
           </Box>
         </Box>
         <Fees
+          gasFeeValue={gasFeeValue}
           gasFeeFiatValue={gasFeeFiatValue}
           gasFeeToken={gasFeeToken}
-          gasFeeValue={gasFeeValue}
-          fees={[
-            {
-              label: t('drawers.feesBreakdown.fees.gasFeeSwap.label'),
-              fiatAmount: `~ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${gasFeeFiatValue}`,
-              amount: tokenValueFormat(gasFeeValue),
-              prefix: '~',
-            },
-          ]}
+          fees={formatFeeBreakdown()}
           onFeesClick={() => {
             track({
               userJourney: UserJourney.SWAP,

--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/SwapFees.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/SwapFees.test.ts
@@ -1,0 +1,68 @@
+import { describe } from '@jest/globals';
+import { BigNumber } from 'ethers';
+import { TransactionResponse } from '@imtbl/dex-sdk';
+import { formatSwapFees } from './SwapFees';
+import { CryptoFiatState } from '../../../context/crypto-fiat-context/CryptoFiatContext';
+
+describe('formatSwapFees', () => {
+  const t = (key) => key; // Mock translation function
+  const DEFAULT_DECIMALS = 18; // Default to 18 if your DEFAULT_TOKEN_DECIMALS is similar
+  const mockCryptoFiatState: CryptoFiatState = {
+    conversions: new Map<string, number>([
+      ['eth', 2500], // Example conversion rate
+    ]),
+  } as CryptoFiatState;
+
+  it('should return an empty array when quoteResult is undefined', () => {
+    expect(formatSwapFees(undefined, mockCryptoFiatState, t)).toEqual([]);
+  });
+
+  it('should handle gasFeeEstimate correctly', () => {
+    const quoteResult = {
+      swap: {
+        gasFeeEstimate: {
+          value: BigNumber.from('100000000000000000'), // 0.1 ETH in wei
+          token: {
+            symbol: 'ETH',
+            decimals: DEFAULT_DECIMALS,
+          },
+        },
+      },
+    } as TransactionResponse;
+    const fees = formatSwapFees(quoteResult, mockCryptoFiatState, t);
+    expect(fees).toHaveLength(1);
+    expect(fees[0].label).toBe('drawers.feesBreakdown.fees.gasFeeSwap.label');
+    expect(fees[0].fiatAmount).toContain('~ drawers.feesBreakdown.fees.fiatPricePrefix250'); // Assuming calculateCryptoToFiat returns a simplified calculation
+  });
+
+  it('should handle gasFeeApprovalEstimate correctly', () => {
+    // Similar to the above test but with approval fees
+  });
+
+  it('should handle additional fees correctly', () => {
+    const quoteResult = {
+      quote: {
+        fees: [
+          {
+            amount: {
+              value: '100000000000000000', // 0.1 ETH in wei
+              token: {
+                symbol: 'ETH',
+                decimals: DEFAULT_DECIMALS,
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as TransactionResponse;
+    const fees = formatSwapFees(quoteResult, mockCryptoFiatState, t);
+    expect(fees).toHaveLength(1);
+    expect(fees[0].label).toBe('drawers.feesBreakdown.fees.secondarySwapFee.label');
+    expect(fees[0].fiatAmount).toContain('drawers.feesBreakdown.fees.fiatPricePrefix250');
+  });
+
+  // Add more tests as needed to cover different scenarios, such as:
+  // - Multiple fees in the quoteResult.quote.fees array
+  // - Handling of different tokens with different decimals
+  // - Edge cases like extremely high fees, 0 fees, etc.
+});

--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/SwapFees.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/SwapFees.ts
@@ -1,0 +1,82 @@
+import { TransactionResponse } from '@imtbl/dex-sdk';
+import { BigNumber, utils } from 'ethers';
+import { calculateCryptoToFiat, tokenValueFormat } from '../../../lib/utils';
+import { CryptoFiatState } from '../../../context/crypto-fiat-context/CryptoFiatContext';
+import { DEFAULT_TOKEN_DECIMALS } from '../../../lib';
+
+export const formatSwapFees = (
+  quoteResult: TransactionResponse | undefined,
+  cryptoFiatState: CryptoFiatState,
+  t,
+): any[] => {
+  const fees: any[] = [];
+  if (!quoteResult) return fees;
+
+  if (quoteResult.quote?.fees?.length > 0) {
+    const additionalFeeAmount = quoteResult.quote.fees.reduce((previous, currentFee) => {
+      const previousFeeAmount = BigNumber.from(previous);
+      const currentFeeAmount = BigNumber.from(currentFee.amount.value);
+      return previousFeeAmount.add(currentFeeAmount);
+    }, BigNumber.from(0));
+
+    const feeToken = quoteResult.quote?.fees[0].amount.token;
+    const additionalFeeValue = utils.formatUnits(
+      additionalFeeAmount,
+      feeToken?.decimals ?? DEFAULT_TOKEN_DECIMALS,
+    );
+
+    const additionalFeeFiatValue = calculateCryptoToFiat(
+      additionalFeeValue,
+      feeToken?.symbol || '',
+      cryptoFiatState.conversions,
+    );
+    fees.push({
+      label: t('drawers.feesBreakdown.fees.secondarySwapFee.label'),
+      fiatAmount: `~ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${additionalFeeFiatValue}`,
+      amount: tokenValueFormat(additionalFeeValue),
+    });
+  }
+
+  const gasFeeEstimate = BigNumber.from(quoteResult.swap?.gasFeeEstimate?.value || 0);
+  if (gasFeeEstimate.gt(0)) {
+    const gasToken = quoteResult.swap.gasFeeEstimate?.token;
+    const gasFeeValue = utils.formatUnits(
+      gasFeeEstimate,
+      gasToken?.decimals ?? DEFAULT_TOKEN_DECIMALS,
+    );
+
+    const gasFeeFiatValue = calculateCryptoToFiat(
+      gasFeeValue,
+      gasToken?.symbol || '',
+      cryptoFiatState.conversions,
+    );
+    fees.push({
+      label: t('drawers.feesBreakdown.fees.gasFeeSwap.label'),
+      fiatAmount: `~ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${gasFeeFiatValue}`,
+      amount: tokenValueFormat(gasFeeValue),
+      prefix: '~',
+    });
+  }
+  const gasFeeApprovalEstimate = BigNumber.from(quoteResult.approval?.gasFeeEstimate?.value || 0);
+  if (gasFeeApprovalEstimate.gt(0)) {
+    const gasToken = quoteResult.approval?.gasFeeEstimate?.token;
+    const gasFeeApprovalValue = utils.formatUnits(
+      gasFeeApprovalEstimate,
+      gasToken?.decimals ?? DEFAULT_TOKEN_DECIMALS,
+    );
+
+    const gasFeeApprovalFiatValue = calculateCryptoToFiat(
+      gasFeeApprovalValue,
+      gasToken?.symbol || '',
+      cryptoFiatState.conversions,
+    );
+    fees.push({
+      label: t('drawers.feesBreakdown.fees.gasFeeApproval.label'),
+      fiatAmount: `~ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${gasFeeApprovalFiatValue}`,
+      amount: tokenValueFormat(gasFeeApprovalValue),
+      prefix: '~',
+    });
+  }
+
+  return fees;
+};


### PR DESCRIPTION
# Summary
Added support for fee breakdown in Swap widget fees component.
[GPR-521](https://immutable.atlassian.net/browse/GPR-521)

<img width="440" alt="Screenshot 2024-03-28 at 9 50 01 AM" src="https://github.com/immutable/ts-immutable-sdk/assets/1617003/bc7c6355-5430-4998-b7e0-d3b1476045d8">


# Detail and impact of the change
## Added 
Swap fees breakdown for swap service fee, gas fee, gas approval fee

[GPR-521]: https://immutable.atlassian.net/browse/GPR-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ