### PR TITLE
chore: bump engine version to v20.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "wsrun": "^5.2.4"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "homepage": "https://github.com/immutable/ts-immutable-sdk#readme",
   "license": "Apache-2.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -24,7 +24,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/internal/bridge/sdk/package.json
+++ b/packages/internal/bridge/sdk/package.json
@@ -30,7 +30,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.11.0"
   },
   "homepage": "https://github.com/immutable/ts-immutable-sdk#readme",
   "keywords": [

--- a/packages/internal/cryptofiat/package.json
+++ b/packages/internal/cryptofiat/package.json
@@ -28,7 +28,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/internal/dex/sdk/package.json
+++ b/packages/internal/dex/sdk/package.json
@@ -26,7 +26,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/internal/factory/sdk/package.json
+++ b/packages/internal/factory/sdk/package.json
@@ -27,7 +27,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.11.0"
   },
   "homepage": "https://github.com/immutable/ts-immutable-sdk#readme",
   "keywords": [

--- a/packages/internal/generated-clients/package.json
+++ b/packages/internal/generated-clients/package.json
@@ -10,7 +10,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/internal/guardian/package.json
+++ b/packages/internal/guardian/package.json
@@ -23,7 +23,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/internal/metrics/package.json
+++ b/packages/internal/metrics/package.json
@@ -21,7 +21,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/internal/toolkit/package.json
+++ b/packages/internal/toolkit/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/internal/version-check/package.json
+++ b/packages/internal/version-check/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/passport/sdk/package.json
+++ b/packages/passport/sdk/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/x-client/package.json
+++ b/packages/x-client/package.json
@@ -32,7 +32,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/packages/x-provider/package.json
+++ b/packages/x-provider/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "files": [
     "dist"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -86,7 +86,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.11.0"
   },
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
Bump engine version to a minimum of 20.11.0, the current LTS version.

# Anything else worth calling out?
No functionality/behavioural changes

CI and local dev are already using `v20.11.0`