### PR TITLE
fix: remove merge_group event from secret scanning

### DIFF
--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,5 +1,5 @@
 name: gitleaks
-on: [pull_request, push, workflow_dispatch, merge_group]
+on: [pull_request, push, workflow_dispatch]
 jobs:
   scan:
     name: gitleaks


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

The GitLeaks workflow doesn't support the `merge_group` Github action event.

The workflow is throwing an error and preventing PR's from merging.

PR removes the `merge_group` event to unblock PR's. 

# Detail and impact of the change
The change should not impact external customers as it only changes the GitLeaks workflow events.

## Removed
- `merge_group` event from GitLeaks workflow

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
