### PR TITLE
chore: [DX-2681] if a check is run in a merge queue, don't run it on push to main

### DIFF
--- a/.github/workflows/build-lint-typecheck-test.yaml
+++ b/.github/workflows/build-lint-typecheck-test.yaml
@@ -1,9 +1,6 @@
 name: Build, Lint, Typecheck, Test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/functional-tests-imx.yml
+++ b/.github/workflows/functional-tests-imx.yml
@@ -1,7 +1,5 @@
 name: Functional Tests (IMX)
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   merge_group:

--- a/.github/workflows/functional-tests-zkevm.yml
+++ b/.github/workflows/functional-tests-zkevm.yml
@@ -1,7 +1,5 @@
 name: Functional Tests (zkEVM)
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   merge_group:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,5 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   merge_group:


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
In order to speed up the build queue, this PR prevents checks that have already run in the merge queue from running on push to main. 

# Anything else worth calling out?
No other code changes.