### PR TITLE
fix: ID-1538 Resolved issue with redirect logout not logging out of Magic

### DIFF
--- a/packages/passport/sdk/src/Passport.test.ts
+++ b/packages/passport/sdk/src/Passport.test.ts
@@ -165,12 +165,28 @@ describe('Passport', () => {
   });
 
   describe('logout', () => {
-    it('should execute logout without error', async () => {
-      await passport.logout();
+    describe('when the logout mode is silent', () => {
+      it('should execute logout without error', async () => {
+        await passport.logout();
 
-      expect(logoutMock).toBeCalledTimes(1);
-      expect(magicLogoutMock).toBeCalledTimes(1);
-      expect(confirmationLogoutMock).toBeCalledTimes(1);
+        expect(logoutMock).toBeCalledTimes(1);
+        expect(magicLogoutMock).toBeCalledTimes(1);
+        expect(confirmationLogoutMock).toBeCalledTimes(1);
+      });
+    });
+
+    describe('when the logout mode is redirect', () => {
+      it('should execute logout without error in the correct order', async () => {
+        await passport.logout();
+
+        const logoutMockOrder = logoutMock.mock.invocationCallOrder[0];
+        const magicLogoutMockOrder = magicLogoutMock.mock.invocationCallOrder[0];
+
+        expect(confirmationLogoutMock).toBeCalledTimes(1);
+        expect(logoutMock).toBeCalledTimes(1);
+        expect(magicLogoutMock).toBeCalledTimes(1);
+        expect(magicLogoutMockOrder).toBeLessThan(logoutMockOrder);
+      });
     });
   });
 

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -228,10 +228,18 @@ export class Passport {
     } catch (err) {
       logger.warn('Failed to logout from confirmation screen', err);
     }
-    await Promise.allSettled([
-      this.authManager.logout(),
-      this.magicAdapter.logout(),
-    ]);
+
+    if (this.config.oidcConfiguration.logoutMode === 'silent') {
+      await Promise.allSettled([
+        this.authManager.logout(),
+        this.magicAdapter.logout(),
+      ]);
+    } else {
+      // We need to ensure that the Magic wallet is logged out BEFORE redirecting
+      await this.magicAdapter.logout();
+      await this.authManager.logout();
+    }
+
     this.passportEventEmitter.emit(PassportEvents.LOGGED_OUT);
   }
 


### PR DESCRIPTION
# Summary
This PR resolves an issue where users were not being correctly logged out of their Magic wallet.

# Detail and impact of the change
## Changed
- Passport: Fixed an issue where users were not correctly logged out of their Magic wallet when using the `redirect` logout mode.