### PR TITLE
feat: GPR-581 - "Advanced Options" in Balance Widget top up screen

### DIFF
--- a/packages/checkout/widgets-lib/src/locales/en.json
+++ b/packages/checkout/widgets-lib/src/locales/en.json
@@ -237,6 +237,12 @@
           "caption": "The coins I have in another wallet or network.",
           "subcaption": "Fees ",
           "disabledCaption": ""
+        },
+        "advanced": {
+          "heading": "Advanced options",
+          "caption": "Perform a fast bridge or CEX deposit.",
+          "subcaption": "Fees ",
+          "disabledCaption": ""
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -244,6 +244,12 @@
           "caption": "別のウォレットやネットワークにある私のコイン。",
           "subcaption": "手数料",
           "disabledCaption": ""
+        },
+        "advanced": {
+          "heading": "高度なオプション",
+          "caption": "迅速なブリッジまたはCEX入金を実行します。",
+          "subcaption": "手数料",
+          "disabledCaption": ""
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -237,6 +237,12 @@
           "caption": "다른 지갑이나 네트워크에 있는 내 코인.",
           "subcaption": "수수료",
           "disabledCaption": ""
+        },
+        "advanced": {
+          "heading": "고급 옵션",
+          "caption": "빠른 브릿지 또는 CEX 입금을 수행합니다.",
+          "subcaption": "수수료",
+          "disabledCaption": ""
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -241,6 +241,12 @@
           "caption": "我在其他钱包或网络中的代币。",
           "subcaption": "费用",
           "disabledCaption": ""
+        },
+        "advanced": {
+          "heading": "高级选项",
+          "caption": "进行快速桥接或CEX存款。",
+          "subcaption": "费用",
+          "disabledCaption": ""
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/views/top-up/TopUpView.cy.tsx
+++ b/packages/checkout/widgets-lib/src/views/top-up/TopUpView.cy.tsx
@@ -56,6 +56,7 @@ describe('Top Up View', () => {
       cySmartGet('menu-item-onramp').should('exist');
       cySmartGet('menu-item-swap').should('exist');
       cySmartGet('menu-item-bridge').should('exist');
+      cySmartGet('menu-item-advanced').should('exist');
     });
 
     it('should hide onramp option', () => {

--- a/packages/checkout/widgets-lib/src/views/top-up/TopUpView.tsx
+++ b/packages/checkout/widgets-lib/src/views/top-up/TopUpView.tsx
@@ -13,6 +13,7 @@ import {
   GasEstimateType,
   IMTBLWidgetEvents,
 } from '@imtbl/checkout-sdk';
+import { Environment } from '@imtbl/config';
 import { DEFAULT_TOKEN_SYMBOLS } from 'context/crypto-fiat-context/CryptoFiatProvider';
 import { BridgeWidgetViews } from 'context/view-context/BridgeViewContextTypes';
 import { Web3Provider } from '@ethersproject/providers';
@@ -57,6 +58,11 @@ interface TopUpViewProps {
   subheading?: [key: string, options?: $Dictionary];
 }
 
+export const TOOLKIT_BASE_URL = {
+  [Environment.SANDBOX]: 'https://checkout-playground.sandbox.immutable.com',
+  [Environment.PRODUCTION]: 'https://toolkit.immutable.com',
+};
+
 export function TopUpView({
   widgetEvent,
   checkout,
@@ -80,6 +86,8 @@ export function TopUpView({
 
   const { cryptoFiatState, cryptoFiatDispatch } = useContext(CryptoFiatContext);
   const { conversions, fiatSymbol } = cryptoFiatState;
+
+  const environment = checkout?.config.environment ?? Environment.SANDBOX;
 
   const {
     eventTargetState: { eventTarget },
@@ -246,6 +254,18 @@ export function TopUpView({
     localTrack('OnRamp', { ...data, widgetEvent });
   };
 
+  const onClickAdvancedOptions = () => {
+    const toolkitBaseUrl = TOOLKIT_BASE_URL[environment];
+    const data = {
+      tokenAddress: tokenAddress ?? '',
+      amount: amount ?? '',
+    };
+
+    localTrack('AdvancedOptions', { ...data, widgetEvent });
+
+    window.open(`${toolkitBaseUrl}/faster-bridge/`, '_blank');
+  };
+
   const renderFees = (txt: string): ReactNode => (
     <Box
       sx={{
@@ -296,6 +316,15 @@ export function TopUpView({
       ),
       isAvailable: true,
       isEnabled: showBridgeOption,
+    },
+    {
+      testId: 'advanced',
+      icon: 'JumpTo',
+      textConfigKey: 'views.TOP_UP_VIEW.topUpOptions.advanced',
+      onClickEvent: onClickAdvancedOptions,
+      fee: () => renderFees(''),
+      isAvailable: true,
+      isEnabled: true,
     },
   ];
 


### PR DESCRIPTION
# Summary

Introducing a link to Layerswap in the Toolkit, opening up in a new tab.

![image](https://github.com/immutable/ts-immutable-sdk/assets/194708/bb789001-a34d-431b-a5ff-59ff75ca44bd)

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

New Top Up feature: advances options for fast bridge and CEX deposits (Layerswap)
