### PR TITLE
feat: [GPR-559] Checkout Connect widget to support blocklist

### DIFF
--- a/packages/checkout/sdk/src/types/config.ts
+++ b/packages/checkout/sdk/src/types/config.ts
@@ -130,7 +130,7 @@ export type ConnectConfig = {
     /** List for sorting injected wallets via wallet rdns */
     priorityWalletRdns: string[];
     /** List for blocking injected wallets via wallet rdns */
-    blacklistWalletRdns: string[];
+    blocklistWalletRdns: string[];
   }
 };
 

--- a/packages/checkout/sdk/src/widgets/definitions/events/connect.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/events/connect.ts
@@ -9,6 +9,7 @@ export enum ConnectEventType {
   SUCCESS = 'success',
   FAILURE = 'failure',
   LANGUAGE_CHANGED = 'language-changed',
+  WALLETCONNECT_PROVIDER_UPDATED = 'walletconnect-provider-updated',
 }
 
 /**
@@ -33,3 +34,20 @@ export type ConnectionFailed = {
   /** The reason for the failed connection. */
   reason: string;
 };
+
+export type WalletConnectProviderChanged = {
+  ethereumProvider: any; // EthereumProvider;
+  walletConnectManager: WalletConnectManager;
+};
+
+/**
+ * Provides access to the underlying WalletConnect modal and provider.
+ */
+export interface WalletConnectManager {
+  isInitialised: () => boolean;
+  isEnabled: () => boolean;
+  getModal: () => any; // WalletConnectModal;
+  getProvider: () => Promise<any>; // EthereumProvider>;
+  loadWalletListings: () => Promise<Response | undefined>;
+  getWalletLogoUrl: (walletSlug?: string) => Promise<string | undefined>;
+}

--- a/packages/checkout/sdk/src/widgets/definitions/parameters/connect.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/parameters/connect.ts
@@ -11,4 +11,6 @@ export type ConnectWidgetParams = {
   language?: WidgetLanguage;
   /** The target chain to connect to as part of the connection process (defaults to Immutable zkEVM / Immutable zkEVM Testnet) */
   targetChainId?: ChainId;
+  /** List of wallets rdns to exclude from the connect widget */
+  blocklistWalletRdns?: string[];
 };

--- a/packages/checkout/sdk/src/widgets/definitions/types.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/types.ts
@@ -29,6 +29,7 @@ import {
   SwapFailed,
   SwapRejected,
   SwapSuccess,
+  WalletConnectProviderChanged,
   WalletDisconnect,
   WalletEventType,
   WalletNetworkSwitch,
@@ -125,6 +126,7 @@ export type WidgetEventData = {
     [ConnectEventType.SUCCESS]: ConnectionSuccess,
     [ConnectEventType.FAILURE]: ConnectionFailed,
     [ConnectEventType.CLOSE_WIDGET]: {},
+    [ConnectEventType.WALLETCONNECT_PROVIDER_UPDATED]: WalletConnectProviderChanged,
   } & OrchestrationMapping & ProviderEventMapping,
 
   [WidgetType.WALLET]: {

--- a/packages/checkout/widgets-lib/src/lib/hooks/useWalletConnect.ts
+++ b/packages/checkout/widgets-lib/src/lib/hooks/useWalletConnect.ts
@@ -124,7 +124,7 @@ export const useWalletConnect = () => {
             setWalletConnectBusy(true);
             reject(error);
           });
-      } else if (!ethereumProvider?.session) {
+      } else if (!ethereumProvider?.session || !restoreSession) {
         // if we don't have a display uri and no connected session
         // call connect to generate display_uri event
         ethereumProvider?.connect();

--- a/packages/checkout/widgets-lib/src/lib/walletConnect.ts
+++ b/packages/checkout/widgets-lib/src/lib/walletConnect.ts
@@ -210,12 +210,11 @@ export class WalletConnectManager {
     return undefined;
   }
 
-  public async getWalletLogoUrl(): Promise<string | undefined> {
+  public async getWalletLogoUrl(walletSlug?: string): Promise<string | undefined> {
     if (!this.walletListings) {
       this.walletListings = await this.loadWalletListings();
     }
-    const walletName = this.ethereumProvider?.session?.peer.metadata.name;
-
+    const walletName = walletSlug || this.ethereumProvider?.session?.peer.metadata.name;
     if (!this.walletListings || !walletName) {
       return undefined;
     }

--- a/packages/checkout/widgets-lib/src/widgets/connect/ConnectWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/connect/ConnectWidget.tsx
@@ -4,7 +4,12 @@ import React, {
 } from 'react';
 import {
   ChainId,
-  Checkout, ConnectWidgetParams, EIP1193Provider, getMetaMaskProviderDetail, getPassportProviderDetail,
+  Checkout,
+  ConnectWidgetParams,
+  EIP1193Provider,
+  getMetaMaskProviderDetail,
+  getPassportProviderDetail,
+  WalletConnectManager as IWalletConnectManager,
 } from '@imtbl/checkout-sdk';
 import { Web3Provider } from '@ethersproject/providers';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +18,7 @@ import {
   sendCloseWidgetEvent,
   sendConnectFailedEvent,
   sendConnectSuccessEvent,
+  sendWalletConnectProviderUpdatedEvent,
 } from './connectWidgetEvents';
 import {
   ConnectActions,
@@ -42,7 +48,8 @@ import { EventTargetContext } from '../../context/event-target-context/EventTarg
 import { UserJourney, useAnalytics } from '../../context/analytics-provider/SegmentAnalyticsProvider';
 import { identifyUser } from '../../lib/analytics/identifyUser';
 import { isMetaMaskProvider, isPassportProvider, isWalletConnectProvider } from '../../lib/provider';
-import { walletConnectProviderInfo } from '../../lib/walletConnect';
+import { WalletConnectManager, walletConnectProviderInfo } from '../../lib/walletConnect';
+import { useWalletConnect } from '../../lib/hooks/useWalletConnect';
 
 export type ConnectWidgetInputs = ConnectWidgetParams & {
   config: StrongCheckoutWidgetsConfig
@@ -65,6 +72,7 @@ export default function ConnectWidget({
 }: ConnectWidgetInputs) {
   const { t } = useTranslation();
   const { environment } = config;
+  const { isWalletConnectEnabled, ethereumProvider } = useWalletConnect();
 
   const errorText = t('views.ERROR_VIEW.actionText');
 
@@ -144,6 +152,16 @@ export default function ConnectWidget({
     if (viewState.view.type !== SharedViews.ERROR_VIEW) return;
     sendConnectFailedEvent(eventTarget, viewState.view.error.message);
   }, [viewState]);
+
+  useEffect(() => {
+    if (isWalletConnectEnabled) {
+      sendWalletConnectProviderUpdatedEvent(
+        eventTarget,
+        ethereumProvider,
+        WalletConnectManager.getInstance() as unknown as IWalletConnectManager,
+      );
+    }
+  }, [isWalletConnectEnabled, ethereumProvider]);
 
   const handleConnectSuccess = useCallback(async () => {
     if (!provider) return;

--- a/packages/checkout/widgets-lib/src/widgets/connect/ConnectWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/connect/ConnectWidget.tsx
@@ -60,6 +60,7 @@ export default function ConnectWidget({
   checkout,
   targetChainId,
   allowedChains,
+  blocklistWalletRdns,
   deepLink = ConnectWidgetViews.CONNECT_WALLET,
 }: ConnectWidgetInputs) {
   const { t } = useTranslation();
@@ -186,7 +187,11 @@ export default function ConnectWidget({
             <LoadingView loadingText="Loading" />
           )}
           {view.type === ConnectWidgetViews.CONNECT_WALLET && (
-            <ConnectWallet targetChainId={targetChain} allowedChains={allowedChains ?? [targetChain]} />
+            <ConnectWallet
+              targetChainId={targetChain}
+              allowedChains={allowedChains ?? [targetChain]}
+              blocklistWalletRdns={blocklistWalletRdns}
+            />
           )}
           {view.type === ConnectWidgetViews.SWITCH_NETWORK && isZkEvmChainId(targetChain) && (
             <SwitchNetworkZkEVM />

--- a/packages/checkout/widgets-lib/src/widgets/connect/ConnectWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/connect/ConnectWidgetRoot.tsx
@@ -68,6 +68,7 @@ export class Connect extends Base<WidgetType.CONNECT> {
                 config={this.strongConfig()}
                 checkout={this.checkout}
                 targetChainId={this.parameters.targetChainId}
+                blocklistWalletRdns={this.parameters.blocklistWalletRdns}
               />
             </Suspense>
           </ThemeProvider>

--- a/packages/checkout/widgets-lib/src/widgets/connect/connectWidgetEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/connect/connectWidgetEvents.ts
@@ -4,10 +4,11 @@ import {
   ConnectEventType,
   WalletProviderName,
   WidgetType,
-  EIP6963ProviderInfo,
+  EIP6963ProviderInfo, WalletConnectManager,
 } from '@imtbl/checkout-sdk';
 
 import { Web3Provider } from '@ethersproject/providers';
+import EthereumProvider from '@walletconnect/ethereum-provider';
 
 export function sendConnectSuccessEvent(
   eventTarget: Window | EventTarget,
@@ -63,4 +64,28 @@ export function sendConnectFailedEvent(eventTarget: Window | EventTarget, reason
   // eslint-disable-next-line no-console
   console.log('failed event:', eventTarget, failedEvent);
   if (eventTarget !== undefined) eventTarget.dispatchEvent(failedEvent);
+}
+
+export function sendWalletConnectProviderUpdatedEvent(
+  eventTarget: Window | EventTarget,
+  ethereumProvider: EthereumProvider | null,
+  walletConnectManager: WalletConnectManager,
+) {
+  const successEvent = new CustomEvent<
+  WidgetEvent<WidgetType.CONNECT, ConnectEventType.WALLETCONNECT_PROVIDER_UPDATED>
+  >(
+    IMTBLWidgetEvents.IMTBL_CONNECT_WIDGET_EVENT,
+    {
+      detail: {
+        type: ConnectEventType.WALLETCONNECT_PROVIDER_UPDATED,
+        data: {
+          ethereumProvider,
+          walletConnectManager,
+        },
+      },
+    },
+  );
+  // eslint-disable-next-line no-console
+  console.log('walletConnect provider updated event:', eventTarget, successEvent);
+  if (eventTarget !== undefined) eventTarget.dispatchEvent(successEvent);
 }

--- a/packages/checkout/widgets-lib/src/widgets/connect/views/ConnectWallet.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/connect/views/ConnectWallet.tsx
@@ -12,9 +12,10 @@ import { UserJourney, useAnalytics } from '../../../context/analytics-provider/S
 export interface ConnectWalletProps {
   targetChainId: ChainId;
   allowedChains: ChainId[];
+  blocklistWalletRdns?: string[];
 }
 
-export function ConnectWallet({ targetChainId, allowedChains }: ConnectWalletProps) {
+export function ConnectWallet({ targetChainId, allowedChains, blocklistWalletRdns }: ConnectWalletProps) {
   const { t } = useTranslation();
   const {
     connectState: { sendCloseEvent },
@@ -67,7 +68,11 @@ export function ConnectWallet({ targetChainId, allowedChains }: ConnectWalletPro
         </Body>
       </Box>
       <Box sx={{ paddingX: 'base.spacing.x2' }}>
-        <WalletList targetChainId={targetChainId} allowedChains={allowedChains} />
+        <WalletList
+          targetChainId={targetChainId}
+          allowedChains={allowedChains}
+          blocklistWalletRdns={blocklistWalletRdns}
+        />
       </Box>
     </SimpleLayout>
   );

--- a/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/MainPage.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/MainPage.tsx
@@ -58,6 +58,9 @@ export const MainPage = () => {
   const swapWidget = useMemo(() => widgetsFactory.create(WidgetType.SWAP), [widgetsFactory]);
   const onRampWidget = useMemo(() => widgetsFactory.create(WidgetType.ONRAMP), [widgetsFactory]);
 
+  connectWidget.addListener(ConnectEventType.WALLETCONNECT_PROVIDER_UPDATED, (event) => {
+    console.log('WalletConnnect provider ready', event);
+  });
   connectWidget.addListener(ConnectEventType.CLOSE_WIDGET, () => { connectWidget.unmount() });
   connectWidget.addListener(ConnectEventType.SUCCESS, (event) => {
     console.log('Connect success', event);

--- a/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/MainPage.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/MainPage.tsx
@@ -106,7 +106,13 @@ export const MainPage = () => {
 
   // button click functions to open/close widgets
   const openConnectWidget = useCallback((targetChainId?: ChainId, blockWallets: boolean = false) => {
-    const connectParams = {targetChainId: targetChainId};
+    const connectParams: {
+      targetChainId?: ChainId,
+      blocklistWalletRdns: string[],
+    } = {
+      targetChainId: targetChainId,
+      blocklistWalletRdns: [],
+    };
     if (blockWallets) {
       connectParams.blocklistWalletRdns = [
         'com.immutable.passport',

--- a/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/MainPage.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/MainPage.tsx
@@ -105,8 +105,16 @@ export const MainPage = () => {
   }, [walletWidget, bridgeWidget, onRampWidget, swapWidget]);
 
   // button click functions to open/close widgets
-  const openConnectWidget = useCallback((targetChainId?: ChainId) => {
-    connectWidget.mount('connect-target', {targetChainId: targetChainId});
+  const openConnectWidget = useCallback((targetChainId?: ChainId, blockWallets: boolean = false) => {
+    const connectParams = {targetChainId: targetChainId};
+    if (blockWallets) {
+      connectParams.blocklistWalletRdns = [
+        'com.immutable.passport',
+        'io.metamask',
+        'xyz.frontier.wallet',
+      ];
+    }
+    connectWidget.mount('connect-target', connectParams);
   }, [connectWidget])
 
   const openWalletWidget = useCallback(() => {
@@ -164,6 +172,7 @@ export const MainPage = () => {
         <Box sx={{ padding: 'base.spacing.x4', display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', gap: 'base.spacing.x6', alignItems: 'center', flexWrap: 'wrap' }}>
           <Button onClick={() => openConnectWidget()}>Connect</Button>
           <Button onClick={() => openConnectWidget(checkout.config.isProduction ? ChainId.ETHEREUM : ChainId.SEPOLIA)}>Connect (Layer 1)</Button>
+          <Button onClick={() => openConnectWidget(undefined, true)}>Connect (Blocked)</Button>
           <Button onClick={openWalletWidget}>Wallet</Button>
           <Button onClick={openSwapWidget}>Swap</Button>
           <Button onClick={openBridgeWidget}>Bridge</Button>


### PR DESCRIPTION
# Summary
Checkout connect widget supports a `blocklistWalletRdns` param to restrict the wallets in the wallet listing.

# Detail and impact of the change
## Added 
blocklistWalletRdns param to support restricting specific wallets.
`Walletconnect-provider-updated` event to propagate walletConnectManager reference.

## Changed
WalletConnect option will always start a new session via the Connect widget