### PR TITLE
fix: Support apiKey from orderbook module when provided

### DIFF
--- a/packages/orderbook/src/api-client/api-client-factory.ts
+++ b/packages/orderbook/src/api-client/api-client-factory.ts
@@ -8,15 +8,15 @@ export class ImmutableApiClientFactory {
     apiEndpoint: string,
     private readonly chainName: string,
     private readonly seaportAddress: string,
-    apiKey?: string,
+    rateLimitingKey?: string,
   ) {
     this.orderbookClient = new OrderBookClient({
       // eslint-disable-next-line @typescript-eslint/naming-convention
       BASE: apiEndpoint,
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      HEADERS: apiKey ? {
+      HEADERS: rateLimitingKey ? {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        'x-immutable-api-key': apiKey!,
+        'x-immutable-api-key': rateLimitingKey!,
       } : undefined,
     });
   }

--- a/packages/orderbook/src/api-client/api-client-factory.ts
+++ b/packages/orderbook/src/api-client/api-client-factory.ts
@@ -16,7 +16,7 @@ export class ImmutableApiClientFactory {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       HEADERS: rateLimitingKey ? {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        'x-immutable-api-key': rateLimitingKey!,
+        'x-api-key': rateLimitingKey!,
       } : undefined,
     });
   }

--- a/packages/orderbook/src/api-client/api-client-factory.ts
+++ b/packages/orderbook/src/api-client/api-client-factory.ts
@@ -8,10 +8,16 @@ export class ImmutableApiClientFactory {
     apiEndpoint: string,
     private readonly chainName: string,
     private readonly seaportAddress: string,
+    apiKey?: string,
   ) {
     this.orderbookClient = new OrderBookClient({
       // eslint-disable-next-line @typescript-eslint/naming-convention
       BASE: apiEndpoint,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      HEADERS: apiKey ? {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'x-immutable-api-key': apiKey!,
+      } : undefined,
     });
   }
 

--- a/packages/orderbook/src/config/config.ts
+++ b/packages/orderbook/src/config/config.ts
@@ -1,4 +1,4 @@
-import { Environment } from '@imtbl/config';
+import { Environment, ModuleConfiguration } from '@imtbl/config';
 import { providers } from 'ethers';
 
 export const TESTNET_CHAIN_NAME = 'imtbl-zkevm-testnet';
@@ -20,19 +20,27 @@ export interface OrderbookModuleConfiguration {
   provider: providers.JsonRpcProvider;
 }
 
+export function getConfiguredProvider(url: string, apiKey?: string): providers.JsonRpcProvider {
+  return new providers.JsonRpcProvider({
+    url,
+    headers: apiKey ? {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'x-immutable-api-key': apiKey!,
+    } : undefined,
+  });
+}
+
 export function getOrderbookConfig(
-  environment: Environment,
+  config: ModuleConfiguration<OrderbookOverrides>,
 ): OrderbookModuleConfiguration | null {
-  switch (environment) {
+  switch (config.baseConfig.environment) {
     case Environment.SANDBOX:
       return {
         seaportContractAddress: '0x7d117aA8BD6D31c4fa91722f246388f38ab1942c',
         zoneContractAddress: '0x8831867E347AB87FA30199C5B695F0A31604Bb52',
         apiEndpoint: 'https://api.sandbox.immutable.com',
         chainName: TESTNET_CHAIN_NAME,
-        provider: new providers.JsonRpcProvider(
-          'https://rpc.testnet.immutable.com',
-        ),
+        provider: getConfiguredProvider('https://rpc.testnet.immutable.com', config.baseConfig.apiKey),
       };
     // not yet deployed
     case Environment.PRODUCTION:
@@ -41,9 +49,7 @@ export function getOrderbookConfig(
         zoneContractAddress: '0x00338b92Bec262078B3e49BF12bbEA058916BF91',
         apiEndpoint: 'https://api.immutable.com',
         chainName: MAINNET_CHAIN_NAME,
-        provider: new providers.JsonRpcProvider(
-          'https://rpc.immutable.com',
-        ),
+        provider: getConfiguredProvider('https://rpc.immutable.com', config.baseConfig.apiKey),
       };
     default:
       return null;

--- a/packages/orderbook/src/config/config.ts
+++ b/packages/orderbook/src/config/config.ts
@@ -20,12 +20,15 @@ export interface OrderbookModuleConfiguration {
   provider: providers.JsonRpcProvider;
 }
 
-export function getConfiguredProvider(url: string, apiKey?: string): providers.JsonRpcProvider {
+export function getConfiguredProvider(
+  url: string,
+  rateLimitingKey?: string,
+): providers.JsonRpcProvider {
   return new providers.JsonRpcProvider({
     url,
-    headers: apiKey ? {
+    headers: rateLimitingKey ? {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      'x-immutable-api-key': apiKey!,
+      'x-api-key': rateLimitingKey!,
     } : undefined,
   });
 }
@@ -40,7 +43,7 @@ export function getOrderbookConfig(
         zoneContractAddress: '0x8831867E347AB87FA30199C5B695F0A31604Bb52',
         apiEndpoint: 'https://api.sandbox.immutable.com',
         chainName: TESTNET_CHAIN_NAME,
-        provider: getConfiguredProvider('https://rpc.testnet.immutable.com', config.baseConfig.apiKey),
+        provider: getConfiguredProvider('https://rpc.testnet.immutable.com', config.baseConfig.rateLimitingKey),
       };
     // not yet deployed
     case Environment.PRODUCTION:
@@ -49,7 +52,7 @@ export function getOrderbookConfig(
         zoneContractAddress: '0x00338b92Bec262078B3e49BF12bbEA058916BF91',
         apiEndpoint: 'https://api.immutable.com',
         chainName: MAINNET_CHAIN_NAME,
-        provider: getConfiguredProvider('https://rpc.immutable.com', config.baseConfig.apiKey),
+        provider: getConfiguredProvider('https://rpc.immutable.com', config.baseConfig.rateLimitingKey),
       };
     default:
       return null;

--- a/packages/orderbook/src/orderbook.ts
+++ b/packages/orderbook/src/orderbook.ts
@@ -1,7 +1,7 @@
 import { ModuleConfiguration } from '@imtbl/config';
-import { providers } from 'ethers';
 import { ImmutableApiClient, ImmutableApiClientFactory } from './api-client';
 import {
+  getConfiguredProvider,
   getOrderbookConfig,
   OrderbookModuleConfiguration,
   OrderbookOverrides,
@@ -49,7 +49,7 @@ export class Orderbook {
   private orderbookConfig: OrderbookModuleConfiguration;
 
   constructor(config: ModuleConfiguration<OrderbookOverrides>) {
-    const obConfig = getOrderbookConfig(config.baseConfig.environment);
+    const obConfig = getOrderbookConfig(config);
 
     const finalConfig: OrderbookModuleConfiguration = {
       ...obConfig,
@@ -57,8 +57,9 @@ export class Orderbook {
     } as OrderbookModuleConfiguration;
 
     if (config.overrides?.jsonRpcProviderUrl) {
-      finalConfig.provider = new providers.JsonRpcProvider(
-        config.overrides.jsonRpcProviderUrl,
+      finalConfig.provider = getConfiguredProvider(
+        config.overrides?.jsonRpcProviderUrl!,
+        config.baseConfig.apiKey,
       );
     }
 
@@ -79,6 +80,7 @@ export class Orderbook {
       apiEndpoint,
       chainName,
       this.orderbookConfig.seaportContractAddress,
+      config.baseConfig.apiKey,
     ).create();
 
     const seaportLibFactory = new SeaportLibFactory(

--- a/packages/orderbook/src/orderbook.ts
+++ b/packages/orderbook/src/orderbook.ts
@@ -92,6 +92,7 @@ export class Orderbook {
       this.orderbookConfig.provider,
       this.orderbookConfig.seaportContractAddress,
       this.orderbookConfig.zoneContractAddress,
+      config.baseConfig.apiKey,
     );
   }
 

--- a/packages/orderbook/src/orderbook.ts
+++ b/packages/orderbook/src/orderbook.ts
@@ -59,7 +59,7 @@ export class Orderbook {
     if (config.overrides?.jsonRpcProviderUrl) {
       finalConfig.provider = getConfiguredProvider(
         config.overrides?.jsonRpcProviderUrl!,
-        config.baseConfig.apiKey,
+        config.baseConfig.rateLimitingKey,
       );
     }
 
@@ -80,7 +80,7 @@ export class Orderbook {
       apiEndpoint,
       chainName,
       this.orderbookConfig.seaportContractAddress,
-      config.baseConfig.apiKey,
+      config.baseConfig.rateLimitingKey,
     ).create();
 
     const seaportLibFactory = new SeaportLibFactory(
@@ -92,7 +92,7 @@ export class Orderbook {
       this.orderbookConfig.provider,
       this.orderbookConfig.seaportContractAddress,
       this.orderbookConfig.zoneContractAddress,
-      config.baseConfig.apiKey,
+      config.baseConfig.rateLimitingKey,
     );
   }
 

--- a/packages/orderbook/src/seaport/seaport-lib-factory.ts
+++ b/packages/orderbook/src/seaport/seaport-lib-factory.ts
@@ -11,11 +11,11 @@ export type SeaportVersion =
 // safely instantiate a V6 provider for the V5 provider URL.
 function convertToV6Provider(
   provider: providers.JsonRpcProvider,
-  apiKey?: string,
+  rateLimitingKey?: string,
 ): JsonRpcProvider {
   const fetch = new FetchRequest(provider.connection.url);
-  if (apiKey) {
-    fetch.setHeader('x-immutable-api-key', apiKey);
+  if (rateLimitingKey) {
+    fetch.setHeader('x-api-key', rateLimitingKey);
   }
 
   const overwrittenProvider = new JsonRpcProvider(fetch);
@@ -53,10 +53,10 @@ export class SeaportLibFactory {
     private readonly provider: providers.JsonRpcProvider,
   ) { }
 
-  create(orderSeaportAddress?: string, apiKey?: string): SeaportLib {
+  create(orderSeaportAddress?: string, rateLimitingKey?: string): SeaportLib {
     const seaportContractAddress = orderSeaportAddress ?? this.defaultSeaportContractAddress;
 
-    return new SeaportLib(convertToV6Provider(this.provider, apiKey), {
+    return new SeaportLib(convertToV6Provider(this.provider, rateLimitingKey), {
       balanceAndApprovalChecksOnOrderCreation: true,
       overrides: {
         contractAddress: seaportContractAddress,

--- a/packages/orderbook/src/seaport/seaport-lib-factory.ts
+++ b/packages/orderbook/src/seaport/seaport-lib-factory.ts
@@ -1,5 +1,5 @@
 import { Seaport as SeaportLib } from '@opensea/seaport-js';
-import { JsonRpcProvider, JsonRpcSigner } from 'ethers-v6';
+import { FetchRequest, JsonRpcProvider, JsonRpcSigner } from 'ethers-v6';
 import { providers } from 'ethers';
 import { SEAPORT_CONTRACT_VERSION_V1_5 } from './constants';
 
@@ -11,8 +11,14 @@ export type SeaportVersion =
 // safely instantiate a V6 provider for the V5 provider URL.
 function convertToV6Provider(
   provider: providers.JsonRpcProvider,
+  apiKey?: string,
 ): JsonRpcProvider {
-  const overwrittenProvider = new JsonRpcProvider(provider.connection.url);
+  const fetch = new FetchRequest(provider.connection.url);
+  if (apiKey) {
+    fetch.setHeader('x-immutable-api-key', apiKey);
+  }
+
+  const overwrittenProvider = new JsonRpcProvider(fetch);
 
   // Need to override the getSigner method to mimic V5 behaviour
   overwrittenProvider.getSigner = async function getSigner(
@@ -47,10 +53,10 @@ export class SeaportLibFactory {
     private readonly provider: providers.JsonRpcProvider,
   ) { }
 
-  create(orderSeaportVersion?: SeaportVersion, orderSeaportAddress?: string): SeaportLib {
+  create(orderSeaportAddress?: string, apiKey?: string): SeaportLib {
     const seaportContractAddress = orderSeaportAddress ?? this.defaultSeaportContractAddress;
 
-    return new SeaportLib(convertToV6Provider(this.provider), {
+    return new SeaportLib(convertToV6Provider(this.provider, apiKey), {
       balanceAndApprovalChecksOnOrderCreation: true,
       overrides: {
         contractAddress: seaportContractAddress,

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -40,7 +40,7 @@ export class Seaport {
     private provider: providers.JsonRpcProvider,
     private seaportContractAddress: string,
     private zoneContractAddress: string,
-    private apiKey?: string,
+    private rateLimitingKey?: string,
   ) {}
 
   async prepareSeaportOrder(
@@ -318,7 +318,7 @@ export class Seaport {
 
   private getSeaportLib(order?: Order): SeaportLib {
     const seaportAddress = order?.protocol_data?.seaport_address ?? this.seaportContractAddress;
-    return this.seaportLibFactory.create(seaportAddress, this.apiKey);
+    return this.seaportLibFactory.create(seaportAddress, this.rateLimitingKey);
   }
 
   private static getExpirationISOTimeFromExtraData(extraData: string): string {

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -30,7 +30,7 @@ import {
   SEAPORT_CONTRACT_VERSION_V1_5,
 } from './constants';
 import { getOrderComponentsFromMessage } from './components';
-import { SeaportLibFactory, SeaportVersion } from './seaport-lib-factory';
+import { SeaportLibFactory } from './seaport-lib-factory';
 import { prepareTransaction } from './transaction';
 import { mapImmutableOrderToSeaportOrderComponents } from './map-to-seaport-order';
 
@@ -40,6 +40,7 @@ export class Seaport {
     private provider: providers.JsonRpcProvider,
     private seaportContractAddress: string,
     private zoneContractAddress: string,
+    private apiKey?: string,
   ) {}
 
   async prepareSeaportOrder(
@@ -317,13 +318,7 @@ export class Seaport {
 
   private getSeaportLib(order?: Order): SeaportLib {
     const seaportAddress = order?.protocol_data?.seaport_address ?? this.seaportContractAddress;
-
-    const seaportVersion: SeaportVersion = SEAPORT_CONTRACT_VERSION_V1_5;
-    // if (order?.protocol_data?.seaport_version === SEAPORT_CONTRACT_VERSION_V1_5) {
-    //   seaportVersion = SEAPORT_CONTRACT_VERSION_V1_5;
-    // }
-
-    return this.seaportLibFactory.create(seaportVersion, seaportAddress);
+    return this.seaportLibFactory.create(seaportAddress, this.apiKey);
   }
 
   private static getExpirationISOTimeFromExtraData(extraData: string): string {


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Previously if an Immutable rate limiting key was provided to the orderbook config, it was not added to the request headers. This PR fixes that

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->

## Fixed
<!-- Section for any bug fixes. -->

- Add immutable rate limit api key to headers when provided from orderbook module

