### PR TITLE
fix: always prompt user for login method

### DIFF
--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -180,6 +180,7 @@ export default class AuthManager {
           third_party_a_id: anonymousId || '',
         },
         popupWindowFeatures,
+        prompt: 'login',
       });
 
       return AuthManager.mapOidcUserToDomainModel(oidcUser);


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
Some users were experiencing issues logging out of one Passport account and then logging into a different account. 

This change will ensure the user is always prompted to select the login method as per [the OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest). 

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
Not being able to log out of one Passport account and then log into a different Passport account

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
