### PR TITLE
fix: ID-1584 Force confirmation popup to be opened while provider is instantiated

### DIFF
--- a/packages/passport/sdk/src/zkEvm/sendTransaction.test.ts
+++ b/packages/passport/sdk/src/zkEvm/sendTransaction.test.ts
@@ -11,7 +11,6 @@ import GuardianClient from '../guardian';
 
 jest.mock('./walletHelpers');
 jest.mock('../network/retry');
-const withConfirmationScreenStub = jest.fn();
 
 describe('sendTransaction', () => {
   const signedTransaction = 'signedTransaction123';
@@ -36,8 +35,6 @@ describe('sendTransaction', () => {
   };
   const guardianClient = {
     validateEVMTransaction: jest.fn(),
-    withConfirmationScreen: jest.fn(() => (task: () => void) => task()),
-    loading: jest.fn(),
   };
   const ethSigner = {
     getAddress: jest.fn(),
@@ -63,10 +60,6 @@ describe('sendTransaction', () => {
       signedTransactions,
     );
     relayerClient.ethSendTransaction.mockResolvedValue(relayerTransactionId);
-    withConfirmationScreenStub.mockImplementation(
-      () => (task: () => void) => task(),
-    );
-    guardianClient.withConfirmationScreen = withConfirmationScreenStub;
     rpcProvider.detectNetwork.mockResolvedValue({ chainId });
   });
 

--- a/packages/passport/sdk/src/zkEvm/sendTransaction.ts
+++ b/packages/passport/sdk/src/zkEvm/sendTransaction.ts
@@ -68,92 +68,91 @@ const getMetaTransactions = async (
   return [metaTransaction, feeMetaTransaction];
 };
 
-export const sendTransaction = ({
+export const sendTransaction = async ({
   params,
   ethSigner,
   rpcProvider,
   relayerClient,
   guardianClient,
   zkevmAddress,
-}: EthSendTransactionParams): Promise<string> => guardianClient
-  .withConfirmationScreen({ width: 480, height: 720 })(async () => {
-    const transactionRequest: TransactionRequest = params[0];
-    if (!transactionRequest.to) {
-      throw new JsonRpcError(RpcErrorCode.INVALID_PARAMS, 'eth_sendTransaction requires a "to" field');
-    }
+}: EthSendTransactionParams): Promise<string> => {
+  const transactionRequest: TransactionRequest = params[0];
+  if (!transactionRequest.to) {
+    throw new JsonRpcError(RpcErrorCode.INVALID_PARAMS, 'eth_sendTransaction requires a "to" field');
+  }
 
-    const { chainId } = await rpcProvider.detectNetwork();
-    const chainIdBigNumber = BigNumber.from(chainId);
+  const { chainId } = await rpcProvider.detectNetwork();
+  const chainIdBigNumber = BigNumber.from(chainId);
 
-    const nonce = await getNonce(rpcProvider, zkevmAddress);
-    const metaTransaction: MetaTransaction = {
-      to: transactionRequest.to,
-      data: transactionRequest.data,
-      nonce,
-      value: transactionRequest.value,
-      revertOnError: true,
-    };
+  const nonce = await getNonce(rpcProvider, zkevmAddress);
+  const metaTransaction: MetaTransaction = {
+    to: transactionRequest.to,
+    data: transactionRequest.data,
+    nonce,
+    value: transactionRequest.value,
+    revertOnError: true,
+  };
 
-    const metaTransactions = await getMetaTransactions(
-      metaTransaction,
+  const metaTransactions = await getMetaTransactions(
+    metaTransaction,
+    nonce,
+    chainIdBigNumber,
+    zkevmAddress,
+    ethSigner,
+    relayerClient,
+  );
+
+  // Parallelize the validation and signing of the transaction
+  const [, signedTransactions] = await Promise.all([
+    guardianClient.validateEVMTransaction({
+      chainId: getEip155ChainId(chainId),
+      nonce: convertBigNumberishToString(nonce),
+      metaTransactions,
+    }),
+    // NOTE: We sign again because we now are adding the fee transaction, so the
+    // whole payload is different and needs a new signature.
+    getSignedMetaTransactions(
+      metaTransactions,
       nonce,
       chainIdBigNumber,
       zkevmAddress,
       ethSigner,
-      relayerClient,
-    );
+    ),
+  ]);
 
-    // Parallelize the validation and signing of the transaction
-    const [, signedTransactions] = await Promise.all([
-      guardianClient.validateEVMTransaction({
-        chainId: getEip155ChainId(chainId),
-        nonce: convertBigNumberishToString(nonce),
-        metaTransactions,
-      }),
-      // NOTE: We sign again because we now are adding the fee transaction, so the
-      // whole payload is different and needs a new signature.
-      getSignedMetaTransactions(
-        metaTransactions,
-        nonce,
-        chainIdBigNumber,
-        zkevmAddress,
-        ethSigner,
-      ),
-    ]);
+  const relayerId = await relayerClient.ethSendTransaction(zkevmAddress, signedTransactions);
 
-    const relayerId = await relayerClient.ethSendTransaction(zkevmAddress, signedTransactions);
-
-    const retrieveRelayerTransaction = async () => {
-      const tx = await relayerClient.imGetTransactionByHash(relayerId);
-      // NOTE: The transaction hash is only available from the Relayer once the
-      // transaction is actually submitted onchain. Hence we need to poll the
-      // Relayer get transaction endpoint until the status transitions to one that
-      // has the hash available.
-      if (tx.status === RelayerTransactionStatus.PENDING) {
-        throw new Error();
-      }
-      return tx;
-    };
-
-    const relayerTransaction = await retryWithDelay(retrieveRelayerTransaction, {
-      retries: MAX_TRANSACTION_HASH_RETRIEVAL_RETRIES,
-      interval: TRANSACTION_HASH_RETRIEVAL_WAIT,
-      finalErr: new JsonRpcError(RpcErrorCode.RPC_SERVER_ERROR, 'transaction hash not generated in time'),
-    });
-
-    if (![
-      RelayerTransactionStatus.SUBMITTED,
-      RelayerTransactionStatus.SUCCESSFUL,
-    ].includes(relayerTransaction.status)) {
-      let errorMessage = `Transaction failed to submit with status ${relayerTransaction.status}.`;
-      if (relayerTransaction.statusMessage) {
-        errorMessage += ` Error message: ${relayerTransaction.statusMessage}`;
-      }
-      throw new JsonRpcError(
-        RpcErrorCode.RPC_SERVER_ERROR,
-        errorMessage,
-      );
+  const retrieveRelayerTransaction = async () => {
+    const tx = await relayerClient.imGetTransactionByHash(relayerId);
+    // NOTE: The transaction hash is only available from the Relayer once the
+    // transaction is actually submitted onchain. Hence we need to poll the
+    // Relayer get transaction endpoint until the status transitions to one that
+    // has the hash available.
+    if (tx.status === RelayerTransactionStatus.PENDING) {
+      throw new Error();
     }
+    return tx;
+  };
 
-    return relayerTransaction.hash;
+  const relayerTransaction = await retryWithDelay(retrieveRelayerTransaction, {
+    retries: MAX_TRANSACTION_HASH_RETRIEVAL_RETRIES,
+    interval: TRANSACTION_HASH_RETRIEVAL_WAIT,
+    finalErr: new JsonRpcError(RpcErrorCode.RPC_SERVER_ERROR, 'transaction hash not generated in time'),
   });
+
+  if (![
+    RelayerTransactionStatus.SUBMITTED,
+    RelayerTransactionStatus.SUCCESSFUL,
+  ].includes(relayerTransaction.status)) {
+    let errorMessage = `Transaction failed to submit with status ${relayerTransaction.status}.`;
+    if (relayerTransaction.statusMessage) {
+      errorMessage += ` Error message: ${relayerTransaction.statusMessage}`;
+    }
+    throw new JsonRpcError(
+      RpcErrorCode.RPC_SERVER_ERROR,
+      errorMessage,
+    );
+  }
+
+  return relayerTransaction.hash;
+};

--- a/packages/passport/sdk/src/zkEvm/signTypedDataV4.test.ts
+++ b/packages/passport/sdk/src/zkEvm/signTypedDataV4.test.ts
@@ -34,10 +34,7 @@ describe('signTypedDataV4', () => {
   };
   const guardianClient = {
     validateMessage: jest.fn(),
-    withConfirmationScreen: jest.fn(() => (task: () => void) => task()),
-    loading: jest.fn(),
   };
-  const withConfirmationScreenStub = jest.fn();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -46,8 +43,6 @@ describe('signTypedDataV4', () => {
     (getSignedTypedData as jest.Mock).mockResolvedValueOnce(
       combinedSignature,
     );
-    withConfirmationScreenStub.mockImplementation(() => (task: () => void) => task());
-    guardianClient.withConfirmationScreen = withConfirmationScreenStub;
     rpcProvider.detectNetwork.mockResolvedValue({ chainId });
   });
 

--- a/packages/passport/sdk/src/zkEvm/signTypedDataV4.ts
+++ b/packages/passport/sdk/src/zkEvm/signTypedDataV4.ts
@@ -69,20 +69,19 @@ export const signTypedDataV4 = async ({
   rpcProvider,
   relayerClient,
   guardianClient,
-}: SignTypedDataV4Params): Promise<string> => guardianClient
-  .withConfirmationScreen({ width: 480, height: 720 })(async () => {
-    const fromAddress: string = params[0];
-    const typedDataParam: string | object = params[1];
+}: SignTypedDataV4Params): Promise<string> => {
+  const fromAddress: string = params[0];
+  const typedDataParam: string | object = params[1];
 
-    if (!fromAddress || !typedDataParam) {
-      throw new JsonRpcError(RpcErrorCode.INVALID_PARAMS, `${method} requires an address and a typed data JSON`);
-    }
+  if (!fromAddress || !typedDataParam) {
+    throw new JsonRpcError(RpcErrorCode.INVALID_PARAMS, `${method} requires an address and a typed data JSON`);
+  }
 
-    const { chainId } = await rpcProvider.detectNetwork();
-    const typedData = transformTypedData(typedDataParam, chainId);
+  const { chainId } = await rpcProvider.detectNetwork();
+  const typedData = transformTypedData(typedDataParam, chainId);
 
-    await guardianClient.validateMessage({ chainID: String(chainId), payload: typedData });
-    const relayerSignature = await relayerClient.imSignTypedData(fromAddress, typedData);
+  await guardianClient.validateMessage({ chainID: String(chainId), payload: typedData });
+  const relayerSignature = await relayerClient.imSignTypedData(fromAddress, typedData);
 
-    return getSignedTypedData(typedData, relayerSignature, BigNumber.from(chainId), fromAddress, ethSigner);
-  });
+  return getSignedTypedData(typedData, relayerSignature, BigNumber.from(chainId), fromAddress, ethSigner);
+};

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
@@ -194,15 +194,17 @@ export class ZkEvmProvider implements Provider {
           throw new JsonRpcError(ProviderErrorCode.UNAUTHORIZED, 'Unauthorised - call eth_requestAccounts first');
         }
 
-        const ethSigner = await this.#getSigner();
+        return this.#guardianClient.withConfirmationScreen({ width: 480, height: 720 })(async () => {
+          const ethSigner = await this.#getSigner();
 
-        return sendTransaction({
-          params: request.params || [],
-          ethSigner,
-          guardianClient: this.#guardianClient,
-          rpcProvider: this.#rpcProvider,
-          relayerClient: this.#relayerClient,
-          zkevmAddress: this.#zkEvmAddress,
+          return sendTransaction({
+            params: request.params || [],
+            ethSigner,
+            guardianClient: this.#guardianClient,
+            rpcProvider: this.#rpcProvider,
+            relayerClient: this.#relayerClient,
+            zkevmAddress: this.#zkEvmAddress!,
+          });
         });
       }
       case 'eth_accounts': {
@@ -214,15 +216,17 @@ export class ZkEvmProvider implements Provider {
           throw new JsonRpcError(ProviderErrorCode.UNAUTHORIZED, 'Unauthorised - call eth_requestAccounts first');
         }
 
-        const ethSigner = await this.#getSigner();
+        return this.#guardianClient.withConfirmationScreen({ width: 480, height: 720 })(async () => {
+          const ethSigner = await this.#getSigner();
 
-        return signTypedDataV4({
-          method: request.method,
-          params: request.params || [],
-          ethSigner,
-          rpcProvider: this.#rpcProvider,
-          relayerClient: this.#relayerClient,
-          guardianClient: this.#guardianClient,
+          return signTypedDataV4({
+            method: request.method,
+            params: request.params || [],
+            ethSigner,
+            rpcProvider: this.#rpcProvider,
+            relayerClient: this.#relayerClient,
+            guardianClient: this.#guardianClient,
+          });
         });
       }
       case 'eth_chainId': {


### PR DESCRIPTION
# Summary
Updated the EVM provider `eth_sendTransaction` and `eth_signTypedData_v4` methods to open the confirmation popup before the ethSigner is initialised. This should prevent browsers from blocking the popup, since the popup will no longer be opened after an async call.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
On the zkEVM provider:
- eth_sendTransaction
- eth_signTypedData_v4
- eth_signTypedData


Before:

https://github.com/immutable/ts-immutable-sdk/assets/24399271/91840cc7-436a-4e75-b8d6-3a60d299691d


After:

https://github.com/immutable/ts-immutable-sdk/assets/24399271/ff2954be-1b90-4341-af92-5144391d7cb2
