### PR TITLE
chore: ID-1588 Add identify to eth_requestAccounts

### DIFF
--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
@@ -1,4 +1,5 @@
 import { StaticJsonRpcProvider, Web3Provider } from '@ethersproject/providers';
+import { identify } from '@imtbl/metrics';
 import AuthManager from 'authManager';
 import { utils } from 'ethers';
 import { ZkEvmProvider, ZkEvmProviderInput } from './zkEvmProvider';
@@ -14,6 +15,7 @@ import { signTypedDataV4 } from './signTypedDataV4';
 import MagicAdapter from '../magicAdapter';
 
 jest.mock('@ethersproject/providers');
+jest.mock('@imtbl/metrics');
 jest.mock('./relayerClient');
 jest.mock('./user');
 jest.mock('./sendTransaction');
@@ -62,9 +64,10 @@ describe('ZkEvmProvider', () => {
       expect(resultOne).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
       expect(resultTwo).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
       expect(authManager.getUserOrLogin).toBeCalledTimes(1);
+      expect(identify).toHaveBeenCalledTimes(1);
     });
 
-    it('should emit accountsChanged event when user logs in', async () => {
+    it('should emit accountsChanged event and identify user when user logs in', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
       const provider = getProvider();
       const onAccountsChanged = jest.fn();
@@ -75,6 +78,9 @@ describe('ZkEvmProvider', () => {
 
       expect(result).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
       expect(onAccountsChanged).toHaveBeenCalledWith([mockUserZkEvm.zkEvm.ethAddress]);
+      expect(identify).toHaveBeenCalledWith({
+        passportId: mockUserZkEvm.profile.sub,
+      });
     });
 
     it('should throw an error if the signer initialisation fails', async () => {

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
@@ -2,6 +2,7 @@ import { StaticJsonRpcProvider, Web3Provider } from '@ethersproject/providers';
 import { MultiRollupApiClients } from '@imtbl/generated-clients';
 import { Signer } from '@ethersproject/abstract-signer';
 import { utils } from 'ethers';
+import { identify } from '@imtbl/metrics';
 import {
   JsonRpcRequestCallback,
   JsonRpcRequestPayload,
@@ -186,6 +187,9 @@ export class ZkEvmProvider implements Provider {
         }
 
         this.#eventEmitter.emit(ProviderEvent.ACCOUNTS_CHANGED, [this.#zkEvmAddress]);
+        identify({
+          passportId: user.profile.sub,
+        });
 
         return [this.#zkEvmAddress];
       }


### PR DESCRIPTION
# Summary
This PR adds a call to the `identify` method in `eth_requestAccounts`

# Detail and impact of the change
## Changed
- Passport: Added additional tracking to `eth_requestAccounts`