### PR TITLE
feat: [GPR-551] Smart checkout routing options flags

### DIFF
--- a/packages/checkout/sdk-sample-app/src/components/SmartCheckoutForm.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/SmartCheckoutForm.tsx
@@ -39,6 +39,9 @@ export const SmartCheckoutForm = ({ checkout, provider }: SmartCheckoutProps) =>
   const [error, setError] = useState<any>(null);
   const [success, setSuccess] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
+  const [onRampChecked, setOnRampChecked] = useState<boolean>(true);
+  const [bridgeChecked, setBridgeChecked] = useState<boolean>(true);
+  const [swapChecked, setSwapChecked] = useState<boolean>(true);
 
   const [seaportContractAddress, setSeaportContractAddress] = useState<string>('');
 
@@ -136,6 +139,11 @@ export const SmartCheckoutForm = ({ checkout, provider }: SmartCheckoutProps) =>
           provider,
           itemRequirements,
           transactionOrGasAmount,
+          routingOptions: {
+            onRamp: onRampChecked,
+            swap: swapChecked,
+            bridge: bridgeChecked,
+          },
         }
       );
       console.log('Smart checkout result', result);
@@ -434,6 +442,43 @@ export const SmartCheckoutForm = ({ checkout, provider }: SmartCheckoutProps) =>
     setGasContractAddressError('');
   }
 
+  const fundingRoutesForm = () => {
+    return(
+      <>
+        <Body>Set Funding Options</Body>
+        <Box sx={{ display: 'flex' }}>
+          <FormControl sx={{ padding: 'base.spacing.x4' }}>
+            <FormControl.Label>OnRamp</FormControl.Label>
+            <Checkbox
+              checked={onRampChecked}
+              onChange={() => {
+                setOnRampChecked(!onRampChecked);
+              }}
+            />
+          </FormControl>
+          <FormControl sx={{ padding: 'base.spacing.x4' }}>
+            <FormControl.Label>Swap</FormControl.Label>
+            <Checkbox
+              checked={swapChecked}
+              onChange={() => {
+                setSwapChecked(!swapChecked);
+              }}
+            />
+          </FormControl>
+          <FormControl sx={{ padding: 'base.spacing.x4' }}>
+            <FormControl.Label>Bridge</FormControl.Label>
+            <Checkbox
+              checked={bridgeChecked}
+              onChange={() => {
+                setBridgeChecked(!bridgeChecked);
+              }}
+            />
+          </FormControl>
+        </Box>
+      </>
+    )
+  }
+
   const gasAmountForm = () => {
     return(
       <>
@@ -524,6 +569,7 @@ export const SmartCheckoutForm = ({ checkout, provider }: SmartCheckoutProps) =>
         paddingTop: 'base.spacing.x4',
         paddingBottom: 'base.spacing.x8'
       }} >
+        {fundingRoutesForm()}
         {gasAmountForm()}
       </Box>
       <LoadingButton onClick={smartCheckout} loading={loading}>

--- a/packages/checkout/sdk-sample-app/src/pages/SmartCheckout.tsx
+++ b/packages/checkout/sdk-sample-app/src/pages/SmartCheckout.tsx
@@ -15,7 +15,9 @@ import Listings from '../components/Listings';
 export default function SmartCheckout() {
   const [environment, setEnvironment] = useState(Environment.SANDBOX);
   const checkout = useMemo(() => {
-    return new Checkout({ baseConfig: { environment: environment } });
+    return new Checkout({ baseConfig: {
+      environment: environment,
+    }});
   }, [environment]);
   const [provider, setProvider] = useState<Web3Provider>();
 

--- a/packages/checkout/sdk/src/connect/connect.test.ts
+++ b/packages/checkout/sdk/src/connect/connect.test.ts
@@ -20,7 +20,9 @@ describe('connect', () => {
       ethereum: {
         request: providerRequestMock,
       },
-      removeEventListener: () => {},
+      dispatchEvent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
     }));
   });
 

--- a/packages/checkout/sdk/src/network/network.test.ts
+++ b/packages/checkout/sdk/src/network/network.test.ts
@@ -70,7 +70,15 @@ describe('network functions', () => {
   let mockedHttpClient: jest.Mocked<HttpClient>;
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    windowSpy = jest.spyOn(window, 'window', 'get');
+    windowSpy.mockImplementation(() => ({
+      ethereum: {
+        request: jest.fn(),
+      },
+      dispatchEvent: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
 
     mockedHttpClient = new HttpClient() as jest.Mocked<HttpClient>;
     (RemoteConfigFetcher as unknown as jest.Mock).mockReturnValue({
@@ -92,22 +100,12 @@ describe('network functions', () => {
     }, mockedHttpClient);
   });
 
+  afterEach(() => {
+    windowSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
   describe('switchWalletNetwork()', () => {
-    beforeEach(() => {
-      windowSpy = jest.spyOn(window, 'window', 'get');
-
-      windowSpy.mockImplementation(() => ({
-        ethereum: {
-          request: jest.fn(),
-        },
-        removeEventListener: () => {},
-      }));
-    });
-
-    afterEach(() => {
-      windowSpy.mockRestore();
-    });
-
     it('should make request for the user to switch network', async () => {
       (Web3Provider as unknown as jest.Mock).mockReturnValue({
         provider: providerMock,

--- a/packages/checkout/sdk/src/provider/provider.ts
+++ b/packages/checkout/sdk/src/provider/provider.ts
@@ -3,10 +3,12 @@ import detectEthereumProvider from '@metamask/detect-provider';
 import { Web3Provider, ExternalProvider } from '@ethersproject/providers';
 import { Passport } from '@imtbl/passport';
 import {
-  CreateProviderResult,
+  CreateProviderResult, EIP6963ProviderDetail,
   WalletProviderName,
 } from '../types';
 import { CheckoutError, CheckoutErrorType, withCheckoutError } from '../errors';
+import { InjectedProvidersManager } from './injectedProvidersManager';
+import { metaMaskProviderInfo, passportProviderInfo } from './providerDetail';
 
 async function getMetaMaskProvider(): Promise<Web3Provider> {
   const provider = await withCheckoutError<ExternalProvider | null>(
@@ -28,39 +30,53 @@ export async function createProvider(
   walletProviderName: WalletProviderName,
   passport?: Passport,
 ): Promise<CreateProviderResult> {
-  let provider: Web3Provider | null = null;
+  let web3Provider: Web3Provider | null = null;
+  let providerDetail: EIP6963ProviderDetail | undefined;
   switch (walletProviderName) {
     case WalletProviderName.PASSPORT: {
-      if (passport) {
-        provider = new Web3Provider(passport.connectEvm());
-      } else {
-        // eslint-disable-next-line no-console
-        console.error(
-          'WalletProviderName was PASSPORT but the passport instance was not provided to the Checkout constructor',
-        );
-        throw new CheckoutError(
-          'Passport not provided',
-          CheckoutErrorType.DEFAULT_PROVIDER_ERROR,
-        );
+      providerDetail = InjectedProvidersManager.getInstance().findProvider({ rdns: passportProviderInfo.rdns });
+      if (!providerDetail) {
+        if (passport) {
+          web3Provider = new Web3Provider(passport.connectEvm());
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(
+            'WalletProviderName was PASSPORT but the passport instance was not provided to the Checkout constructor',
+          );
+          throw new CheckoutError(
+            'Passport not provided',
+            CheckoutErrorType.DEFAULT_PROVIDER_ERROR,
+          );
+        }
       }
       break;
     }
     case WalletProviderName.METAMASK: {
-      provider = await getMetaMaskProvider();
+      providerDetail = InjectedProvidersManager.getInstance().findProvider({ rdns: metaMaskProviderInfo.rdns });
+      if (!providerDetail) {
+        web3Provider = await getMetaMaskProvider();
+      }
       break;
     }
     default:
-      // eslint-disable-next-line no-console
-      console.error(
-        'The WalletProviderName that was provided is not supported',
-      );
-      throw new CheckoutError(
-        'Provider not supported',
-        CheckoutErrorType.DEFAULT_PROVIDER_ERROR,
-      );
+      providerDetail = InjectedProvidersManager.getInstance().findProvider({ rdns: walletProviderName });
+      if (!providerDetail) {
+        // eslint-disable-next-line no-console
+        console.error(
+          'The WalletProviderName that was provided is not supported',
+        );
+        throw new CheckoutError(
+          'Provider not supported',
+          CheckoutErrorType.DEFAULT_PROVIDER_ERROR,
+        );
+      }
+  }
+
+  if (!web3Provider && providerDetail) {
+    web3Provider = new Web3Provider(providerDetail.provider);
   }
   return {
-    provider,
+    provider: web3Provider as Web3Provider,
     walletProviderName,
   };
 }

--- a/packages/checkout/sdk/src/sdk.test.ts
+++ b/packages/checkout/sdk/src/sdk.test.ts
@@ -641,6 +641,7 @@ describe('Connect', () => {
       params.provider,
       params.itemRequirements,
       params.transactionOrGasAmount,
+      undefined,
     );
   });
 

--- a/packages/checkout/sdk/src/sdk.ts
+++ b/packages/checkout/sdk/src/sdk.ts
@@ -575,6 +575,7 @@ export class Checkout {
       web3Provider,
       itemRequirements,
       params.transactionOrGasAmount,
+      params.routingOptions,
     );
   }
 

--- a/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
+++ b/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
@@ -27,6 +27,7 @@ export const smartCheckout = async (
   provider: Web3Provider,
   itemRequirements: ItemRequirement[],
   transactionOrGasAmount?: FulfillmentTransaction | GasAmount,
+  routingOptions?: AvailableRoutingOptions,
 ): Promise<SmartCheckoutResult> => {
   const ownerAddress = await provider.getSigner().getAddress();
 
@@ -78,6 +79,9 @@ export const smartCheckout = async (
     'Time to fetch available routing options',
     getAvailableRoutingOptions(config, provider),
   );
+  if (routingOptions?.onRamp === false) availableRoutingOptions.onRamp = false;
+  if (routingOptions?.swap === false) availableRoutingOptions.swap = false;
+  if (routingOptions?.bridge === false) availableRoutingOptions.bridge = false;
 
   const routingOutcome = await measureAsyncExecution<RoutingOutcome>(
     config,

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -327,6 +327,8 @@ export interface SmartCheckoutParams {
   itemRequirements: (NativeItemRequirement | ERC20ItemRequirement | ERC721ItemRequirement)[];
   /** The transaction or gas amount. */
   transactionOrGasAmount?: FulfillmentTransaction | GasAmount,
+  /** The overrides for funding routes to consider */
+  routingOptions?: AvailableRoutingOptions,
 }
 
 /**


### PR DESCRIPTION
# Summary
Smart checkout optimisations to flag only the funding routes you are interested in calculating.
[GPR-551](https://immutable.atlassian.net/browse/GPR-551)

# Detail and impact of the change
## Added 
Added `routingOptions` to Smart checkout to flag the funding paths swap, bridge, onRamp

## Changed
CreateProvider to use new injected providers listing.


[GPR-551]: https://immutable.atlassian.net/browse/GPR-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ