### PR TITLE
chore: make build:onlysdk actually only build the sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "responselike": "^2.0.0"
   },
   "scripts": {
-    "build": "NODE_OPTIONS=--max-old-space-size=14366 wsrun -y 4 -p @imtbl/sdk -p @imtbl/checkout-widgets-lib -e -r --serial build && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
-    "build:onlysdk": "NODE_OPTIONS=--max-old-space-size=14366 wsrun -y 4 --stages build && yarn syncpack:format",
+    "build": "NODE_OPTIONS=--max-old-space-size=14366 wsrun -y 4 -p @imtbl/sdk -p @imtbl/checkout-widgets -e -r --serial build && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
+    "build:onlysdk": "NODE_OPTIONS=--max-old-space-size=14366 wsrun -y 4 -p @imtbl/sdk --stages build && yarn syncpack:format",
     "docs:build": "typedoc",
     "docs:serve": "http-server ./docs --cors -p 8080 -c-1",
     "lint": "wsrun --exclude-missing -e lint --no-error-on-unmatched-pattern",


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
Change `@imtbl/checkout-widgets-lib` to `@imtbl/checkout-widgets` in the build script and only build `@imtbl/sdk` for `build:onlysdk`

# Anything else worth calling out?
No code changes.