### PR TITLE
[feat]gpr-593 smart checkout onComplete and onFundingRoute callbacks

### DIFF
--- a/packages/checkout/sdk/src/sdk.test.ts
+++ b/packages/checkout/sdk/src/sdk.test.ts
@@ -642,6 +642,8 @@ describe('Connect', () => {
       params.itemRequirements,
       params.transactionOrGasAmount,
       undefined,
+      undefined,
+      undefined,
     );
   });
 

--- a/packages/checkout/sdk/src/sdk.ts
+++ b/packages/checkout/sdk/src/sdk.ts
@@ -576,6 +576,8 @@ export class Checkout {
       itemRequirements,
       params.transactionOrGasAmount,
       params.routingOptions,
+      params.onComplete,
+      params.onFundingRoute,
     );
   }
 

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.test.ts
@@ -393,7 +393,7 @@ describe('routingCalculator', () => {
       type: RoutingOutcomeType.ROUTES_FOUND,
       fundingRoutes: [
         {
-          priority: 1,
+          priority: 2,
           steps: [bridgeFundingStep],
         },
       ],
@@ -870,7 +870,7 @@ describe('routingCalculator', () => {
       type: RoutingOutcomeType.ROUTES_FOUND,
       fundingRoutes: [
         {
-          priority: 1,
+          priority: 3,
           steps: [onRampFundingStep],
         },
       ],
@@ -1136,7 +1136,7 @@ describe('routingCalculator', () => {
           steps: [bridgeFundingStep],
         },
         {
-          priority: 3,
+          priority: 4,
           steps: [bridgeImxFundingStep, swapImxFundingStep],
         },
       ],

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
@@ -307,14 +307,12 @@ export const routingCalculator = async (
         insufficientRequirement,
         tokenBalances,
       ).then((result) => {
-        if (result) {
-          handleRouteProgress(
-            result,
-            PRIORITIES.bridge,
-            fundingRoutes,
-            onFundingRoute,
-          );
-        }
+        handleRouteProgress(
+          result,
+          PRIORITIES.bridge,
+          fundingRoutes,
+          onFundingRoute,
+        );
       }),
     );
   }

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
@@ -213,7 +213,7 @@ const handleRouteProgress = (
   const route = { priority, steps };
   fundingRoutes.push(route);
 
-  if (onFundingRoute) onFundingRoute(route);
+  onFundingRoute?.(route);
 };
 
 export const routingCalculator = async (

--- a/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/routingCalculator.ts
@@ -1,23 +1,19 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
-import {
-  BalanceCheckResult,
-  BalanceRequirement,
-} from '../balanceCheck/types';
+import { BalanceCheckResult, BalanceRequirement } from '../balanceCheck/types';
 import {
   AvailableRoutingOptions,
   BridgeFundingStep,
   ChainId,
+  FundingRoute,
+  FundingStep,
   ItemType,
   OnRampFundingStep,
-  RoutesFound,
   RoutingOutcome,
   RoutingOutcomeType,
   SwapFundingStep,
   TokenInfo,
 } from '../../types';
-import {
-  TokenBalanceResult,
-} from './types';
+import { TokenBalanceResult } from './types';
 import { getAllTokenBalances } from './tokenBalances';
 import {
   CheckoutConfiguration,
@@ -29,15 +25,20 @@ import { CheckoutError, CheckoutErrorType } from '../../errors';
 import { swapRoute } from './swap/swapRoute';
 import { allowListCheck } from '../allowList';
 import { RoutingTokensAllowList } from '../allowList/types';
-import { BridgeAndSwapRoute, bridgeAndSwapRoute } from './bridgeAndSwap/bridgeAndSwapRoute';
+import {
+  BridgeAndSwapRoute,
+  bridgeAndSwapRoute,
+} from './bridgeAndSwap/bridgeAndSwapRoute';
 import { BridgeRequirement, bridgeRoute } from './bridge/bridgeRoute';
 import { onRampRoute } from './onRamp';
 import { INDEXER_ETH_ROOT_CONTRACT_ADDRESS } from './indexer/fetchL1Representation';
 import { measureAsyncExecution } from '../../logger/debugLogger';
 
-const hasAvailableRoutingOptions = (availableRoutingOptions: AvailableRoutingOptions) => (
-  availableRoutingOptions.bridge || availableRoutingOptions.swap || availableRoutingOptions.onRamp
-);
+const hasAvailableRoutingOptions = (
+  availableRoutingOptions: AvailableRoutingOptions,
+) => availableRoutingOptions.bridge
+  || availableRoutingOptions.swap
+  || availableRoutingOptions.onRamp;
 
 export const getInsufficientRequirement = (
   balanceRequirements: BalanceCheckResult,
@@ -64,7 +65,10 @@ export const getBridgeFundingStep = async (
 ): Promise<BridgeFundingStep | undefined> => {
   let bridgeFundingStep;
   if (insufficientRequirement === undefined) return undefined;
-  if (insufficientRequirement.type !== ItemType.NATIVE && insufficientRequirement.type !== ItemType.ERC20) {
+  if (
+    insufficientRequirement.type !== ItemType.NATIVE
+    && insufficientRequirement.type !== ItemType.ERC20
+  ) {
     return undefined;
   }
 
@@ -107,7 +111,8 @@ export const getSwapFundingSteps = async (
 
   if (swapTokenAllowList.length === 0) return fundingSteps;
   const swappableTokens: string[] = swapTokenAllowList
-    .filter((token) => token.address).map((token) => token.address as string);
+    .filter((token) => token.address)
+    .map((token) => token.address as string);
 
   if (swappableTokens.length === 0) return fundingSteps;
 
@@ -152,7 +157,10 @@ export const getBridgeAndSwapFundingSteps = async (
   });
   const swapTokenAllowList = tokenAllowList?.swap ?? [];
 
-  if (insufficientRequirement.type !== ItemType.NATIVE && insufficientRequirement.type !== ItemType.ERC20) {
+  if (
+    insufficientRequirement.type !== ItemType.NATIVE
+    && insufficientRequirement.type !== ItemType.ERC20
+  ) {
     return [];
   }
 
@@ -188,11 +196,32 @@ export const getOnRampFundingStep = async (
   return onRampFundingStep;
 };
 
+const handleRouteProgress = (
+  result: FundingStep | BridgeAndSwapRoute,
+  priority: number,
+  fundingRoutes: FundingRoute[],
+  onFundingRoute?: (fundingRoute: FundingRoute) => void,
+) => {
+  let steps;
+  if ('bridgeFundingStep' in result && 'swapFundingStep' in result) {
+    // Handling BridgeAndSwapRoute
+    steps = [result.bridgeFundingStep, result.swapFundingStep];
+  } else {
+    // Handling individual SwapFundingStep, BridgeFundingStep, or OnRampFundingStep
+    steps = [result];
+  }
+  const route = { priority, steps };
+  fundingRoutes.push(route);
+
+  if (onFundingRoute) onFundingRoute(route);
+};
+
 export const routingCalculator = async (
   config: CheckoutConfiguration,
   ownerAddress: string,
   balanceRequirements: BalanceCheckResult,
   availableRoutingOptions: AvailableRoutingOptions,
+  onFundingRoute?: (fundingRoute: FundingRoute) => void,
 ): Promise<RoutingOutcome> => {
   if (!hasAvailableRoutingOptions(availableRoutingOptions)) {
     return {
@@ -212,7 +241,9 @@ export const routingCalculator = async (
     );
   }
 
-  const tokenBalances = await measureAsyncExecution<Map<ChainId, TokenBalanceResult>>(
+  const tokenBalances = await measureAsyncExecution<
+  Map<ChainId, TokenBalanceResult>
+  >(
     config,
     'Time to get token balances inside router',
     getAllTokenBalances(
@@ -226,150 +257,107 @@ export const routingCalculator = async (
   const allowList = await measureAsyncExecution<RoutingTokensAllowList>(
     config,
     'Time to get routing allowlist',
-    allowListCheck(
-      config,
-      tokenBalances,
-      availableRoutingOptions,
-    ),
+    allowListCheck(config, tokenBalances, availableRoutingOptions),
   );
 
   // Ensures only 1 balance requirement is insufficient
   const insufficientRequirement = getInsufficientRequirement(balanceRequirements);
 
   const routePromises: Promise<any>[] = [];
-  const routeSteps: string[] = [];
-
-  if (availableRoutingOptions.bridge) {
-    routeSteps.push('bridgeFundingStep');
-    routePromises.push(getBridgeFundingStep(
-      config,
-      readOnlyProviders,
-      availableRoutingOptions,
-      insufficientRequirement,
-      tokenBalances,
-    ));
-  }
+  const fundingRoutes: FundingRoute[] = [];
+  let priority = 0;
 
   if (availableRoutingOptions.swap) {
-    routeSteps.push('swapFundingSteps');
-    routePromises.push(getSwapFundingSteps(
-      config,
-      availableRoutingOptions,
-      insufficientRequirement,
-      ownerAddress,
-      tokenBalances,
-      allowList.swap,
-      balanceRequirements,
-    ));
+    routePromises.push(
+      getSwapFundingSteps(
+        config,
+        availableRoutingOptions,
+        insufficientRequirement,
+        ownerAddress,
+        tokenBalances,
+        allowList.swap,
+        balanceRequirements,
+      ).then((result) => {
+        if (result.length) {
+          priority++;
+          result.forEach((step) => {
+            handleRouteProgress(step, priority, fundingRoutes, onFundingRoute);
+          });
+        }
+      }),
+    );
+  }
+
+  if (availableRoutingOptions.bridge) {
+    routePromises.push(
+      getBridgeFundingStep(
+        config,
+        readOnlyProviders,
+        availableRoutingOptions,
+        insufficientRequirement,
+        tokenBalances,
+      ).then((result) => {
+        if (result) {
+          priority++;
+          handleRouteProgress(result, priority, fundingRoutes, onFundingRoute);
+        }
+      }),
+    );
   }
 
   if (availableRoutingOptions.onRamp) {
-    routeSteps.push('onRampFundingStep');
-    routePromises.push(getOnRampFundingStep(
-      config,
-      availableRoutingOptions,
-      insufficientRequirement,
-    ));
+    routePromises.push(
+      getOnRampFundingStep(
+        config,
+        availableRoutingOptions,
+        insufficientRequirement,
+      ).then((result) => {
+        if (result) {
+          priority++;
+          handleRouteProgress(result, priority, fundingRoutes, onFundingRoute);
+        }
+      }),
+    );
   }
 
   if (availableRoutingOptions.swap && availableRoutingOptions.bridge) {
-    routeSteps.push('bridgeAndSwapFundingSteps');
-    routePromises.push(getBridgeAndSwapFundingSteps(
-      config,
-      readOnlyProviders,
-      availableRoutingOptions,
-      insufficientRequirement,
-      ownerAddress,
-      tokenBalances,
-      allowList,
-      balanceRequirements,
-    ));
+    routePromises.push(
+      getBridgeAndSwapFundingSteps(
+        config,
+        readOnlyProviders,
+        availableRoutingOptions,
+        insufficientRequirement,
+        ownerAddress,
+        tokenBalances,
+        allowList,
+        balanceRequirements,
+      ).then((result) => {
+        result.forEach((route) => {
+          if (result) {
+            priority++;
+            handleRouteProgress(route, priority, fundingRoutes, onFundingRoute);
+          }
+        });
+      }),
+    );
   }
 
-  const resolved = await measureAsyncExecution<any[]>(
+  await measureAsyncExecution<any[]>(
     config,
     'Time to resolve all routes',
     Promise.all(routePromises),
   );
 
-  let bridgeFundingStep: BridgeFundingStep | undefined;
-  let swapFundingSteps: SwapFundingStep[] = [];
-  let onRampFundingStep: OnRampFundingStep | undefined;
-  let bridgeAndSwapFundingSteps: BridgeAndSwapRoute[] = [];
-  resolved.forEach((result, index) => {
-    const routeStep = routeSteps[index];
-    switch (routeStep) {
-      case 'bridgeFundingStep':
-        bridgeFundingStep = result as BridgeFundingStep | undefined;
-        break;
-      case 'swapFundingSteps':
-        swapFundingSteps = result as SwapFundingStep[];
-        break;
-      case 'onRampFundingStep':
-        onRampFundingStep = result as OnRampFundingStep | undefined;
-        break;
-      case 'bridgeAndSwapFundingSteps':
-        bridgeAndSwapFundingSteps = result as BridgeAndSwapRoute[];
-        break;
-      default:
-        break;
-    }
-  });
-
-  if (!bridgeFundingStep
-    && swapFundingSteps.length === 0
-    && !onRampFundingStep
-    && bridgeAndSwapFundingSteps.length === 0) {
+  if (fundingRoutes.length === 0) {
     return {
       type: RoutingOutcomeType.NO_ROUTES_FOUND,
-      message: 'Smart Checkout did not find any funding routes to fulfill the transaction',
+      message:
+        'Smart Checkout did not find any funding routes to fulfill the transaction',
     };
   }
 
-  const response: RoutesFound = {
+  return {
     type: RoutingOutcomeType.ROUTES_FOUND,
-    fundingRoutes: [],
+    fundingRoutes,
   };
-
-  let priority = 0;
-
-  if (swapFundingSteps.length > 0) {
-    priority++;
-    swapFundingSteps.forEach((swapFundingStep) => {
-      response.fundingRoutes.push({
-        priority,
-        steps: [swapFundingStep],
-      });
-    });
-  }
-
-  if (bridgeFundingStep) {
-    priority++;
-    response.fundingRoutes.push({
-      priority,
-      steps: [bridgeFundingStep],
-    });
-  }
-
-  if (onRampFundingStep) {
-    priority++;
-    response.fundingRoutes.push({
-      priority,
-      steps: [onRampFundingStep],
-    });
-  }
-
-  if (bridgeAndSwapFundingSteps) {
-    priority++;
-    bridgeAndSwapFundingSteps.forEach((bridgeAndSwapFundingStep) => {
-      const bridgeStep = bridgeAndSwapFundingStep.bridgeFundingStep;
-      const swapStep = bridgeAndSwapFundingStep.swapFundingStep;
-      response.fundingRoutes.push({
-        priority,
-        steps: [bridgeStep, swapStep],
-      });
-    });
-  }
-
-  return response;
 };

--- a/packages/checkout/sdk/src/smartCheckout/smartCheckout.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/smartCheckout.test.ts
@@ -250,6 +250,300 @@ describe('smartCheckout', () => {
       });
     });
 
+    it('should invoke onComplete callback with sufficient checkout', (done) => {
+      (hasERC20Allowances as jest.Mock).mockResolvedValue({
+        sufficient: true,
+        allowances: [],
+      });
+
+      (hasERC721Allowances as jest.Mock).mockResolvedValue({
+        sufficient: true,
+        allowances: [],
+      });
+
+      (gasCalculator as jest.Mock).mockResolvedValue({
+        type: ItemType.NATIVE,
+        amount: BigNumber.from(1),
+      });
+
+      (balanceCheck as jest.Mock).mockResolvedValue({
+        sufficient: true,
+        balanceRequirements: [
+          {
+            type: ItemType.NATIVE,
+            sufficient: true,
+            required: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+              token: {
+                name: 'IMX',
+                symbol: 'IMX',
+                decimals: 18,
+                address: '0x1010',
+              },
+            },
+            current: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+              token: {
+                name: 'IMX',
+                symbol: 'IMX',
+                decimals: 18,
+                address: '0x1010',
+              },
+            },
+            delta: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+            },
+          },
+          {
+            type: ItemType.ERC20,
+            sufficient: true,
+            required: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+              token: {
+                name: 'zkTKN',
+                symbol: 'zkTKN',
+                decimals: 18,
+                address: '0xERC20',
+              },
+            },
+            current: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+              token: {
+                name: 'zkTKN',
+                symbol: 'zkTKN',
+                decimals: 18,
+                address: '0xERC20',
+              },
+            },
+            delta: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+            },
+          },
+          {
+            type: ItemType.ERC721,
+            sufficient: true,
+            required: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+              id: '0',
+              contractAddress: '0xCollection',
+            },
+            current: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+            },
+            delta: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+            },
+          },
+        ],
+      });
+
+      const itemRequirements: ItemRequirement[] = [
+        {
+          type: ItemType.NATIVE,
+          amount: BigNumber.from(1),
+        },
+      ];
+
+      const transactionOrGasAmount: GasAmount = {
+        type: TransactionOrGasType.GAS,
+        gasToken: {
+          type: GasTokenType.NATIVE,
+          limit: BigNumber.from(1),
+        },
+      };
+
+      const mockOnComplete = jest.fn().mockImplementation((result) => {
+        expect(result).toMatchObject({
+          sufficient: true,
+          transactionRequirements: [
+            {
+              type: ItemType.NATIVE,
+              sufficient: true,
+              required: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+                token: {
+                  name: 'IMX',
+                  symbol: 'IMX',
+                  decimals: 18,
+                  address: '0x1010',
+                },
+              },
+              current: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+                token: {
+                  name: 'IMX',
+                  symbol: 'IMX',
+                  decimals: 18,
+                  address: '0x1010',
+                },
+              },
+              delta: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+              },
+            },
+            {
+              type: ItemType.ERC20,
+              sufficient: true,
+              required: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+                token: {
+                  name: 'zkTKN',
+                  symbol: 'zkTKN',
+                  decimals: 18,
+                  address: '0xERC20',
+                },
+              },
+              current: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+                token: {
+                  name: 'zkTKN',
+                  symbol: 'zkTKN',
+                  decimals: 18,
+                  address: '0xERC20',
+                },
+              },
+              delta: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+              },
+            },
+            {
+              type: ItemType.ERC721,
+              sufficient: true,
+              required: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+                id: '0',
+                contractAddress: '0xCollection',
+              },
+              current: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+              },
+              delta: {
+                balance: BigNumber.from(1),
+                formattedBalance: '1.0',
+              },
+            },
+          ],
+        });
+        done();
+      });
+
+      smartCheckout(
+        {} as CheckoutConfiguration,
+        mockProvider,
+        itemRequirements,
+        transactionOrGasAmount,
+        undefined,
+        mockOnComplete,
+      );
+    });
+
+    it('should invoke onComplete callback with insufficient checkout', async () => {
+      (hasERC20Allowances as jest.Mock).mockResolvedValue({
+        sufficient: true,
+        allowances: [],
+      });
+
+      (hasERC721Allowances as jest.Mock).mockResolvedValue({
+        sufficient: true,
+        allowances: [],
+      });
+
+      (gasCalculator as jest.Mock).mockResolvedValue(null);
+
+      (balanceCheck as jest.Mock).mockResolvedValue({
+        sufficient: false,
+        balanceRequirements: [
+          {
+            type: ItemType.NATIVE,
+            sufficient: false,
+            required: {
+              balance: BigNumber.from(2),
+              formattedBalance: '2.0',
+              token: {
+                name: 'IMX',
+                symbol: 'IMX',
+                decimals: 18,
+                address: '0x1010',
+              },
+            },
+            current: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+              token: {
+                name: 'IMX',
+                symbol: 'IMX',
+                decimals: 18,
+                address: '0x1010',
+              },
+            },
+            delta: {
+              balance: BigNumber.from(1),
+              formattedBalance: '1.0',
+            },
+          },
+        ],
+      });
+
+      const itemRequirements: ItemRequirement[] = [
+        {
+          type: ItemType.NATIVE,
+          amount: BigNumber.from(1),
+        },
+      ];
+
+      const mockOnComplete = jest.fn();
+
+      const result = await smartCheckout(
+        {} as CheckoutConfiguration,
+        mockProvider,
+        itemRequirements,
+        undefined,
+        undefined,
+        mockOnComplete,
+      );
+
+      expect(mockOnComplete).toHaveBeenCalledTimes(1);
+      expect(mockOnComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sufficient: false,
+          transactionRequirements: expect.any(Array),
+          router: expect.objectContaining({
+            routingOutcome: expect.objectContaining({
+              type: RoutingOutcomeType.NO_ROUTES_FOUND,
+              message: 'No routes found',
+            }),
+          }),
+        }),
+      );
+
+      expect(result).toMatchObject({
+        sufficient: false,
+        transactionRequirements: expect.any(Array),
+        router: expect.objectContaining({
+          routingOutcome: expect.objectContaining({
+            type: RoutingOutcomeType.NO_ROUTES_FOUND,
+          }),
+        }),
+      });
+    });
+
     it('should return sufficient false with item requirements', async () => {
       (hasERC20Allowances as jest.Mock).mockResolvedValue({
         sufficient: true,
@@ -796,7 +1090,8 @@ describe('smartCheckout', () => {
     it('should return swap funding route when available', async () => {
       (routingCalculator as jest.Mock).mockResolvedValue({
         type: RoutingOutcomeType.NO_ROUTES_FOUND,
-        message: 'Smart Checkout did not find any funding routes to fulfill the transaction',
+        message:
+          'Smart Checkout did not find any funding routes to fulfill the transaction',
       });
 
       (hasERC20Allowances as jest.Mock).mockResolvedValue({
@@ -902,7 +1197,8 @@ describe('smartCheckout', () => {
           },
           routingOutcome: {
             type: RoutingOutcomeType.NO_ROUTES_FOUND,
-            message: 'Smart Checkout did not find any funding routes to fulfill the transaction',
+            message:
+              'Smart Checkout did not find any funding routes to fulfill the transaction',
           },
         },
       });

--- a/packages/checkout/sdk/src/smartCheckout/smartCheckout.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/smartCheckout.test.ts
@@ -250,7 +250,7 @@ describe('smartCheckout', () => {
       });
     });
 
-    it('should invoke onComplete callback with sufficient checkout', (done) => {
+    it('should invoke onComplete callback once funding routes are returned', (done) => {
       (hasERC20Allowances as jest.Mock).mockResolvedValue({
         sufficient: true,
         allowances: [],
@@ -452,96 +452,6 @@ describe('smartCheckout', () => {
         undefined,
         mockOnComplete,
       );
-    });
-
-    it('should invoke onComplete callback with insufficient checkout', async () => {
-      (hasERC20Allowances as jest.Mock).mockResolvedValue({
-        sufficient: true,
-        allowances: [],
-      });
-
-      (hasERC721Allowances as jest.Mock).mockResolvedValue({
-        sufficient: true,
-        allowances: [],
-      });
-
-      (gasCalculator as jest.Mock).mockResolvedValue(null);
-
-      (balanceCheck as jest.Mock).mockResolvedValue({
-        sufficient: false,
-        balanceRequirements: [
-          {
-            type: ItemType.NATIVE,
-            sufficient: false,
-            required: {
-              balance: BigNumber.from(2),
-              formattedBalance: '2.0',
-              token: {
-                name: 'IMX',
-                symbol: 'IMX',
-                decimals: 18,
-                address: '0x1010',
-              },
-            },
-            current: {
-              balance: BigNumber.from(1),
-              formattedBalance: '1.0',
-              token: {
-                name: 'IMX',
-                symbol: 'IMX',
-                decimals: 18,
-                address: '0x1010',
-              },
-            },
-            delta: {
-              balance: BigNumber.from(1),
-              formattedBalance: '1.0',
-            },
-          },
-        ],
-      });
-
-      const itemRequirements: ItemRequirement[] = [
-        {
-          type: ItemType.NATIVE,
-          amount: BigNumber.from(1),
-        },
-      ];
-
-      const mockOnComplete = jest.fn();
-
-      const result = await smartCheckout(
-        {} as CheckoutConfiguration,
-        mockProvider,
-        itemRequirements,
-        undefined,
-        undefined,
-        mockOnComplete,
-      );
-
-      expect(mockOnComplete).toHaveBeenCalledTimes(1);
-      expect(mockOnComplete).toHaveBeenCalledWith(
-        expect.objectContaining({
-          sufficient: false,
-          transactionRequirements: expect.any(Array),
-          router: expect.objectContaining({
-            routingOutcome: expect.objectContaining({
-              type: RoutingOutcomeType.NO_ROUTES_FOUND,
-              message: 'No routes found',
-            }),
-          }),
-        }),
-      );
-
-      expect(result).toMatchObject({
-        sufficient: false,
-        transactionRequirements: expect.any(Array),
-        router: expect.objectContaining({
-          routingOutcome: expect.objectContaining({
-            type: RoutingOutcomeType.NO_ROUTES_FOUND,
-          }),
-        }),
-      });
     });
 
     it('should return sufficient false with item requirements', async () => {

--- a/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
+++ b/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
@@ -124,7 +124,7 @@ export const smartCheckout = async (
   if (routingOptions?.swap === false) availableRoutingOptions.swap = false;
   if (routingOptions?.bridge === false) availableRoutingOptions.bridge = false;
 
-  if (sufficient) {
+  if (sufficient || onComplete) {
     processRoutes(
       config,
       provider,

--- a/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
+++ b/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
@@ -2,16 +2,14 @@ import { Web3Provider } from '@ethersproject/providers';
 import {
   AvailableRoutingOptions,
   FulfillmentTransaction,
+  FundingRoute,
   GasAmount,
   ItemRequirement,
   RoutingOutcome,
   SmartCheckoutResult,
 } from '../types/smartCheckout';
 import { itemAggregator } from './aggregators';
-import {
-  hasERC20Allowances,
-  hasERC721Allowances,
-} from './allowance';
+import { hasERC20Allowances, hasERC721Allowances } from './allowance';
 import { balanceCheck } from './balanceCheck';
 import { CheckoutConfiguration } from '../config';
 import { allowanceAggregator } from './aggregators/allowanceAggregator';
@@ -19,8 +17,43 @@ import { gasCalculator } from './gas';
 import { getAvailableRoutingOptions } from './routing';
 import { routingCalculator } from './routing/routingCalculator';
 import { Allowance } from './allowance/types';
-import { BalanceCheckResult } from './balanceCheck/types';
+import { BalanceCheckResult, BalanceRequirement } from './balanceCheck/types';
 import { measureAsyncExecution } from '../logger/debugLogger';
+
+const processRoutes = async (
+  config: CheckoutConfiguration,
+  provider: Web3Provider,
+  ownerAddress: string,
+  sufficient: boolean,
+  availableRoutingOptions: AvailableRoutingOptions,
+  transactionRequirements: BalanceRequirement[],
+  balanceCheckResult: BalanceCheckResult,
+  onComplete?: (result: SmartCheckoutResult) => void,
+  onFundingRoute?: (fundingRoute: FundingRoute) => void,
+): Promise<RoutingOutcome> => {
+  const routingOutcome = await measureAsyncExecution<RoutingOutcome>(
+    config,
+    'Total time to run the routing calculator',
+    routingCalculator(
+      config,
+      ownerAddress,
+      balanceCheckResult,
+      availableRoutingOptions,
+      onFundingRoute,
+    ),
+  );
+
+  onComplete?.({
+    sufficient,
+    transactionRequirements,
+    router: {
+      availableRoutingOptions,
+      routingOutcome,
+    },
+  });
+
+  return routingOutcome;
+};
 
 export const smartCheckout = async (
   config: CheckoutConfiguration,
@@ -28,21 +61,36 @@ export const smartCheckout = async (
   itemRequirements: ItemRequirement[],
   transactionOrGasAmount?: FulfillmentTransaction | GasAmount,
   routingOptions?: AvailableRoutingOptions,
+  onComplete?: (result: SmartCheckoutResult) => void,
+  onFundingRoute?: (fundingRoute: FundingRoute) => void,
 ): Promise<SmartCheckoutResult> => {
   const ownerAddress = await provider.getSigner().getAddress();
 
   let aggregatedItems = itemAggregator(itemRequirements);
 
-  const erc20AllowancePromise = hasERC20Allowances(provider, ownerAddress, aggregatedItems);
-  const erc721AllowancePromise = hasERC721Allowances(provider, ownerAddress, aggregatedItems);
+  const erc20AllowancePromise = hasERC20Allowances(
+    provider,
+    ownerAddress,
+    aggregatedItems,
+  );
+  const erc721AllowancePromise = hasERC721Allowances(
+    provider,
+    ownerAddress,
+    aggregatedItems,
+  );
 
-  const resolvedAllowances = await measureAsyncExecution<{ sufficient: boolean, allowances: Allowance[] }[]>(
+  const resolvedAllowances = await measureAsyncExecution<
+  { sufficient: boolean; allowances: Allowance[] }[]
+  >(
     config,
     'Time to calculate token allowances',
     Promise.all([erc20AllowancePromise, erc721AllowancePromise]),
   );
 
-  const aggregatedAllowances = allowanceAggregator(resolvedAllowances[0], resolvedAllowances[1]);
+  const aggregatedAllowances = allowanceAggregator(
+    resolvedAllowances[0],
+    resolvedAllowances[1],
+  );
 
   // Skip gas calculation if transactionOrGasAmount is not provided
   let gasItem = null;
@@ -67,13 +115,6 @@ export const smartCheckout = async (
   const { sufficient } = balanceCheckResult;
   const transactionRequirements = balanceCheckResult.balanceRequirements;
 
-  if (sufficient) {
-    return {
-      sufficient,
-      transactionRequirements,
-    };
-  }
-
   const availableRoutingOptions = await measureAsyncExecution<AvailableRoutingOptions>(
     config,
     'Time to fetch available routing options',
@@ -83,15 +124,34 @@ export const smartCheckout = async (
   if (routingOptions?.swap === false) availableRoutingOptions.swap = false;
   if (routingOptions?.bridge === false) availableRoutingOptions.bridge = false;
 
-  const routingOutcome = await measureAsyncExecution<RoutingOutcome>(
-    config,
-    'Total time to run the routing calculator',
-    routingCalculator(
+  if (sufficient) {
+    processRoutes(
       config,
+      provider,
       ownerAddress,
-      balanceCheckResult,
+      sufficient,
       availableRoutingOptions,
-    ),
+      transactionRequirements,
+      balanceCheckResult,
+      onComplete,
+      onFundingRoute,
+    );
+    return {
+      sufficient,
+      transactionRequirements,
+    };
+  }
+
+  const routingOutcome = await processRoutes(
+    config,
+    provider,
+    ownerAddress,
+    sufficient,
+    availableRoutingOptions,
+    transactionRequirements,
+    balanceCheckResult,
+    onComplete,
+    onFundingRoute,
   );
 
   return {

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -571,7 +571,7 @@ export type SmartCheckoutInsufficient = {
   /** The transaction requirements smart checkout determined were required for the transaction. */
   transactionRequirements: TransactionRequirement[];
   /** The type containing the funding routes the user can take to fulfill the transaction requirements */
-  router: SmartCheckoutRouter;
+  router?: SmartCheckoutRouter;
 };
 
 /**

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -329,6 +329,10 @@ export interface SmartCheckoutParams {
   transactionOrGasAmount?: FulfillmentTransaction | GasAmount,
   /** The overrides for funding routes to consider */
   routingOptions?: AvailableRoutingOptions,
+  /** The callback to be execured once all funding routes are found */
+  onComplete?: (result: SmartCheckoutResult) => void,
+  /** The callback to be executed on each funding route found */
+  onFundingRoute?: (fundingRoute: FundingRoute) => void,
 }
 
 /**

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -1,16 +1,20 @@
-import { TransactionRequest, TransactionResponse, Web3Provider } from '@ethersproject/providers';
+import {
+  TransactionRequest,
+  TransactionResponse,
+  Web3Provider,
+} from '@ethersproject/providers';
 import { BigNumber } from 'ethers';
 import { TokenInfo } from './tokenInfo';
 import { OrderFee } from './fees';
 
 /*
-* Type representing the result of the buy
-*/
+ * Type representing the result of the buy
+ */
 export type BuyResult =
-  BuyResultSuccess |
-  BuyResultFailed |
-  BuyResultFulfillmentsUnsettled |
-  BuyResultInsufficientFunds;
+  | BuyResultSuccess
+  | BuyResultFailed
+  | BuyResultFulfillmentsUnsettled
+  | BuyResultInsufficientFunds;
 
 /**
  * Represents the result of {@link Checkout.buy}
@@ -19,9 +23,9 @@ export type BuyResult =
  */
 export type BuyResultSuccess = {
   /** The status to indicate success */
-  status: CheckoutStatus.SUCCESS,
+  status: CheckoutStatus.SUCCESS;
   /** The sufficient result of smart checkout */
-  smartCheckoutResult: SmartCheckoutSufficient
+  smartCheckoutResult: SmartCheckoutSufficient;
 };
 
 /**
@@ -33,13 +37,13 @@ export type BuyResultSuccess = {
  */
 export type BuyResultFailed = {
   /** The status to indicate failure */
-  status: CheckoutStatus.FAILED,
+  status: CheckoutStatus.FAILED;
   /** The transaction hash of the failed transaction */
-  transactionHash: string,
+  transactionHash: string;
   /** The reason for the failure */
-  reason: string,
+  reason: string;
   /** The sufficient result of smart checkout */
-  smartCheckoutResult: SmartCheckoutSufficient
+  smartCheckoutResult: SmartCheckoutSufficient;
 };
 
 /**
@@ -50,11 +54,11 @@ export type BuyResultFailed = {
  */
 export type BuyResultFulfillmentsUnsettled = {
   /** The status to indicate success */
-  status: CheckoutStatus.FULFILLMENTS_UNSETTLED,
+  status: CheckoutStatus.FULFILLMENTS_UNSETTLED;
   /** The sufficient result of smart checkout */
-  smartCheckoutResult: SmartCheckoutSufficient,
+  smartCheckoutResult: SmartCheckoutSufficient;
   /** Array of transaction results */
-  transactions: TransactionResponse[],
+  transactions: TransactionResponse[];
 };
 
 /**
@@ -64,9 +68,9 @@ export type BuyResultFulfillmentsUnsettled = {
  */
 export type BuyResultInsufficientFunds = {
   /** The status to indicate insufficient funds */
-  status: CheckoutStatus.INSUFFICIENT_FUNDS,
+  status: CheckoutStatus.INSUFFICIENT_FUNDS;
   /** The insufficient result of smart checkout */
-  smartCheckoutResult: SmartCheckoutInsufficient
+  smartCheckoutResult: SmartCheckoutInsufficient;
 };
 
 /**
@@ -79,9 +83,12 @@ export type BuyOverrides = {
 };
 
 /*
-* Type representing the result of the sell
-*/
-export type SellResult = SellResultSuccess | SellResultFailed | SellResultInsufficientFunds;
+ * Type representing the result of the sell
+ */
+export type SellResult =
+  | SellResultSuccess
+  | SellResultFailed
+  | SellResultInsufficientFunds;
 
 /**
  * Represents the result of {@link Checkout.sell}
@@ -91,11 +98,11 @@ export type SellResult = SellResultSuccess | SellResultFailed | SellResultInsuff
  */
 export type SellResultSuccess = {
   /** The status to indicate success */
-  status: CheckoutStatus.SUCCESS,
+  status: CheckoutStatus.SUCCESS;
   /** The orders' ids */
-  orderIds: string[],
+  orderIds: string[];
   /** The sufficient result of smart checkout */
-  smartCheckoutResult: SmartCheckoutSufficient
+  smartCheckoutResult: SmartCheckoutSufficient;
 };
 
 /**
@@ -107,13 +114,13 @@ export type SellResultSuccess = {
  */
 export type SellResultFailed = {
   /** The status to indicate failure */
-  status: CheckoutStatus.FAILED,
+  status: CheckoutStatus.FAILED;
   /** The transaction hash of the failed transaction */
-  transactionHash: string,
+  transactionHash: string;
   /** The reason for the failure */
-  reason: string,
+  reason: string;
   /** The sufficient result of smart checkout */
-  smartCheckoutResult: SmartCheckoutSufficient
+  smartCheckoutResult: SmartCheckoutSufficient;
 };
 
 /**
@@ -123,18 +130,19 @@ export type SellResultFailed = {
  */
 export type SellResultInsufficientFunds = {
   /** The status to indicate insufficient funds */
-  status: CheckoutStatus.INSUFFICIENT_FUNDS,
+  status: CheckoutStatus.INSUFFICIENT_FUNDS;
   /** The insufficient result of smart checkout */
-  smartCheckoutResult: SmartCheckoutInsufficient
+  smartCheckoutResult: SmartCheckoutInsufficient;
 };
 
 /*
-* Type representing the result of the cancel
-*/
-export type CancelResult = CancelResultSuccess |
-CancelResultFailed |
-CancelResultFulfillmentsUnsettled |
-CancelResultGasless;
+ * Type representing the result of the cancel
+ */
+export type CancelResult =
+  | CancelResultSuccess
+  | CancelResultFailed
+  | CancelResultFulfillmentsUnsettled
+  | CancelResultGasless;
 
 /**
  * Represents the result of {@link Checkout.cancel}
@@ -142,7 +150,7 @@ CancelResultGasless;
  */
 export type CancelResultSuccess = {
   /** The status to indicate success */
-  status: CheckoutStatus.SUCCESS,
+  status: CheckoutStatus.SUCCESS;
 };
 
 /**
@@ -153,11 +161,11 @@ export type CancelResultSuccess = {
  */
 export type CancelResultFailed = {
   /** The status to indicate failure */
-  status: CheckoutStatus.FAILED,
+  status: CheckoutStatus.FAILED;
   /** The transaction hash of the failed transaction */
-  transactionHash: string,
+  transactionHash: string;
   /** The reason for the failure */
-  reason: string,
+  reason: string;
 };
 
 /**
@@ -167,9 +175,9 @@ export type CancelResultFailed = {
  */
 export type CancelResultFulfillmentsUnsettled = {
   /** The status to indicate the fulfillments have not yet settled on chain. */
-  status: CheckoutStatus.FULFILLMENTS_UNSETTLED,
+  status: CheckoutStatus.FULFILLMENTS_UNSETTLED;
   /** Array of transaction results */
-  transactions: TransactionResponse[],
+  transactions: TransactionResponse[];
 };
 
 /**
@@ -179,9 +187,9 @@ export type CancelResultFulfillmentsUnsettled = {
  * @property {PendingGaslessCancellation[]} pendingCancellations
  */
 export type CancelResultGasless = {
-  successfulCancellations: SuccessfulGaslessCancellation[],
-  failedCancellations: FailedGaslessCancellation[],
-  pendingCancellations: PendingGaslessCancellation[],
+  successfulCancellations: SuccessfulGaslessCancellation[];
+  failedCancellations: FailedGaslessCancellation[];
+  pendingCancellations: PendingGaslessCancellation[];
 };
 
 /**
@@ -247,9 +255,9 @@ export enum CheckoutStatus {
  */
 export type BuyOrder = {
   /** the id of the order to buy */
-  id: string,
+  id: string;
   /** array of order fees to apply to the order */
-  takerFees?: OrderFee[],
+  takerFees?: OrderFee[];
 };
 
 /**
@@ -260,11 +268,11 @@ export type BuyOrder = {
  */
 export type SellOrder = {
   /** the token to be listed for sale */
-  sellToken: SellToken,
+  sellToken: SellToken;
   /** the token info of the price of the item */
-  buyToken: BuyToken,
+  buyToken: BuyToken;
   /** optional array of makerFees to be applied to the listing */
-  makerFees?: OrderFee[],
+  makerFees?: OrderFee[];
   /** optional order expiry date. Default order expiry to 2 years from now */
   orderExpiry?: Date;
 };
@@ -309,9 +317,9 @@ export type ERC20BuyToken = {
  */
 export type SellToken = {
   /**  The ERC721 token id */
-  id: string,
+  id: string;
   /** The ERC721 collection address */
-  collectionAddress: string
+  collectionAddress: string;
 };
 
 /**
@@ -324,15 +332,19 @@ export interface SmartCheckoutParams {
   /** The provider to use for smart checkout. */
   provider: Web3Provider;
   /** The item requirements for the transaction. */
-  itemRequirements: (NativeItemRequirement | ERC20ItemRequirement | ERC721ItemRequirement)[];
+  itemRequirements: (
+    | NativeItemRequirement
+    | ERC20ItemRequirement
+    | ERC721ItemRequirement
+  )[];
   /** The transaction or gas amount. */
-  transactionOrGasAmount?: FulfillmentTransaction | GasAmount,
+  transactionOrGasAmount?: FulfillmentTransaction | GasAmount;
   /** The overrides for funding routes to consider */
-  routingOptions?: AvailableRoutingOptions,
+  routingOptions?: AvailableRoutingOptions;
   /** The callback to be execured once all funding routes are found */
-  onComplete?: (result: SmartCheckoutResult) => void,
+  onComplete?: (result: SmartCheckoutResult) => void;
   /** The callback to be executed on each funding route found */
-  onFundingRoute?: (fundingRoute: FundingRoute) => void,
+  onFundingRoute?: (fundingRoute: FundingRoute) => void;
 }
 
 /**
@@ -362,7 +374,7 @@ export type ERC20ItemRequirement = {
   /** The amount of the item. */
   amount: string;
   /** The contract address of the approver. */
-  spenderAddress: string,
+  spenderAddress: string;
 };
 
 /**
@@ -380,7 +392,7 @@ export type ERC721ItemRequirement = {
   /** The ID of this ERC721 in the collection. */
   id: string;
   /** The contract address of the approver. */
-  spenderAddress: string,
+  spenderAddress: string;
 };
 
 /**
@@ -429,7 +441,7 @@ export type ERC20Item = {
   /** The amount of the item. */
   amount: BigNumber;
   /** The contract address of the approver. */
-  spenderAddress: string,
+  spenderAddress: string;
 };
 
 /**
@@ -447,7 +459,7 @@ export type ERC721Item = {
   /**  The ID of this ERC721 in the collection. */
   id: string;
   /** The contract address of the approver. */
-  spenderAddress: string,
+  spenderAddress: string;
 };
 
 /**
@@ -508,7 +520,7 @@ export enum GasTokenType {
  */
 export type NativeGas = {
   /** The type to indicate this is a native gas token. */
-  type: GasTokenType.NATIVE,
+  type: GasTokenType.NATIVE;
   /** The gas limit. */
   limit: BigNumber;
 };
@@ -521,7 +533,7 @@ export type NativeGas = {
  */
 export type ERC20Gas = {
   /** The type to indicate this is an ERC20 gas token. */
-  type: GasTokenType.ERC20,
+  type: GasTokenType.ERC20;
   /** The token address of the ERC20. */
   tokenAddress: string;
   /** The gas limit. */
@@ -531,7 +543,9 @@ export type ERC20Gas = {
 /**
  * The type representing the result of {@link Checkout.smartCheckout}.
  */
-export type SmartCheckoutResult = SmartCheckoutSufficient | SmartCheckoutInsufficient;
+export type SmartCheckoutResult =
+  | SmartCheckoutSufficient
+  | SmartCheckoutInsufficient;
 
 /**
  * Represents the result of {@link Checkout.smartCheckout} when smart checkout is sufficient.
@@ -539,10 +553,10 @@ export type SmartCheckoutResult = SmartCheckoutSufficient | SmartCheckoutInsuffi
  * @property {TransactionRequirement[]} transactionRequirements
  */
 export type SmartCheckoutSufficient = {
-/** Indicates that smart checkout determined the user had sufficient funds. */
-  sufficient: true,
+  /** Indicates that smart checkout determined the user had sufficient funds. */
+  sufficient: true;
   /** The transaction requirements smart checkout determined were required for the transaction. */
-  transactionRequirements: TransactionRequirement[],
+  transactionRequirements: TransactionRequirement[];
 };
 
 /**
@@ -553,11 +567,11 @@ export type SmartCheckoutSufficient = {
  */
 export type SmartCheckoutInsufficient = {
   /** Indicates that smart checkout determined the user has insufficient funds */
-  sufficient: false,
+  sufficient: false;
   /** The transaction requirements smart checkout determined were required for the transaction. */
-  transactionRequirements: TransactionRequirement[],
+  transactionRequirements: TransactionRequirement[];
   /** The type containing the funding routes the user can take to fulfill the transaction requirements */
-  router: SmartCheckoutRouter
+  router: SmartCheckoutRouter;
 };
 
 /**
@@ -567,9 +581,9 @@ export type SmartCheckoutInsufficient = {
  */
 export type SmartCheckoutRouter = {
   /** The routing options available to the user */
-  availableRoutingOptions: AvailableRoutingOptions,
+  availableRoutingOptions: AvailableRoutingOptions;
   /** The routing outcome for the transaction which includes the funding routes if routes were found */
-  routingOutcome: RoutingOutcome
+  routingOutcome: RoutingOutcome;
 };
 
 /**
@@ -596,10 +610,10 @@ export type RoutingOutcome = RoutesFound | NoRoutesFound | NoRouteOptions;
  * @property {AvailableRoutingOptions} fundingRoutes
  */
 export type RoutesFound = {
-/** Indicates that funding routes were found for the transaction. */
-  type: RoutingOutcomeType.ROUTES_FOUND,
+  /** Indicates that funding routes were found for the transaction. */
+  type: RoutingOutcomeType.ROUTES_FOUND;
   /** The funding routes found for the transaction. */
-  fundingRoutes: FundingRoute[]
+  fundingRoutes: FundingRoute[];
 };
 
 /**
@@ -609,9 +623,9 @@ export type RoutesFound = {
  */
 export type NoRoutesFound = {
   /** Indicates that no funding routes were found for the transaction. */
-  type: RoutingOutcomeType.NO_ROUTES_FOUND,
+  type: RoutingOutcomeType.NO_ROUTES_FOUND;
   /** The message indicating why no funding routes were found. */
-  message: string
+  message: string;
 };
 
 /**
@@ -621,9 +635,9 @@ export type NoRoutesFound = {
  */
 export type NoRouteOptions = {
   /** Indicates that no routing options were available for the transaction. */
-  type: RoutingOutcomeType.NO_ROUTE_OPTIONS,
+  type: RoutingOutcomeType.NO_ROUTE_OPTIONS;
   /** The message indicating why no routing options were available. */
-  message: string
+  message: string;
 };
 
 /**
@@ -635,7 +649,7 @@ export type FundingRoute = {
   /** The priority of the route */
   priority: number;
   /** The steps associated with this funding route */
-  steps: FundingStep[]
+  steps: FundingStep[];
 };
 
 /**
@@ -671,9 +685,12 @@ export enum FeeType {
 }
 
 /*
-* Type representing the various funding steps
-*/
-export type FundingStep = BridgeFundingStep | SwapFundingStep | OnRampFundingStep;
+ * Type representing the various funding steps
+ */
+export type FundingStep =
+  | BridgeFundingStep
+  | SwapFundingStep
+  | OnRampFundingStep;
 
 /**
  * Represents a bridge funding route
@@ -684,13 +701,13 @@ export type FundingStep = BridgeFundingStep | SwapFundingStep | OnRampFundingSte
  */
 export type BridgeFundingStep = {
   /** Indicates that this is a bridge funding step */
-  type: FundingStepType.BRIDGE,
+  type: FundingStepType.BRIDGE;
   /** The chain id the bridge should be executed on */
-  chainId: number,
+  chainId: number;
   /** The funding item for the bridge */
-  fundingItem: FundingItem,
+  fundingItem: FundingItem;
   /** The fees for the bridge */
-  fees: BridgeFees,
+  fees: BridgeFees;
 };
 
 /**
@@ -701,11 +718,11 @@ export type BridgeFundingStep = {
  */
 export type BridgeFees = {
   /** The approval gas fee for the bridge */
-  approvalGasFee: Fee,
+  approvalGasFee: Fee;
   /** The bridge gas fee for the bridge */
-  bridgeGasFee: Fee,
+  bridgeGasFee: Fee;
   /** Additional bridge fees for the bridge */
-  bridgeFees: Fee[],
+  bridgeFees: Fee[];
 };
 
 /**
@@ -717,13 +734,13 @@ export type BridgeFees = {
  */
 export type SwapFundingStep = {
   /** Indicates that this is a swap funding step */
-  type: FundingStepType.SWAP,
+  type: FundingStepType.SWAP;
   /** The chain id the swap should be executed on */
-  chainId: number,
+  chainId: number;
   /** The funding item for the swap */
-  fundingItem: FundingItem,
+  fundingItem: FundingItem;
   /** The fees for the swap */
-  fees: SwapFees,
+  fees: SwapFees;
 };
 
 /**
@@ -734,11 +751,11 @@ export type SwapFundingStep = {
  */
 export type SwapFees = {
   /** The approval gas fee for the swap */
-  approvalGasFee: Fee,
+  approvalGasFee: Fee;
   /** The swap gas fee for the swap */
-  swapGasFee: Fee,
+  swapGasFee: Fee;
   /** Additional swap fees for the swap */
-  swapFees: Fee[],
+  swapFees: Fee[];
 };
 
 /**
@@ -749,11 +766,11 @@ export type SwapFees = {
  */
 export type OnRampFundingStep = {
   /** Indicates that this is an onramp funding step */
-  type: FundingStepType.ONRAMP,
+  type: FundingStepType.ONRAMP;
   /** The chain id the onramp should provide funds to */
-  chainId: number,
+  chainId: number;
   /** The item to be onramped */
-  fundingItem: FundingItem
+  fundingItem: FundingItem;
 };
 
 /**
@@ -778,13 +795,13 @@ export enum FundingStepType {
  */
 export type FundingItem = {
   /** The type of the funding item */
-  type: ItemType.NATIVE | ItemType.ERC20,
+  type: ItemType.NATIVE | ItemType.ERC20;
   /** The amount of funds required of this funding item */
-  fundsRequired: FundsRequired,
+  fundsRequired: FundsRequired;
   /** The current user balance of this funding item */
-  userBalance: UserBalance,
+  userBalance: UserBalance;
   /** The token info for the funding item */
-  token: TokenInfo
+  token: TokenInfo;
 };
 
 /**
@@ -794,9 +811,9 @@ export type FundingItem = {
  */
 export type FundsRequired = {
   /** The amount of funds required */
-  amount: BigNumber,
+  amount: BigNumber;
   /** The formatted amount of funds required */
-  formattedAmount: string
+  formattedAmount: string;
 };
 
 /**
@@ -806,9 +823,9 @@ export type FundsRequired = {
  */
 export type UserBalance = {
   /** The balance of the funding item */
-  balance: BigNumber,
+  balance: BigNumber;
   /** The formatted balance of the funding item */
-  formattedBalance: string
+  formattedBalance: string;
 };
 
 /**
@@ -821,15 +838,15 @@ export type UserBalance = {
  */
 export type TransactionRequirement = {
   /** The type of the transaction requirement. */
-  type: ItemType,
+  type: ItemType;
   /** If the user address has sufficient funds to cover the transaction. */
   sufficient: boolean;
   /** The required item balance. */
-  required: ItemBalance,
+  required: ItemBalance;
   /** The current item balance. */
-  current: ItemBalance,
+  current: ItemBalance;
   /** The delta between the required and current balances. */
-  delta: BalanceDelta,
+  delta: BalanceDelta;
 };
 
 /**
@@ -860,7 +877,7 @@ export type TokenBalance = {
  */
 export type ERC721Balance = {
   /** Type to indicate this is an ERC721 token. */
-  type: ItemType.ERC721,
+  type: ItemType.ERC721;
   /** The balance of the item. */
   balance: BigNumber;
   /** The formatted balance of the item. */
@@ -904,7 +921,9 @@ export type AvailableRoutingOptions = {
   bridge?: boolean;
 };
 
-export type FundingRouteFeeEstimate = SwapRouteFeeEstimate | BridgeRouteFeeEstimate;
+export type FundingRouteFeeEstimate =
+  | SwapRouteFeeEstimate
+  | BridgeRouteFeeEstimate;
 export type SwapRouteFeeEstimate = {
   type: FundingStepType.SWAP;
   estimatedAmount: BigNumber;

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -341,7 +341,7 @@ export interface SmartCheckoutParams {
   transactionOrGasAmount?: FulfillmentTransaction | GasAmount;
   /** The overrides for funding routes to consider */
   routingOptions?: AvailableRoutingOptions;
-  /** The callback to be execured once all funding routes are found */
+  /** The callback to be executed once all funding routes are found */
   onComplete?: (result: SmartCheckoutResult) => void;
   /** The callback to be executed on each funding route found */
   onFundingRoute?: (fundingRoute: FundingRoute) => void;

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/smartCheckoutUtils.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/smartCheckoutUtils.ts
@@ -9,7 +9,8 @@ import {
   ItemType,
   RoutingOutcome,
   RoutingOutcomeType,
-  SmartCheckoutResult, TokenBalance,
+  SmartCheckoutResult,
+  TokenBalance,
   TransactionOrGasType,
 } from '@imtbl/checkout-sdk';
 import { BigNumber } from 'ethers';
@@ -18,8 +19,11 @@ import { SmartCheckoutError } from '../types';
 
 export const MAX_GAS_LIMIT = '30000000';
 
-export const getItemRequirements = (amount: string, spenderAddress: string, tokenAddress: string)
-: ERC20ItemRequirement[] => [
+export const getItemRequirements = (
+  amount: string,
+  spenderAddress: string,
+  tokenAddress: string,
+): ERC20ItemRequirement[] => [
   {
     type: ItemType.ERC20,
     tokenAddress,
@@ -61,7 +65,11 @@ export const fundingRouteFees = (
   let totalUsd: number = 0;
   for (const fee of fees) {
     if (fee.token) {
-      const feeUsd = calculateCryptoToFiat(fee.formattedAmount, fee.token.symbol, conversions);
+      const feeUsd = calculateCryptoToFiat(
+        fee.formattedAmount,
+        fee.token.symbol,
+        conversions,
+      );
       totalUsd += parseFloat(feeUsd);
     }
   }
@@ -71,19 +79,23 @@ export const fundingRouteFees = (
 export const smartCheckoutTokensList = (
   smartCheckoutResult: SmartCheckoutResult,
 ) => {
-  if (smartCheckoutResult.sufficient
-    || smartCheckoutResult.router.routingOutcome.type !== RoutingOutcomeType.ROUTES_FOUND) {
+  if (
+    smartCheckoutResult.sufficient
+    || smartCheckoutResult.router?.routingOutcome.type
+      !== RoutingOutcomeType.ROUTES_FOUND
+  ) {
     return [];
   }
 
   const tokenSymbols: string[] = [];
   for (const requirement of smartCheckoutResult.transactionRequirements) {
-    const { token } = (requirement.current as TokenBalance);
+    const { token } = requirement.current as TokenBalance;
     if (!tokenSymbols.includes(token.symbol)) {
       tokenSymbols.push(token.symbol);
     }
   }
-  for (const fundingRoute of smartCheckoutResult.router.routingOutcome.fundingRoutes) {
+  for (const fundingRoute of smartCheckoutResult.router.routingOutcome
+    .fundingRoutes) {
     for (const step of fundingRoute.steps) {
       if (!tokenSymbols.includes(step.fundingItem.token.symbol)) {
         tokenSymbols.push(step.fundingItem.token.symbol);
@@ -118,7 +130,7 @@ export const filterSmartCheckoutResult = (
   // if the transaction has been made sufficient, no need to filter
   if (
     filteredSmartCheckoutResult.sufficient
-    || filteredSmartCheckoutResult.router.routingOutcome.type
+    || filteredSmartCheckoutResult.router?.routingOutcome.type
       !== RoutingOutcomeType.ROUTES_FOUND
   ) {
     return filteredSmartCheckoutResult;
@@ -130,12 +142,12 @@ export const filterSmartCheckoutResult = (
     // FundingStepType.ONRAMP,
     // FundingStepType.BRIDGE,
   ] as FundingStepType[];
-  const filteredFundingRoutes = filteredSmartCheckoutResult.router.routingOutcome.fundingRoutes.filter(
+  const filteredFundingRoutes = filteredSmartCheckoutResult.router?.routingOutcome.fundingRoutes.filter(
     (route) => !route.steps.some((step) => stepTypesToFiler.includes(step.type)),
   );
 
   let routingOutcome: RoutingOutcome;
-  if (filteredFundingRoutes.length === 0) {
+  if (filteredFundingRoutes?.length === 0) {
     routingOutcome = {
       type: RoutingOutcomeType.NO_ROUTES_FOUND,
       message:


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Update `smartCheckout` to accept `onComplete` and `onFundingRoute` callbacks.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->
Add `onComplete` and `onFundingRoute` optional callbacks to `smartCheckout`. 

### `onComplete`:

When `onComplete` callback is passed in, the method returns `SmartCheckoutSufficient` early while allowing the user to get notified about funding routes through `onComplete` callback.

### `onFundingRoute`:
Allows the user to get notified on each funding route found, avoiding the need to wait until all funding routes are found.

## Changed
<!-- Section for changes in existing functionality. -->
Refactor the way `routingCalculator` constructs routes. 
