### PR TITLE
feat: [GPR-476][Sale Widget] Generate transaction ID for Transak's NFT sale

### DIFF
--- a/packages/checkout/widgets-lib/src/components/Transak/TransakIframe.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transak/TransakIframe.tsx
@@ -76,6 +76,7 @@ export function TransakIframe(props: TransakIframeProps) {
       walletAddress,
       partnerOrderId,
     },
+    onError: onFailedToLoad,
   });
 
   return (

--- a/packages/checkout/widgets-lib/src/components/Transak/useTransakIframe.ts
+++ b/packages/checkout/widgets-lib/src/components/Transak/useTransakIframe.ts
@@ -1,4 +1,3 @@
-import pako from 'pako';
 import { useCallback, useEffect, useState } from 'react';
 import { Environment } from '@imtbl/config';
 
@@ -23,17 +22,21 @@ type UseTransakIframeProps = {
   contractId: string;
   environment: Environment;
   transakParams: TransakNFTCheckoutParams;
+  onError?: () => void;
 };
 
 const MAX_GAS_LIMIT = '30000000';
 
 // TODO: Move to common config file inside Checkout SDK while refactoring onRamp
 // TODO: Get transak config from checkout SDK
-// const { checkout, provider } = connectLoaderState;
-// const { baseUrl, apiKey, environment } = checkout.fiatExchangeConfig('transak')
-export const TRANSAK_API_BASE_URL = {
+export const TRANSAK_WIDGET_BASE_URL = {
   [Environment.SANDBOX]: 'https://global-stg.transak.com',
   [Environment.PRODUCTION]: 'https://global.transak.com/',
+};
+
+export const TRANSAK_API_BASE_URL = {
+  [Environment.SANDBOX]: 'https://api-stg.transak.com',
+  [Environment.PRODUCTION]: 'https://api.transak.com',
 };
 
 export const TRANSAK_ENVIRONMENT = {
@@ -47,50 +50,82 @@ export const TRANSAK_API_KEY = {
 };
 
 export const useTransakIframe = (props: UseTransakIframeProps) => {
-  const { contractId, environment, transakParams } = props;
+  const {
+    contractId, environment, transakParams, onError,
+  } = props;
   const [iframeSrc, setIframeSrc] = useState<string>('');
 
-  const getNFTCheckoutURL = useCallback(() => {
-    const {
-      calldata,
-      nftData: nfts,
-      estimatedGasLimit,
-      ...restTransakParams
-    } = transakParams;
+  const getNFTCheckoutURL = useCallback(async () => {
+    try {
+      const {
+        calldata,
+        nftData: nfts,
+        estimatedGasLimit,
+        cryptoCurrencyCode,
+        ...restWidgetParams
+      } = transakParams;
 
-    // FIXME: defaulting to first nft in the list
-    // as transak currently only supports on nft at a time
-    const nftData = nfts?.slice(0, 1).map((item) => ({
-      ...item,
-      imageURL: sanitizeToLatin1(item.imageURL),
-      nftName: sanitizeToLatin1(item.nftName),
-    }));
+      // FIXME: defaulting to first nft in the list
+      // as transak currently only supports on nft at a time
+      const nftData = nfts?.slice(0, 1)
+        .map((item) => ({
+          ...item,
+          imageURL: sanitizeToLatin1(item.imageURL),
+          nftName: sanitizeToLatin1(item.nftName),
+        }));
 
-    const gasLimit = estimatedGasLimit > 0 ? estimatedGasLimit : MAX_GAS_LIMIT;
+      const gasLimit = estimatedGasLimit > 0 ? estimatedGasLimit : MAX_GAS_LIMIT;
 
-    const params = {
-      apiKey: TRANSAK_API_KEY[environment],
-      isNFT: 'true',
-      disableWalletAddressForm: 'true',
-      contractId,
-      environment: TRANSAK_ENVIRONMENT[environment],
-      calldata: btoa(String.fromCharCode.apply(null, pako.deflate(calldata))),
-      nftData: btoa(JSON.stringify(nftData)),
-      estimatedGasLimit: gasLimit.toString(),
-      ...restTransakParams,
-      themeColor: '0D0D0D',
-    };
+      const params = {
+        contractId,
+        cryptoCurrencyCode,
+        calldata,
+        nftData,
+        estimatedGasLimit: gasLimit.toString(),
+      };
 
-    const baseUrl = `${TRANSAK_API_BASE_URL[environment]}?`;
-    const queryParams = new URLSearchParams(params);
-    const widgetUrl = `${baseUrl}${queryParams.toString()}`;
+      // eslint-disable-next-line max-len
+      const baseApiUrl = `${TRANSAK_API_BASE_URL[environment]}/cryptocoverage/api/v1/public/one-click-protocol/nft-transaction-id`;
 
-    return widgetUrl;
-  }, [props]);
+      const response = await fetch(baseApiUrl, {
+        method: 'POST',
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to get NFT transaction ID');
+      }
+
+      const { id: nftTransactionId } = await response.json();
+
+      const baseWidgetUrl = `${TRANSAK_WIDGET_BASE_URL[environment]}?`;
+      const queryParams = new URLSearchParams({
+        apiKey: TRANSAK_API_KEY[environment],
+        environment: TRANSAK_ENVIRONMENT[environment],
+        isNFT: 'true',
+        nftTransactionId,
+        themeColor: '0D0D0D',
+        ...restWidgetParams,
+      });
+
+      return `${baseWidgetUrl}${queryParams.toString()}`;
+    } catch {
+      onError?.();
+    }
+
+    return '';
+  }, [contractId, environment, transakParams, onError]);
 
   useEffect(() => {
-    setIframeSrc(getNFTCheckoutURL());
-  }, [props]);
+    (async () => {
+      const checkoutUrl = await getNFTCheckoutURL();
+      setIframeSrc(checkoutUrl);
+    })();
+  }, []);
 
   return { iframeSrc };
 };

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/WithCard.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/WithCard.tsx
@@ -53,7 +53,7 @@ export function WithCard(props: WithCardProps) {
   );
 
   const onFailedToLoad = () => {
-    goToErrorView(SaleErrorTypes.TRANSACTION_FAILED);
+    goToErrorView(SaleErrorTypes.TRANSAK_FAILED);
   };
 
   return (

--- a/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
@@ -9,6 +9,7 @@ import {
   SaleItem,
   SalePaymentTypes,
   SwapEventType,
+  WidgetLanguage,
   WidgetTheme,
   WidgetType,
 } from "@imtbl/checkout-sdk";
@@ -30,7 +31,7 @@ const defaultItems: SaleItem[] = [
     qty: 2,
     name: "Lab Iguana",
     image:
-      "https://pokemon-nfts.mystagingwebsite.com/wp-content/uploads/2023/11/645-300x300.png",
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-IsR4OA7a9IStLeQ9cPo75tII.png",
     description: "Lab Iguana",
   },
 ];
@@ -276,7 +277,7 @@ export function SaleUI() {
       </button>
       <select
         onChange={(e) =>
-          saleWidget.update({ config: { language: e.target.value } })
+          saleWidget.update({ config: { language: e.target.value as WidgetLanguage } })
         }
       >
         <option value="en">EN</option>


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

The old way of using a query string with all data will break when the payload is too big. Transak implemented this new approach so we can post the data before generating the URL.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
