### PR TITLE
chore: ID-1601 Added additional transaction confirmation message types

### DIFF
--- a/packages/passport/sdk/src/confirmation/confirmation.ts
+++ b/packages/passport/sdk/src/confirmation/confirmation.ts
@@ -70,7 +70,11 @@ export default class ConfirmationScreen {
             break;
           }
           case ReceiveMessage.TRANSACTION_ERROR: {
-            reject(new Error('Transaction error'));
+            reject(new Error('Error during transaction confirmation'));
+            break;
+          }
+          case ReceiveMessage.TRANSACTION_REJECTED: {
+            reject(new Error('User rejected transaction'));
             break;
           }
           default:
@@ -116,8 +120,12 @@ export default class ConfirmationScreen {
             resolve({ confirmed: true });
             break;
           }
+          case ReceiveMessage.MESSAGE_ERROR: {
+            reject(new Error('Error during message confirmation'));
+            break;
+          }
           case ReceiveMessage.MESSAGE_REJECTED: {
-            reject(new Error('Message rejected'));
+            reject(new Error('User rejected message'));
             break;
           }
 

--- a/packages/passport/sdk/src/confirmation/types.ts
+++ b/packages/passport/sdk/src/confirmation/types.ts
@@ -6,7 +6,9 @@ export enum ReceiveMessage {
   CONFIRMATION_WINDOW_READY = 'confirmation_window_ready',
   TRANSACTION_CONFIRMED = 'transaction_confirmed',
   TRANSACTION_ERROR = 'transaction_error',
+  TRANSACTION_REJECTED = 'transaction_rejected',
   MESSAGE_CONFIRMED = 'message_confirmed',
+  MESSAGE_ERROR = 'message_error',
   MESSAGE_REJECTED = 'message_rejected',
   LOGOUT_SUCCESS = 'logout_success',
 }


### PR DESCRIPTION
# Summary
This PR adds additional message types for the message that is posted to the SDK from the transaction confirmation screen.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
- Passport: Added support for additional transaction confirmation messages