### PR TITLE
chore: ID-1591 Remove logic to logout of transaction confirmation

### DIFF
--- a/packages/passport/sdk/src/Passport.test.ts
+++ b/packages/passport/sdk/src/Passport.test.ts
@@ -3,7 +3,6 @@ import { IMXClient } from '@imtbl/x-client';
 import { ImxApiClients, MultiRollupApiClients, imxApiConfig } from '@imtbl/generated-clients';
 import AuthManager from './authManager';
 import MagicAdapter from './magicAdapter';
-import { ConfirmationScreen } from './confirmation';
 import { Passport } from './Passport';
 import { PassportImxProvider, PassportImxProviderFactory } from './starkEx';
 import { OidcConfiguration } from './types';
@@ -36,7 +35,6 @@ describe('Passport', () => {
   let getDeviceFlowEndSessionEndpointMock: jest.Mock;
   let magicLoginMock: jest.Mock;
   let magicLogoutMock: jest.Mock;
-  let confirmationLogoutMock: jest.Mock;
   let getUserMock: jest.Mock;
   let requestRefreshTokenMock: jest.Mock;
   let getProviderMock: jest.Mock;
@@ -47,7 +45,6 @@ describe('Passport', () => {
     authLoginMock = jest.fn().mockReturnValue(mockUser);
     loginCallbackMock = jest.fn();
     magicLoginMock = jest.fn();
-    confirmationLogoutMock = jest.fn();
     magicLogoutMock = jest.fn();
     logoutMock = jest.fn();
     removeUserMock = jest.fn();
@@ -65,9 +62,6 @@ describe('Passport', () => {
       getDeviceFlowEndSessionEndpoint: getDeviceFlowEndSessionEndpointMock,
       getUser: getUserMock,
       requestRefreshTokenAfterRegistration: requestRefreshTokenMock,
-    });
-    (ConfirmationScreen as jest.Mock).mockReturnValue({
-      logout: confirmationLogoutMock,
     });
     (MagicAdapter as jest.Mock).mockReturnValue({
       login: magicLoginMock,
@@ -207,7 +201,6 @@ describe('Passport', () => {
 
         expect(logoutMock).toBeCalledTimes(1);
         expect(magicLogoutMock).toBeCalledTimes(1);
-        expect(confirmationLogoutMock).toBeCalledTimes(1);
       });
     });
 
@@ -218,7 +211,6 @@ describe('Passport', () => {
         const logoutMockOrder = logoutMock.mock.invocationCallOrder[0];
         const magicLogoutMockOrder = magicLogoutMock.mock.invocationCallOrder[0];
 
-        expect(confirmationLogoutMock).toBeCalledTimes(1);
         expect(logoutMock).toBeCalledTimes(1);
         expect(magicLogoutMock).toBeCalledTimes(1);
         expect(magicLogoutMockOrder).toBeLessThan(logoutMockOrder);

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -237,12 +237,6 @@ export class Passport {
   }
 
   public async logout(): Promise<void> {
-    try {
-      await this.confirmationScreen.logout();
-    } catch (err) {
-      logger.warn('Failed to logout from confirmation screen', err);
-    }
-
     if (this.config.oidcConfiguration.logoutMode === 'silent') {
       await Promise.allSettled([
         this.authManager.logout(),

--- a/packages/passport/sdk/src/confirmation/confirmation.test.ts
+++ b/packages/passport/sdk/src/confirmation/confirmation.test.ts
@@ -72,27 +72,6 @@ describe('confirmation', () => {
     });
   });
 
-  describe('logout', () => {
-    it('should logout the confirmation screen', async () => {
-      const mockedSuccessReturnValue = {
-        origin: testConfig.passportDomain,
-        data: {
-          eventType: PASSPORT_EVENT_TYPE,
-          messageType: ReceiveMessage.LOGOUT_SUCCESS,
-        },
-      };
-      addEventListenerMock
-        .mockImplementationOnce((event, callback) => {
-          callback(mockedSuccessReturnValue);
-        });
-
-      const result = await confirmationScreen.logout();
-
-      expect(addEventListenerMock).toHaveBeenCalledTimes(1);
-      expect(result.logout).toEqual(true);
-    });
-  });
-
   describe('requestConfirmation', () => {
     it('should handle popup window opened', async () => {
       const transactionId = 'transactionId123';

--- a/packages/passport/sdk/src/confirmation/confirmation.ts
+++ b/packages/passport/sdk/src/confirmation/confirmation.ts
@@ -161,33 +161,6 @@ export default class ConfirmationScreen {
     this.confirmationWindow?.close();
   }
 
-  logout(): Promise<{ logout: boolean }> {
-    return new Promise((resolve, rejects) => {
-      const iframe = document.createElement('iframe');
-      iframe.setAttribute('id', CONFIRMATION_IFRAME_ID);
-      iframe.setAttribute('src', this.getHref('logout'));
-      iframe.setAttribute('style', CONFIRMATION_IFRAME_STYLE);
-      const logoutHandler = ({ data, origin }: MessageEvent) => {
-        if (
-          origin !== this.config.passportDomain
-          || data.eventType !== PASSPORT_EVENT_TYPE
-        ) {
-          return;
-        }
-        window.removeEventListener('message', logoutHandler);
-        iframe.remove();
-
-        if (data.messageType === ReceiveMessage.LOGOUT_SUCCESS) {
-          resolve({ logout: true });
-        }
-        rejects(new Error('Unsupported logout type'));
-      };
-
-      window.addEventListener('message', logoutHandler);
-      document.body.appendChild(iframe);
-    });
-  }
-
   showConfirmationScreen(href: string, messageHandler: MessageHandler, resolve: Function) {
     this.confirmationWindow!.location.href = href;
     // https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128

--- a/packages/passport/sdk/src/confirmation/types.ts
+++ b/packages/passport/sdk/src/confirmation/types.ts
@@ -10,7 +10,6 @@ export enum ReceiveMessage {
   MESSAGE_CONFIRMED = 'message_confirmed',
   MESSAGE_ERROR = 'message_error',
   MESSAGE_REJECTED = 'message_rejected',
-  LOGOUT_SUCCESS = 'logout_success',
 }
 
 export type ConfirmationResult = {


### PR DESCRIPTION
# Summary
This PR removes the logic that opens the `logout` page of the transaction confirmation app.