### PR TITLE
[feat] gpr 536 smart checkout override balance requirement on sufficient

### DIFF
--- a/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
+++ b/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
@@ -48,7 +48,6 @@ export const overrideSufficientBalanceCheckResult = (
 
 const processRoutes = async (
   config: CheckoutConfiguration,
-  provider: Web3Provider,
   ownerAddress: string,
   sufficient: boolean,
   availableRoutingOptions: AvailableRoutingOptions,
@@ -157,7 +156,6 @@ export const smartCheckout = async (
   if (onComplete) {
     processRoutes(
       config,
-      provider,
       ownerAddress,
       sufficient,
       availableRoutingOptions,
@@ -181,7 +179,6 @@ export const smartCheckout = async (
 
   const routingOutcome = await processRoutes(
     config,
-    provider,
     ownerAddress,
     sufficient,
     availableRoutingOptions,

--- a/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
+++ b/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
@@ -57,7 +57,7 @@ const processRoutes = async (
   onComplete?: (result: SmartCheckoutResult) => void,
   onFundingRoute?: (fundingRoute: FundingRoute) => void,
 ): Promise<RoutingOutcome> => {
-  const finalBalanceCheckResult = sufficient
+  const finalBalanceCheckResult = sufficient && onComplete
     ? overrideSufficientBalanceCheckResult(balanceCheckResult)
     : balanceCheckResult;
 

--- a/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
+++ b/packages/checkout/sdk/src/smartCheckout/smartCheckout.ts
@@ -5,6 +5,7 @@ import {
   FundingRoute,
   GasAmount,
   ItemRequirement,
+  ItemType,
   RoutingOutcome,
   SmartCheckoutResult,
 } from '../types/smartCheckout';
@@ -20,6 +21,31 @@ import { Allowance } from './allowance/types';
 import { BalanceCheckResult, BalanceRequirement } from './balanceCheck/types';
 import { measureAsyncExecution } from '../logger/debugLogger';
 
+export const overrideSufficientBalanceCheckResult = (
+  balanceCheckResult: BalanceCheckResult,
+): BalanceCheckResult => {
+  const modifiedRequirements = balanceCheckResult.balanceRequirements.map(
+    (requirement) => {
+      if (requirement.type === ItemType.ERC20 && requirement.sufficient) {
+        return {
+          ...requirement,
+          sufficient: false,
+          delta: {
+            balance: requirement.required.balance,
+            formattedBalance: requirement.required.formattedBalance,
+          },
+        };
+      }
+      return requirement;
+    },
+  );
+
+  return {
+    sufficient: false,
+    balanceRequirements: modifiedRequirements,
+  };
+};
+
 const processRoutes = async (
   config: CheckoutConfiguration,
   provider: Web3Provider,
@@ -31,13 +57,17 @@ const processRoutes = async (
   onComplete?: (result: SmartCheckoutResult) => void,
   onFundingRoute?: (fundingRoute: FundingRoute) => void,
 ): Promise<RoutingOutcome> => {
+  const finalBalanceCheckResult = sufficient
+    ? overrideSufficientBalanceCheckResult(balanceCheckResult)
+    : balanceCheckResult;
+
   const routingOutcome = await measureAsyncExecution<RoutingOutcome>(
     config,
     'Total time to run the routing calculator',
     routingCalculator(
       config,
       ownerAddress,
-      balanceCheckResult,
+      finalBalanceCheckResult,
       availableRoutingOptions,
       onFundingRoute,
     ),
@@ -124,7 +154,7 @@ export const smartCheckout = async (
   if (routingOptions?.swap === false) availableRoutingOptions.swap = false;
   if (routingOptions?.bridge === false) availableRoutingOptions.bridge = false;
 
-  if (sufficient || onComplete) {
+  if (onComplete) {
     processRoutes(
       config,
       provider,
@@ -136,6 +166,13 @@ export const smartCheckout = async (
       onComplete,
       onFundingRoute,
     );
+    return {
+      sufficient,
+      transactionRequirements,
+    };
+  }
+
+  if (sufficient) {
     return {
       sufficient,
       transactionRequirements,


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Add `overrideSufficientBalanceCheckResult` to get funding routes when `sufficient: true` and `onComplete` callback is defined.