### PR TITLE
fix: [GPR-528] Add support for zero IMX balance swaps with Passport in Swap widget

### DIFF
--- a/packages/checkout/sdk/src/transaction/transaction.ts
+++ b/packages/checkout/sdk/src/transaction/transaction.ts
@@ -13,6 +13,7 @@ export const setTransactionGasLimits = async (
 
   const { chainId } = await web3Provider.getNetwork();
   if (!isZkEvmChainId(chainId)) return rawTx;
+  if (typeof rawTx.gasPrice !== 'undefined') return rawTx;
 
   rawTx.maxFeePerGas = IMMUTABLE_ZKVEM_GAS_OVERRIDES.maxFeePerGas;
   rawTx.maxPriorityFeePerGas = IMMUTABLE_ZKVEM_GAS_OVERRIDES.maxPriorityFeePerGas;

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapButton.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapButton.tsx
@@ -4,6 +4,7 @@ import { TransactionResponse } from '@imtbl/dex-sdk';
 import { CheckoutErrorType } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
 import { getL2ChainId } from 'lib';
+import { BigNumber } from 'ethers';
 import { PrefilledSwapForm, SwapWidgetViews } from '../../../context/view-context/SwapViewContextTypes';
 import {
   ViewContext,
@@ -18,6 +19,7 @@ import { SwapFormData } from './swapFormTypes';
 import { TransactionRejected } from '../../../components/TransactionRejected/TransactionRejected';
 import { ConnectLoaderContext } from '../../../context/connect-loader-context/ConnectLoaderContext';
 import { UserJourney, useAnalytics } from '../../../context/analytics-provider/SegmentAnalyticsProvider';
+import { isPassportProvider } from '../../../lib/provider';
 
 export interface SwapButtonProps {
   loading: boolean
@@ -117,7 +119,10 @@ export function SwapButton({
       }
       const txn = await checkout.sendTransaction({
         provider,
-        transaction: transaction.swap.transaction,
+        transaction: {
+          ...transaction.swap.transaction,
+          gasPrice: (isPassportProvider(provider) ? BigNumber.from(0) : undefined),
+        },
       });
 
       viewDispatch({

--- a/packages/checkout/widgets-lib/src/widgets/swap/views/ApproveERC20Onboarding.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/ApproveERC20Onboarding.tsx
@@ -4,6 +4,7 @@ import {
 } from 'react';
 import { CheckoutErrorType, TokenInfo } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
+import { BigNumber } from 'ethers';
 import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
 import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
 import { sendSwapWidgetCloseEvent } from '../SwapWidgetEvents';
@@ -120,6 +121,8 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
       return;
     }
 
+    // eslint-disable-next-line no-console
+    console.error('Approve ERC20 failed', err);
     viewDispatch({
       payload: {
         type: ViewActions.UPDATE_VIEW,
@@ -130,6 +133,11 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
       },
     });
   };
+
+  const prepareTransaction = (transaction, isGasFree = false) => ({
+    ...transaction,
+    gasPrice: (isGasFree ? BigNumber.from(0) : undefined),
+  });
 
   /* --------------------- */
   // Approve spending step //
@@ -155,7 +163,7 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
     try {
       const txnResult = await checkout.sendTransaction({
         provider,
-        transaction: data.approveTransaction,
+        transaction: prepareTransaction(data.approveTransaction, isPassport),
       });
 
       setApprovalTxnLoading(true);
@@ -258,7 +266,7 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
     try {
       const txn = await checkout.sendTransaction({
         provider,
-        transaction: data.transaction,
+        transaction: prepareTransaction(data.transaction, isPassport),
       });
 
       setActionDisabled(false);

--- a/packages/checkout/widgets-lib/src/widgets/swap/views/SwapCoins.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/SwapCoins.tsx
@@ -20,6 +20,7 @@ import { NotEnoughImx } from '../../../components/NotEnoughImx/NotEnoughImx';
 import { IMX_TOKEN_SYMBOL } from '../../../lib';
 import { EventTargetContext } from '../../../context/event-target-context/EventTargetContext';
 import { UserJourney, useAnalytics } from '../../../context/analytics-provider/SegmentAnalyticsProvider';
+import { isPassportProvider } from '../../../lib/provider';
 
 export interface SwapCoinsProps {
   theme: WidgetTheme;
@@ -49,6 +50,7 @@ export function SwapCoins({
   const {
     connectLoaderState: {
       checkout,
+      provider,
     },
   } = useContext(ConnectLoaderContext);
 
@@ -70,7 +72,7 @@ export function SwapCoins({
   }, []);
 
   useEffect(() => {
-    if (hasZeroBalance(tokenBalances, IMX_TOKEN_SYMBOL)) {
+    if (hasZeroBalance(tokenBalances, IMX_TOKEN_SYMBOL) && !isPassportProvider(provider)) {
       setShowNotEnoughImxDrawer(true);
     }
   }, [tokenBalances]);

--- a/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/MainPage.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/marketplace-orchestrator/MainPage.tsx
@@ -58,11 +58,11 @@ export const MainPage = () => {
   const swapWidget = useMemo(() => widgetsFactory.create(WidgetType.SWAP), [widgetsFactory]);
   const onRampWidget = useMemo(() => widgetsFactory.create(WidgetType.ONRAMP), [widgetsFactory]);
 
-  connectWidget.addListener(ConnectEventType.WALLETCONNECT_PROVIDER_UPDATED, (event) => {
+  connectWidget.addListener(ConnectEventType.WALLETCONNECT_PROVIDER_UPDATED, (event: any) => {
     console.log('WalletConnnect provider ready', event);
   });
   connectWidget.addListener(ConnectEventType.CLOSE_WIDGET, () => { connectWidget.unmount() });
-  connectWidget.addListener(ConnectEventType.SUCCESS, (event) => {
+  connectWidget.addListener(ConnectEventType.SUCCESS, (event: any) => {
     console.log('Connect success', event);
   });
   walletWidget.addListener(WalletEventType.CLOSE_WIDGET, () => { walletWidget.unmount() });


### PR DESCRIPTION
# Summary
Added support for zero IMX balance swaps in the swap widget. Swap transactions for Passport users have been adjusted to support zero gas.

# Detail and impact of the change
## Removed
IMX zero balance checks in swap widget for Passport users, as gas fees don't apply.
