### PR TITLE
[feat][sale widget] Move CC warning drawer to the root

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useReducer,
   useRef,
+  useState,
 } from 'react';
 
 import {
@@ -38,6 +39,7 @@ import { UserJourney } from '../../context/analytics-provider/SegmentAnalyticsPr
 import { sendSaleWidgetCloseEvent } from './SaleWidgetEvents';
 import { EventTargetContext } from '../../context/event-target-context/EventTargetContext';
 import { OrderSummary } from './views/OrderSummary';
+import { CreditCardWarningDrawer } from './components/CreditCardWarningDrawer';
 
 type OptionalWidgetParams = Pick<SaleWidgetParams, 'excludePaymentTypes'>;
 type RequiredWidgetParams = Required<
@@ -79,6 +81,8 @@ export default function SaleWidget(props: SaleWidgetProps) {
     () => ({ viewState, viewDispatch }),
     [viewState, viewDispatch],
   );
+
+  const [showCreditCardWarning, setShowCreditCardWarning] = useState(false);
 
   const loadingText = viewState.view.data?.loadingText || t('views.LOADING_VIEW.text');
 
@@ -134,7 +138,9 @@ export default function SaleWidget(props: SaleWidgetProps) {
             <LoadingView loadingText={loadingText} />
           )}
           {viewState.view.type === SaleWidgetViews.PAYMENT_METHODS && (
-            <PaymentMethods />
+            <PaymentMethods
+              setShowCreditCardWarning={setShowCreditCardWarning}
+            />
           )}
           {viewState.view.type === SaleWidgetViews.PAY_WITH_CARD && (
             <PayWithCard />
@@ -183,6 +189,10 @@ export default function SaleWidget(props: SaleWidgetProps) {
               subheading={viewState.view.data?.subheading}
             />
           )}
+          <CreditCardWarningDrawer
+            visible={showCreditCardWarning}
+            setShowCreditCardWarning={setShowCreditCardWarning}
+          />
         </CryptoFiatProvider>
       </SaleContextProvider>
     </ViewContext.Provider>

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -5,7 +5,6 @@ import {
   useMemo,
   useReducer,
   useRef,
-  useState,
 } from 'react';
 
 import {
@@ -82,8 +81,6 @@ export default function SaleWidget(props: SaleWidgetProps) {
     [viewState, viewDispatch],
   );
 
-  const [showCreditCardWarning, setShowCreditCardWarning] = useState(false);
-
   const loadingText = viewState.view.data?.loadingText || t('views.LOADING_VIEW.text');
 
   useEffect(() => {
@@ -138,9 +135,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
             <LoadingView loadingText={loadingText} />
           )}
           {viewState.view.type === SaleWidgetViews.PAYMENT_METHODS && (
-            <PaymentMethods
-              setShowCreditCardWarning={setShowCreditCardWarning}
-            />
+            <PaymentMethods />
           )}
           {viewState.view.type === SaleWidgetViews.PAY_WITH_CARD && (
             <PayWithCard />
@@ -189,10 +184,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
               subheading={viewState.view.data?.subheading}
             />
           )}
-          <CreditCardWarningDrawer
-            visible={showCreditCardWarning}
-            setShowCreditCardWarning={setShowCreditCardWarning}
-          />
+          <CreditCardWarningDrawer />
         </CryptoFiatProvider>
       </SaleContextProvider>
     </ViewContext.Provider>

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/CreditCardWarningDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/CreditCardWarningDrawer.tsx
@@ -18,6 +18,11 @@ export function CreditCardWarningDrawer({
   const { t } = useTranslation();
   const { setPaymentMethod } = useSaleContext();
 
+  const handleCtaButtonClick = () => {
+    setShowCreditCardWarning(false);
+    setPaymentMethod(SalePaymentTypes.CREDIT);
+  };
+
   return (
     <Drawer
       size="threeQuarter"
@@ -64,7 +69,7 @@ export function CreditCardWarningDrawer({
             testId="credit-card-button"
             variant="primary"
             size="large"
-            onClick={() => setPaymentMethod(SalePaymentTypes.CREDIT)}
+            onClick={handleCtaButtonClick}
           >
             {t('views.PAYMENT_METHODS.creditCardWarningDrawer.ctaButton')}
           </Button>

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/CreditCardWarningDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/CreditCardWarningDrawer.tsx
@@ -6,29 +6,19 @@ import { CreditCardWarningHero } from 'components/Hero/CreditCardWarningHero';
 import { useTranslation } from 'react-i18next';
 import { useSaleContext } from '../context/SaleContextProvider';
 
-type CreditCardWarningDrawerProps = {
-  visible: boolean;
-  setShowCreditCardWarning: (show: boolean) => void;
-};
-
-export function CreditCardWarningDrawer({
-  visible,
-  setShowCreditCardWarning,
-}: CreditCardWarningDrawerProps) {
+export function CreditCardWarningDrawer() {
   const { t } = useTranslation();
-  const { setPaymentMethod } = useSaleContext();
+  const { showCreditCardWarning, setShowCreditCardWarning, setPaymentMethod } = useSaleContext();
 
   const handleCtaButtonClick = () => {
-    setShowCreditCardWarning(false);
     setPaymentMethod(SalePaymentTypes.CREDIT);
   };
 
   return (
     <Drawer
       size="threeQuarter"
-      visible={visible}
+      visible={showCreditCardWarning}
       showHeaderBar={false}
-      onCloseDrawer={() => setShowCreditCardWarning(false)}
     >
       <Drawer.Content>
         <ButtCon

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/CreditCardWarningDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/CreditCardWarningDrawer.tsx
@@ -4,19 +4,19 @@ import {
 import { SalePaymentTypes } from '@imtbl/checkout-sdk';
 import { CreditCardWarningHero } from 'components/Hero/CreditCardWarningHero';
 import { useTranslation } from 'react-i18next';
+import { useSaleContext } from '../context/SaleContextProvider';
 
 type CreditCardWarningDrawerProps = {
   visible: boolean;
   setShowCreditCardWarning: (show: boolean) => void;
-  setPaymentMethod: (type: SalePaymentTypes) => void;
 };
 
 export function CreditCardWarningDrawer({
   visible,
   setShowCreditCardWarning,
-  setPaymentMethod,
 }: CreditCardWarningDrawerProps) {
   const { t } = useTranslation();
+  const { setPaymentMethod } = useSaleContext();
 
   return (
     <Drawer

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -74,6 +74,8 @@ type SaleContextValues = SaleContextProps & {
   signError: SignOrderError | undefined;
   executeResponse: ExecuteOrderResponse | undefined;
   isPassportWallet: boolean;
+  showCreditCardWarning: boolean;
+  setShowCreditCardWarning: (show: boolean) => void;
   paymentMethod: SalePaymentTypes | undefined;
   setPaymentMethod: (paymentMethod: SalePaymentTypes | undefined) => void;
   goBackToPaymentMethods: (
@@ -114,6 +116,8 @@ const SaleContext = createContext<SaleContextValues>({
   executeResponse: undefined,
   passport: undefined,
   isPassportWallet: false,
+  showCreditCardWarning: false,
+  setShowCreditCardWarning: () => {},
   paymentMethod: undefined,
   setPaymentMethod: () => {},
   goBackToPaymentMethods: () => {},
@@ -170,9 +174,20 @@ export function SaleContextProvider(props: {
     recipientAddress: '',
   });
 
-  const [paymentMethod, setPaymentMethod] = useState<
+  const [showCreditCardWarning, setShowCreditCardWarning] = useState(false);
+  const [paymentMethod, setPaymentMethodState] = useState<
   SalePaymentTypes | undefined
   >(undefined);
+
+  const setPaymentMethod = (type: SalePaymentTypes | undefined) => {
+    if (type === SalePaymentTypes.CREDIT && !showCreditCardWarning) {
+      setShowCreditCardWarning(true);
+      return;
+    }
+
+    setPaymentMethodState(type);
+    setShowCreditCardWarning(false);
+  };
 
   const [fundingRoutes] = useState<FundingRoute[]>([]);
   const [disabledPaymentTypes, setDisabledPaymentTypes] = useState<
@@ -185,15 +200,13 @@ export function SaleContextProvider(props: {
 
   const [invalidParameters, setInvalidParameters] = useState<boolean>(false);
 
-  const {
-    selectedCurrency,
-    clientConfig,
-    clientConfigError,
-  } = useClientConfig({
-    amount,
-    environmentId,
-    environment: config.environment,
-  });
+  const { selectedCurrency, clientConfig, clientConfigError } = useClientConfig(
+    {
+      amount,
+      environmentId,
+      environment: config.environment,
+    },
+  );
 
   const fromTokenAddress = selectedCurrency?.address || '';
 
@@ -396,6 +409,8 @@ export function SaleContextProvider(props: {
       checkout,
       recipientAddress,
       recipientEmail,
+      showCreditCardWarning,
+      setShowCreditCardWarning,
       paymentMethod,
       setPaymentMethod,
       goBackToPaymentMethods,
@@ -429,6 +444,8 @@ export function SaleContextProvider(props: {
       signResponse,
       signError,
       executeResponse,
+      showCreditCardWarning,
+      setShowCreditCardWarning,
       paymentMethod,
       goBackToPaymentMethods,
       goToErrorView,

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
@@ -1,5 +1,5 @@
 import { Box, Heading } from '@biom3/react';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect } from 'react';
 
 import { SalePaymentTypes } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
@@ -21,11 +21,12 @@ import { PaymentOptions } from '../components/PaymentOptions';
 import { useSaleContext } from '../context/SaleContextProvider';
 import { useSaleEvent } from '../hooks/useSaleEvents';
 import { SaleErrorTypes, SignPaymentTypes } from '../types';
-import { CreditCardWarningDrawer } from '../components/CreditCardWarningDrawer';
 
-export function PaymentMethods() {
-  const [showCreditCardWarning, setShowCreditCardWarning] = useState(false);
+interface PaymentMethodsProps {
+  setShowCreditCardWarning: (showCreditCardWarning: boolean) => void;
+}
 
+export function PaymentMethods(props: PaymentMethodsProps) {
   const { t } = useTranslation();
   const { viewDispatch } = useContext(ViewContext);
   const {
@@ -38,6 +39,7 @@ export function PaymentMethods() {
     multicurrency,
   } = useSaleContext();
   const { sendPageView, sendCloseEvent, sendSelectedPaymentMethod } = useSaleEvent();
+  const { setShowCreditCardWarning } = props;
 
   const handleOptionClick = (type: SalePaymentTypes) => {
     if (type === SalePaymentTypes.CREDIT) {
@@ -144,11 +146,6 @@ export function PaymentMethods() {
           />
         </Box>
       </Box>
-      <CreditCardWarningDrawer
-        visible={showCreditCardWarning}
-        setShowCreditCardWarning={setShowCreditCardWarning}
-        setPaymentMethod={setPaymentMethod}
-      />
     </SimpleLayout>
   );
 }

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
@@ -22,11 +22,7 @@ import { useSaleContext } from '../context/SaleContextProvider';
 import { useSaleEvent } from '../hooks/useSaleEvents';
 import { SaleErrorTypes, SignPaymentTypes } from '../types';
 
-interface PaymentMethodsProps {
-  setShowCreditCardWarning: (showCreditCardWarning: boolean) => void;
-}
-
-export function PaymentMethods(props: PaymentMethodsProps) {
+export function PaymentMethods() {
   const { t } = useTranslation();
   const { viewDispatch } = useContext(ViewContext);
   const {
@@ -39,14 +35,9 @@ export function PaymentMethods(props: PaymentMethodsProps) {
     multicurrency,
   } = useSaleContext();
   const { sendPageView, sendCloseEvent, sendSelectedPaymentMethod } = useSaleEvent();
-  const { setShowCreditCardWarning } = props;
 
   const handleOptionClick = (type: SalePaymentTypes) => {
-    if (type === SalePaymentTypes.CREDIT) {
-      setShowCreditCardWarning(true);
-    } else {
-      setPaymentMethod(type);
-    }
+    setPaymentMethod(type);
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

## Changed
<!-- Section for changes in existing functionality. -->
Move the CC warning component to the root so it shows up globally.
