### PR TITLE
feat: ID-1590 Updates AuthManager Logout to use OIDC methods

### DIFF
--- a/packages/passport/sdk/src/Passport.int.test.ts
+++ b/packages/passport/sdk/src/Passport.int.test.ts
@@ -25,6 +25,10 @@ jest.mock('magic-sdk');
 jest.mock('oidc-client-ts');
 jest.mock('@imtbl/x-client');
 
+const authenticationDomain = 'example.com';
+const redirectUri = 'example.com';
+const logoutRedirectUri = 'example.com';
+const clientId = 'clientId123';
 const mockOidcUser = {
   profile: {
     sub: 'sub123',
@@ -48,9 +52,9 @@ const mockOidcUserZkevm = {
 };
 
 const oidcConfiguration: OidcConfiguration = {
-  clientId: '11111',
-  redirectUri: 'https://test.com',
-  logoutRedirectUri: 'https://test.com',
+  clientId,
+  redirectUri,
+  logoutRedirectUri,
 };
 
 const getZkEvmProvider = () => {
@@ -59,9 +63,9 @@ const getZkEvmProvider = () => {
       environment: Environment.SANDBOX,
     }),
     audience: 'platform_api',
-    clientId: 'clientId123',
-    logoutRedirectUri: 'https://example.com/logout',
-    redirectUri: 'https://example.com/login',
+    clientId,
+    redirectUri,
+    logoutRedirectUri,
     scope: 'openid offline_access profile email transact',
   });
 
@@ -134,7 +138,7 @@ describe('Passport', () => {
         const baseConfig = new ImmutableConfiguration({ environment: Environment.SANDBOX });
         const immutableXClient = new IMXClient({ baseConfig });
         const overrides = {
-          authenticationDomain: 'authenticationDomain123',
+          authenticationDomain,
           imxPublicApiDomain: 'guardianDomain123',
           magicProviderId: 'providerId123',
           magicPublishableApiKey: 'publishableKey123',

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -17,7 +17,7 @@ jest.mock('oidc-client-ts', () => ({
   WebStorageStateStore: jest.fn(),
 }));
 
-const authDomain = 'auth.immutable.com';
+const authenticationDomain = 'auth.immutable.com';
 const clientId = '11111';
 const redirectUri = 'https://test.com';
 const logoutEndpoint = '/oidc/logout';
@@ -152,7 +152,7 @@ describe('AuthManager', () => {
         const configWithLogoutRedirectUri = getConfig({ logoutRedirectUri });
         const am = new AuthManager(configWithLogoutRedirectUri);
 
-        const uri = new URL(logoutEndpoint, `https://${authDomain}`);
+        const uri = new URL(logoutEndpoint, `https://${authenticationDomain}`);
         uri.searchParams.append('client_id', clientId);
         uri.searchParams.append('post_logout_redirect_uri', logoutRedirectUri);
 
@@ -508,7 +508,7 @@ describe('AuthManager', () => {
           const result = await am.getDeviceFlowEndSessionEndpoint();
           const uri = new URL(result);
 
-          expect(uri.hostname).toEqual(authDomain);
+          expect(uri.hostname).toEqual(authenticationDomain);
           expect(uri.pathname).toEqual(logoutEndpoint);
           expect(uri.searchParams.get('client_id')).toEqual(clientId);
           expect(uri.searchParams.get('id_token_hint')).toEqual(mockUser.idToken);
@@ -524,7 +524,7 @@ describe('AuthManager', () => {
           const result = await am.getDeviceFlowEndSessionEndpoint();
           const uri = new URL(result);
 
-          expect(uri.hostname).toEqual(authDomain);
+          expect(uri.hostname).toEqual(authenticationDomain);
           expect(uri.pathname).toEqual(logoutEndpoint);
           expect(uri.searchParams.get('client_id')).toEqual(clientId);
           expect(uri.searchParams.get('id_token_hint')).toEqual(mockUser.idToken);

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -20,7 +20,7 @@ jest.mock('oidc-client-ts', () => ({
 const authDomain = 'auth.immutable.com';
 const clientId = '11111';
 const redirectUri = 'https://test.com';
-const logoutEndpoint = '/oidc';
+const logoutEndpoint = '/oidc/logout';
 const logoutRedirectUri = `${redirectUri}logout/callback`;
 
 const getConfig = (values?: Partial<PassportModuleConfiguration>) => new PassportConfiguration({

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -286,6 +286,16 @@ describe('AuthManager', () => {
   });
 
   describe('logout', () => {
+    it('should build the correct logout object', async () => {
+      mockSigninSilent.mockReturnValue(mockOidcUser);
+
+      const am = new AuthManager(getConfig({ logoutRedirectUri }));
+      const logoutArgs = await am.getLogoutArgs();
+
+      expect(logoutArgs.id_token_hint).toEqual(mockOidcUser.id_token);
+      expect(logoutArgs.post_logout_redirect_uri).toEqual(logoutRedirectUri);
+    });
+
     it('should call redirect logout if logout mode is redirect', async () => {
       const configuration = getConfig({
         logoutMode: 'redirect',

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -17,12 +17,18 @@ jest.mock('oidc-client-ts', () => ({
   WebStorageStateStore: jest.fn(),
 }));
 
+const authDomain = 'auth.immutable.com';
+const clientId = '11111';
+const redirectUri = 'https://test.com';
+const logoutEndpoint = '/oidc';
+const logoutRedirectUri = `${redirectUri}logout/callback`;
+
 const getConfig = (values?: Partial<PassportModuleConfiguration>) => new PassportConfiguration({
   baseConfig: new ImmutableConfiguration({
     environment: Environment.SANDBOX,
   }),
-  clientId: '11111',
-  redirectUri: 'https://test.com',
+  clientId,
+  redirectUri,
   scope: 'email profile',
   ...values,
 });
@@ -116,7 +122,7 @@ describe('AuthManager', () => {
           authorization_endpoint: `${config.authenticationDomain}/authorize`,
           token_endpoint: `${config.authenticationDomain}/oauth/token`,
           userinfo_endpoint: `${config.authenticationDomain}/userinfo`,
-          end_session_endpoint: `${config.authenticationDomain}/v2/oidc`
+          end_session_endpoint: `${config.authenticationDomain}/oidc`
             + `?client_id=${config.oidcConfiguration.clientId}`,
         },
         popup_redirect_uri: config.oidcConfiguration.redirectUri,
@@ -142,16 +148,18 @@ describe('AuthManager', () => {
     });
 
     describe('when a logoutRedirectUri is specified', () => {
-      it('should set the endSessionEndpoint `returnTo` and `client_id` query string params', () => {
-        const configWithLogoutRedirectUri = getConfig({
-          logoutRedirectUri: 'https://test.com/logout/callback',
-        });
-
+      it('should set the endSessionEndpoint `post_logout_redirect_uri` and `client_id` query string params', () => {
+        const configWithLogoutRedirectUri = getConfig({ logoutRedirectUri });
         const am = new AuthManager(configWithLogoutRedirectUri);
+
+        const uri = new URL('/oidc', 'https://auth.immutable.com');
+        uri.searchParams.append('client_id', clientId);
+        uri.searchParams.append('post_logout_redirect_uri', logoutRedirectUri);
+
         expect(am).toBeDefined();
         expect(UserManager).toBeCalledWith(expect.objectContaining({
           metadata: expect.objectContaining({
-            end_session_endpoint: 'https://auth.immutable.com/v2/oidc?client_id=11111&returnTo=https%3A%2F%2Ftest.com%2Flogout%2Fcallback',
+            end_session_endpoint: uri.toString(),
           }),
         }));
       });
@@ -164,7 +172,6 @@ describe('AuthManager', () => {
         mockSigninPopup.mockResolvedValue(mockOidcUser);
 
         const result = await authManager.login();
-
         expect(result).toEqual(mockUser);
       });
     });
@@ -482,27 +489,37 @@ describe('AuthManager', () => {
   });
 
   describe('getDeviceFlowEndSessionEndpoint', () => {
-    describe('when a logoutRedirectUri is specified', () => {
-      it('should set the endSessionEndpoint `returnTo` and `client_id` query string params', () => {
-        const am = new AuthManager(getConfig({
-          logoutRedirectUri: 'https://test.com/logout/callback',
-        }));
-
-        const result = am.getDeviceFlowEndSessionEndpoint();
-
-        expect(result).toEqual(
-          'https://auth.immutable.com/v2/oidc?client_id=11111&returnTo=https%3A%2F%2Ftest.com%2Flogout%2Fcallback',
-        );
+    describe('with a logged in user', () => {
+      beforeEach(() => {
+        mockSigninSilent.mockReturnValue(mockOidcUser);
       });
-    });
 
-    describe('when no logoutRedirectUri is specified', () => {
-      it('should return the endSessionEndpoint without a `returnTo` or `client_id` query string params', () => {
-        const am = new AuthManager(getConfig());
+      describe('when a logoutRedirectUri is specified', () => {
+        it('should set the endSessionEndpoint `post_logout_redirect_uri` and `client_id` query string params', async () => {
+          const am = new AuthManager(getConfig({ logoutRedirectUri }));
+          const result = await am.getDeviceFlowEndSessionEndpoint();
+          const uri = new URL(result);
 
-        const result = am.getDeviceFlowEndSessionEndpoint();
+          expect(uri.hostname).toEqual(authDomain);
+          expect(uri.pathname).toEqual(logoutEndpoint);
+          expect(uri.searchParams.get('client_id')).toEqual(clientId);
+          expect(uri.searchParams.get('id_token_hint')).toEqual(mockUser.idToken);
+          expect(uri.searchParams.get('post_logout_redirect_uri')).toEqual(logoutRedirectUri);
+        });
+      });
 
-        expect(result).toEqual('https://auth.immutable.com/v2/oidc');
+      describe('when no post_logout_redirect_uri is specified', () => {
+        it('should return the endSessionEndpoint without a `post_logout_redirect_uri` or `client_id` query string params', async () => {
+          const am = new AuthManager(getConfig());
+          const result = await am.getDeviceFlowEndSessionEndpoint();
+          const uri = new URL(result);
+
+          expect(uri.hostname).toEqual(authDomain);
+          expect(uri.pathname).toEqual(logoutEndpoint);
+          expect(uri.searchParams.get('client_id')).toEqual(clientId);
+          expect(uri.searchParams.get('id_token_hint')).toEqual(mockUser.idToken);
+          expect(uri.searchParams.get('post_logout_redirect_uri')).toBeNull();
+        });
       });
     });
   });

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -116,7 +116,7 @@ describe('AuthManager', () => {
           authorization_endpoint: `${config.authenticationDomain}/authorize`,
           token_endpoint: `${config.authenticationDomain}/oauth/token`,
           userinfo_endpoint: `${config.authenticationDomain}/userinfo`,
-          end_session_endpoint: `${config.authenticationDomain}/v2/logout`
+          end_session_endpoint: `${config.authenticationDomain}/v2/oidc`
             + `?client_id=${config.oidcConfiguration.clientId}`,
         },
         popup_redirect_uri: config.oidcConfiguration.redirectUri,
@@ -151,7 +151,7 @@ describe('AuthManager', () => {
         expect(am).toBeDefined();
         expect(UserManager).toBeCalledWith(expect.objectContaining({
           metadata: expect.objectContaining({
-            end_session_endpoint: 'https://auth.immutable.com/v2/logout?client_id=11111&returnTo=https%3A%2F%2Ftest.com%2Flogout%2Fcallback',
+            end_session_endpoint: 'https://auth.immutable.com/v2/oidc?client_id=11111&returnTo=https%3A%2F%2Ftest.com%2Flogout%2Fcallback',
           }),
         }));
       });
@@ -491,7 +491,7 @@ describe('AuthManager', () => {
         const result = am.getDeviceFlowEndSessionEndpoint();
 
         expect(result).toEqual(
-          'https://auth.immutable.com/v2/logout?client_id=11111&returnTo=https%3A%2F%2Ftest.com%2Flogout%2Fcallback',
+          'https://auth.immutable.com/v2/oidc?client_id=11111&returnTo=https%3A%2F%2Ftest.com%2Flogout%2Fcallback',
         );
       });
     });
@@ -502,7 +502,7 @@ describe('AuthManager', () => {
 
         const result = am.getDeviceFlowEndSessionEndpoint();
 
-        expect(result).toEqual('https://auth.immutable.com/v2/logout');
+        expect(result).toEqual('https://auth.immutable.com/v2/oidc');
       });
     });
   });

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -38,7 +38,7 @@ const formUrlEncodedHeader = {
   },
 };
 
-const logoutEndpoint = '/oidc';
+const logoutEndpoint = '/oidc/logout';
 const authorizeEndpoint = '/?authorize';
 
 const getAuthConfiguration = (config: PassportConfiguration): UserManagerSettings => {
@@ -360,11 +360,8 @@ export default class AuthManager {
 
   public async getLogoutArgs(): Promise<SignoutRedirectArgs> {
     const user = await this.getUser();
-    const { oidcConfiguration } = this.config;
-
     return {
       id_token_hint: user?.idToken,
-      post_logout_redirect_uri: oidcConfiguration.logoutRedirectUri,
     };
   }
 

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -360,8 +360,11 @@ export default class AuthManager {
 
   public async getLogoutArgs(): Promise<SignoutRedirectArgs> {
     const user = await this.getUser();
+    const { oidcConfiguration } = this.config;
+
     return {
       id_token_hint: user?.idToken,
+      post_logout_redirect_uri: oidcConfiguration.logoutRedirectUri,
     };
   }
 

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -47,7 +47,7 @@ const getAuthConfiguration = (config: PassportConfiguration): UserManagerSetting
   const store = typeof window !== 'undefined' ? window.localStorage : new InMemoryWebStorage();
   const userStore = new WebStorageStateStore({ store });
 
-  const endSessionEndpoint = new URL(logoutEndpoint, authenticationDomain);
+  const endSessionEndpoint = new URL(logoutEndpoint, authenticationDomain.replace(/^(?:https?:\/\/)?(.*)/, 'https://$1'));
   endSessionEndpoint.searchParams.set('client_id', oidcConfiguration.clientId);
   if (oidcConfiguration.logoutRedirectUri) {
     endSessionEndpoint.searchParams.set('post_logout_redirect_uri', oidcConfiguration.logoutRedirectUri);

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -39,7 +39,7 @@ const formUrlEncodedHeader = {
 };
 
 const logoutEndpoint = '/oidc/logout';
-const authorizeEndpoint = '/?authorize';
+const authorizeEndpoint = '/authorize';
 
 const getAuthConfiguration = (config: PassportConfiguration): UserManagerSettings => {
   const { authenticationDomain, oidcConfiguration } = config;
@@ -48,9 +48,9 @@ const getAuthConfiguration = (config: PassportConfiguration): UserManagerSetting
   const userStore = new WebStorageStateStore({ store });
 
   const endSessionEndpoint = new URL(logoutEndpoint, authenticationDomain);
-  endSessionEndpoint.searchParams.append('client_id', oidcConfiguration.clientId);
+  endSessionEndpoint.searchParams.set('client_id', oidcConfiguration.clientId);
   if (oidcConfiguration.logoutRedirectUri) {
-    endSessionEndpoint.searchParams.append('post_logout_redirect_uri', oidcConfiguration.logoutRedirectUri);
+    endSessionEndpoint.searchParams.set('post_logout_redirect_uri', oidcConfiguration.logoutRedirectUri);
   }
 
   const baseConfiguration: UserManagerSettings = {
@@ -309,15 +309,15 @@ export default class AuthManager {
     this.deviceCredentialsManager.savePKCEData({ state, verifier });
 
     const pKCEAuthorizationUrl = new URL(authorizeEndpoint, this.config.authenticationDomain);
-    pKCEAuthorizationUrl.searchParams.append('response_type', 'code');
-    pKCEAuthorizationUrl.searchParams.append('code_challenge', challenge);
-    pKCEAuthorizationUrl.searchParams.append('code_challenge_method', 'S256');
-    pKCEAuthorizationUrl.searchParams.append('client_id', clientId);
-    pKCEAuthorizationUrl.searchParams.append('redirect_uri', redirectUri);
-    pKCEAuthorizationUrl.searchParams.append('state', state);
+    pKCEAuthorizationUrl.searchParams.set('response_type', 'code');
+    pKCEAuthorizationUrl.searchParams.set('code_challenge', challenge);
+    pKCEAuthorizationUrl.searchParams.set('code_challenge_method', 'S256');
+    pKCEAuthorizationUrl.searchParams.set('client_id', clientId);
+    pKCEAuthorizationUrl.searchParams.set('redirect_uri', redirectUri);
+    pKCEAuthorizationUrl.searchParams.set('state', state);
 
-    if (scope) pKCEAuthorizationUrl.searchParams.append('scope', scope);
-    if (audience) pKCEAuthorizationUrl.searchParams.append('audience', audience);
+    if (scope) pKCEAuthorizationUrl.searchParams.set('scope', scope);
+    if (audience) pKCEAuthorizationUrl.searchParams.set('audience', audience);
 
     return pKCEAuthorizationUrl.toString();
   }
@@ -393,11 +393,11 @@ export default class AuthManager {
     const { authenticationDomain, oidcConfiguration } = this.config;
 
     const endSessionEndpoint = new URL(logoutEndpoint, authenticationDomain);
-    endSessionEndpoint.searchParams.append('client_id', oidcConfiguration.clientId);
+    endSessionEndpoint.searchParams.set('client_id', oidcConfiguration.clientId);
 
     const logoutArgs = await this.getLogoutArgs();
-    if (logoutArgs.id_token_hint) endSessionEndpoint.searchParams.append('id_token_hint', logoutArgs.id_token_hint);
-    if (logoutArgs.post_logout_redirect_uri) endSessionEndpoint.searchParams.append('post_logout_redirect_uri', logoutArgs.post_logout_redirect_uri);
+    if (logoutArgs.id_token_hint) endSessionEndpoint.searchParams.set('id_token_hint', logoutArgs.id_token_hint);
+    if (logoutArgs.post_logout_redirect_uri) endSessionEndpoint.searchParams.set('post_logout_redirect_uri', logoutArgs.post_logout_redirect_uri);
 
     return endSessionEndpoint.toString();
   }

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -43,7 +43,7 @@ const getAuthConfiguration = (config: PassportConfiguration): UserManagerSetting
   const store = typeof window !== 'undefined' ? window.localStorage : new InMemoryWebStorage();
   const userStore = new WebStorageStateStore({ store });
 
-  let endSessionEndpoint = `${authenticationDomain}/v2/logout?client_id=${oidcConfiguration.clientId}`;
+  let endSessionEndpoint = `${authenticationDomain}/v2/oidc?client_id=${oidcConfiguration.clientId}`;
   if (oidcConfiguration.logoutRedirectUri) {
     endSessionEndpoint += `&returnTo=${encodeURIComponent(oidcConfiguration.logoutRedirectUri)}`;
   }
@@ -364,7 +364,7 @@ export default class AuthManager {
 
   public getDeviceFlowEndSessionEndpoint(): string {
     const { authenticationDomain, oidcConfiguration } = this.config;
-    let endSessionEndpoint = `${authenticationDomain}/v2/logout`;
+    let endSessionEndpoint = `${authenticationDomain}/v2/oidc`;
     if (oidcConfiguration.logoutRedirectUri) {
       endSessionEndpoint += `?client_id=${oidcConfiguration.clientId}`
         + `&returnTo=${encodeURIComponent(oidcConfiguration.logoutRedirectUri)}`;


### PR DESCRIPTION
Updates logout functions in AuthManager to use `/oidc/` endpoint (documented https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0) to work around looming changes to third-party cookie restrictions

# Detail and impact of the change
Changes logout method from retrieving user session via cookie to supplying the user session to the logout endpoint

## Changed
* New method to build logout arguments, and supplying those to the logout functions

## Fixed
* Rewrites URL construction to use URI objects rather than compounding strings.
