### PR TITLE
fix: [NO-JIRA] Tenderly gas simulation error logging

### DIFF
--- a/packages/internal/bridge/sdk/src/tokenBridge.ts
+++ b/packages/internal/bridge/sdk/src/tokenBridge.ts
@@ -954,7 +954,7 @@ export class TokenBridge {
     for (let i = 0; i < simResults.length; i++) {
       if (simResults[i].simulation.error_message) {
         throw new BridgeError(
-          `Estimating deposit gas failed with the reason: ${simResults[0].simulation.error_message}`,
+          `Estimating deposit gas failed with the reason: ${simResults[i].simulation.error_message}`,
           BridgeErrorType.TENDERLY_GAS_ESTIMATE_FAILED,
         );
       }


### PR DESCRIPTION
# Summary
Error logging in the tokenBridge is returning undefined.

# Detail and impact of the change
## Fixed
Fix to address the simulation error message being reported as `undefined`