### PR TITLE
feat: [CM-521] Updates to Swap widget fee breakdown

### DIFF
--- a/packages/checkout/widgets-lib/src/components/Fees/Fees.tsx
+++ b/packages/checkout/widgets-lib/src/components/Fees/Fees.tsx
@@ -7,6 +7,7 @@ import {
 import { TokenInfo } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
+import { Token } from '@imtbl/dex-sdk';
 import { formatZeroAmount, tokenValueFormat } from '../../lib/utils';
 import { FeesBreakdown } from '../FeesBreakdown/FeesBreakdown';
 import { gasAmountAccordionStyles, gasAmountHeadingStyles } from './FeeStyles';
@@ -20,6 +21,7 @@ interface FeesProps {
     amount: string;
     label: string;
     prefix?: string;
+    token: Token;
   }[];
   onFeesClick?: () => void;
   loading?: boolean;

--- a/packages/checkout/widgets-lib/src/components/FeesBreakdown/FeesBreakdown.tsx
+++ b/packages/checkout/widgets-lib/src/components/FeesBreakdown/FeesBreakdown.tsx
@@ -3,6 +3,7 @@ import {
 } from '@biom3/react';
 import { formatZeroAmount, tokenValueFormat } from 'lib/utils';
 import { useTranslation } from 'react-i18next';
+import { Token } from '@imtbl/dex-sdk';
 import { feeItemContainerStyles, feeItemLoadingStyles, feesBreakdownContentStyles } from './FeesBreakdownStyles';
 import { FeeItem } from './FeeItem';
 import { FooterLogo } from '../Footer/FooterLogo';
@@ -12,6 +13,7 @@ type Fee = {
   amount: string;
   fiatAmount: string;
   prefix?: string;
+  token: Token;
 };
 
 type FeesBreakdownProps = {
@@ -62,13 +64,14 @@ export function FeesBreakdown({
               amount,
               fiatAmount,
               prefix,
+              token,
             }) => (
               <FeeItem
                 key={label}
                 label={label}
                 amount={amount}
                 fiatAmount={fiatAmount}
-                tokenSymbol={tokenSymbol}
+                tokenSymbol={token.symbol ?? ''}
                 prefix={prefix}
               />
             ))

--- a/packages/checkout/widgets-lib/src/components/FeesBreakdown/FeesBreakdownStyles.tsx
+++ b/packages/checkout/widgets-lib/src/components/FeesBreakdown/FeesBreakdownStyles.tsx
@@ -15,12 +15,12 @@ export const feeItemContainerStyles = {
 export const feeItemStyles = { display: 'flex', width: '100%' };
 
 export const feeItemLabelStyles = (boldLabel?: boolean) => ({
-  width: '50%',
+  width: '65%',
   color: boldLabel ? 'base.color.text.body.primary' : 'base.color.text.body.secondary',
 });
 
 export const feeItemPriceDisplayStyles = {
-  width: '50%',
+  width: '35%',
 };
 
 export const feeItemLoadingStyles = {

--- a/packages/checkout/widgets-lib/src/locales/en.json
+++ b/packages/checkout/widgets-lib/src/locales/en.json
@@ -618,14 +618,17 @@
       "total": "Total fees",
       "fees": {
         "fiatPricePrefix": "USD $",
-        "gasFeeSwap": {
-          "label": "Gas fee swap"
-        },
         "gasFeeMove": {
-          "label": "Gas fee move"
+          "label": "Gas fee"
         },
-        "gasFeeApproval": {
-          "label": "Gas fee approval"
+        "approvalFee": {
+          "label": "Approval fee"
+        },
+        "swapGasFee": {
+          "label": "Gas fee"
+        },
+        "swapSecondaryFee": {
+          "label": "{{amount}} Swap fee (factored into quote)"
         },
         "serviceFee": {
           "label": "Service fee"

--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -625,20 +625,22 @@
       "total": "総手数料",
       "fees": {
         "fiatPricePrefix": "USD $",
-        "gasFeeSwap": {
-          "label": "ガス手数料スワップ"
-        },
         "gasFeeMove": {
-          "label": "ガス手数料移動"
+          "label": "ガス手数料"
         },
-        "gasFeeApproval": {
-          "label": "ガス手数料承認"
+        "approvalFee": {
+          "label": "承認手数料"
+        },
+        "swapGasFee": {
+          "label": "ガス手数料"
+        },
+        "swapSecondaryFee": {
+          "label": "{{amount}} スワップ手数料（見積もりに含まれる）"
         },
         "serviceFee": {
           "label": "サービス手数料"
         }
       }
-
     },
     "transactionFailed": {
       "content": {

--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -624,10 +624,21 @@
       "heading": "手数料の内訳",
       "total": "総手数料",
       "fees": {
-        "gas": {
-          "label": "ガス手数料"
+        "fiatPricePrefix": "USD $",
+        "gasFeeSwap": {
+          "label": "ガス手数料スワップ"
+        },
+        "gasFeeMove": {
+          "label": "ガス手数料移動"
+        },
+        "gasFeeApproval": {
+          "label": "ガス手数料承認"
+        },
+        "serviceFee": {
+          "label": "サービス手数料"
         }
       }
+
     },
     "transactionFailed": {
       "content": {

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -618,14 +618,17 @@
       "total": "수수료 총액",
       "fees": {
         "fiatPricePrefix": "USD $",
-        "gasFeeSwap": {
-          "label": "가스 수수료 스왑"
-        },
         "gasFeeMove": {
-          "label": "가스 수수료 이동"
+          "label": "가스 수수료"
         },
-        "gasFeeApproval": {
-          "label": "가스 수수료 승인"
+        "approvalFee": {
+          "label": "승인 수수료"
+        },
+        "swapGasFee": {
+          "label": "가스 수수료"
+        },
+        "swapSecondaryFee": {
+          "label": "{{amount}} 스왑 수수료 (견적에 포함)"
         },
         "serviceFee": {
           "label": "서비스 수수료"

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -617,8 +617,18 @@
       "heading": "수수료 내역",
       "total": "수수료 총액",
       "fees": {
-        "gas": {
-          "label": "가스 수수료"
+        "fiatPricePrefix": "USD $",
+        "gasFeeSwap": {
+          "label": "가스 수수료 스왑"
+        },
+        "gasFeeMove": {
+          "label": "가스 수수료 이동"
+        },
+        "gasFeeApproval": {
+          "label": "가스 수수료 승인"
+        },
+        "serviceFee": {
+          "label": "서비스 수수료"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -618,14 +618,17 @@
       "total": "费用总计",
       "fees": {
         "fiatPricePrefix": "USD $",
-        "gasFeeSwap": {
-          "label": "气体费用交换"
-        },
         "gasFeeMove": {
-          "label": "气体费用移动"
+          "label": "气体费用"
         },
-        "gasFeeApproval": {
-          "label": "气体费用批准"
+        "approvalFee": {
+          "label": "批准费"
+        },
+        "swapGasFee": {
+          "label": "气体费用"
+        },
+        "swapSecondaryFee": {
+          "label": "{{amount}} 交换费（已计入报价）"
         },
         "serviceFee": {
           "label": "服务费"

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -617,8 +617,18 @@
       "heading": "费用分解",
       "total": "费用总计",
       "fees": {
-        "gas": {
-          "label": "燃气费"
+        "fiatPricePrefix": "USD $",
+        "gasFeeSwap": {
+          "label": "气体费用交换"
+        },
+        "gasFeeMove": {
+          "label": "气体费用移动"
+        },
+        "gasFeeApproval": {
+          "label": "气体费用批准"
+        },
+        "serviceFee": {
+          "label": "服务费"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/widgets/bridge/functions/BridgeFees.ts
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/functions/BridgeFees.ts
@@ -36,7 +36,7 @@ export const formatBridgeFees = (estimates: GasEstimateBridgeToL2Result | undefi
   if (estimates.fees.approvalFee?.gt(0)) {
     const formattedApprovalGas = utils.formatUnits(estimates.fees.approvalFee, estimates.token.decimals);
     fees.push({
-      label: t('drawers.feesBreakdown.fees.gasFeeApproval.label'),
+      label: t('drawers.feesBreakdown.fees.approvalFee.label'),
       fiatAmount: `~ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${calculateCryptoToFiat(
         formattedApprovalGas,
         estimates.token.symbol,

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -155,7 +155,7 @@ export function SwapForm({ data, theme }: SwapFromProps) {
   const [gasFeeFiatValue, setGasFeeFiatValue] = useState<string>('');
   const [tokensOptionsFrom, setTokensOptionsForm] = useState<CoinSelectorOptionProps[]>([]);
   const formattedFees = useMemo(
-    (): any => (quote ? formatSwapFees(quote, cryptoFiatState, t) : []),
+    () => (quote ? formatSwapFees(quote, cryptoFiatState, t) : []),
     [quote, cryptoFiatState, t],
   );
 

--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/swapFees.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/swapFees.test.ts
@@ -9,43 +9,10 @@ import { formatSwapFees } from './swapFees';
 import { CryptoFiatState } from '../../../context/crypto-fiat-context/CryptoFiatContext';
 import { calculateCryptoToFiat, tokenValueFormat } from '../../../lib/utils';
 
-// const tokenValueFormat = value => `Formatted: ${value}`;
 jest.mock('../../../lib/utils');
-// const calculateCryptoToFiat = (value, symbol, conversions) => `FiatValue:${value}`;
 
 describe('formatSwapFees', () => {
   const mockTranslate = ((labelKey) => labelKey) as any;
-  // const mockQuote = {
-  //   quote: {
-  //     amount: {} as Amount,
-  //     amountWithMaxSlippage: {} as Amount,
-  //     slippage: 0,
-  //     fees: [{
-  //       recipient: '0x123',
-  //       basisPoints: 100,
-  //       amount: {
-  //         value: BigNumber.from(100),
-  //         token: {
-  //           symbol: 'ETH',
-  //           address: '0x123',
-  //           chainId: 1,
-  //           decimals: 18,
-  //         },
-  //       },
-  //     } as Fee],
-  //   } as Quote,
-  //   swap: {
-  //     gasFeeEstimate: {
-  //       value: BigNumber.from(100),
-  //     },
-  //   },
-  //   approval: {
-  //     gasFeeEstimate: {
-  //       value: BigNumber.from(50),
-  //     },
-  //   },
-  // } as TransactionResponse;
-
   beforeEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
# Summary
Updates to Swap widget fee breakdown.
[CM-521](https://immutable.atlassian.net/browse/CM-521)

# Detail and impact of the change
## Changed
Separated the Swap widget fees into gas, approval gas, and secondary fees.
Removed swap gas fees from the UI for Passport users.

[CM-521]: https://immutable.atlassian.net/browse/CM-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ