### PR TITLE
feat: [CM-607][Sale Widget] Get order config from product skus + qty

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/parameters/sale.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/parameters/sale.ts
@@ -12,8 +12,6 @@ import { SalePaymentTypes } from '../events/sale';
  * @property {WalletProviderName | undefined} walletProviderName
  */
 export type SaleWidgetParams = {
-  /** The total price to pay for the items in the sale */
-  amount?: string;
   /** Environment id from Immutable Hub */
   environmentId?: string;
   /** The list of products to be purchased */

--- a/packages/checkout/widgets-lib/src/lib/utils.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.ts
@@ -10,6 +10,10 @@ import {
   NATIVE,
 } from './constants';
 
+export const tokenSymbolNameOverrides = {
+  timx: 'imx',
+};
+
 export const sortTokensByAmount = (
   config: CheckoutConfiguration,
   tokens: GetBalanceResult[],
@@ -71,7 +75,8 @@ export const calculateCryptoToFiat = (
 ): string => {
   if (!amount) return zeroString;
 
-  const conversion = conversions.get(symbol.toLowerCase());
+  const name = tokenSymbolNameOverrides[symbol.toLowerCase()] || symbol.toLowerCase();
+  const conversion = conversions.get(name);
   if (!conversion) return zeroString;
 
   const parsedAmount = parseFloat(amount);

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -57,7 +57,6 @@ export default function SaleWidget(props: SaleWidgetProps) {
   const { t } = useTranslation();
   const {
     config,
-    amount,
     items,
     environmentId,
     collectionName,
@@ -119,7 +118,6 @@ export default function SaleWidget(props: SaleWidgetProps) {
         value={{
           config,
           items,
-          amount,
           environment: config.environment,
           environmentId,
           provider,

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
@@ -16,7 +16,6 @@ import {
 } from 'components/ConnectLoader/ConnectLoader';
 import { getL2ChainId } from 'lib';
 import {
-  isValidAmount,
   isValidWalletProvider,
 } from 'lib/validations/widgetValidators';
 import { ThemeProvider } from 'components/ThemeProvider/ThemeProvider';
@@ -61,12 +60,6 @@ export class Sale extends Base<WidgetType.SALE> {
       // eslint-disable-next-line no-console
       console.warn('[IMTBL]: invalid "walletProviderName" widget input');
       validatedParams.walletProviderName = undefined;
-    }
-
-    if (!isValidAmount(params.amount)) {
-      // eslint-disable-next-line no-console
-      console.warn('[IMTBL]: invalid "amount" widget input');
-      validatedParams.amount = '';
     }
 
     // TODO: fix the logic here when proper , currently saying if valid then reset to empty array.
@@ -125,7 +118,6 @@ export class Sale extends Base<WidgetType.SALE> {
               <Suspense fallback={<LoadingView loadingText={t('views.LOADING_VIEW.text')} />}>
                 <SaleWidget
                   config={config}
-                  amount={this.parameters.amount!}
                   items={this.parameters.items!}
                   environmentId={this.parameters.environmentId!}
                   collectionName={this.parameters.collectionName!}

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/OrderItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/OrderItem.tsx
@@ -1,37 +1,45 @@
-import { Heading, MenuItem } from '@biom3/react';
+import { Heading, MenuItem, MenuItemSize } from '@biom3/react';
 import { SaleItem } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
 import { calculateCryptoToFiat, tokenValueFormat } from 'lib/utils';
 import { ReactElement } from 'react';
-import { FundingBalance } from '../types';
+import { ClientConfigPricing, FundingBalance } from '../types';
 
 export interface OrderItemProps<
   RC extends ReactElement | undefined = undefined,
 > {
   item: SaleItem;
   balance: FundingBalance;
+  pricing: ClientConfigPricing | undefined;
   conversions: Map<string, number>;
+  size?: MenuItemSize;
   rc?: RC;
 }
 
 export function OrderItem<RC extends ReactElement | undefined = undefined>({
   item,
   balance,
+  pricing,
   conversions,
+  size,
   rc = <span />,
 }: OrderItemProps<RC>) {
   const { t } = useTranslation();
 
-  const { token, fundsRequired } = balance.fundingItem;
+  const { token } = balance.fundingItem;
+  const amount = pricing?.amount || 0;
 
-  const amount = fundsRequired.formattedAmount;
-  const fiatAmount = calculateCryptoToFiat(amount, token.symbol, conversions);
+  const fiatAmount = calculateCryptoToFiat(
+    amount.toString(),
+    token.symbol,
+    conversions,
+  );
 
   return (
     <MenuItem
       rc={rc}
       emphasized
-      size="medium"
+      size={size || 'medium'}
       key={item.name}
       sx={{
         pointerEvents: 'none',
@@ -41,20 +49,20 @@ export function OrderItem<RC extends ReactElement | undefined = undefined>({
       <MenuItem.FramedImage imageUrl={item.image} />
       <MenuItem.Label>{item.name}</MenuItem.Label>
       <MenuItem.Caption>
-        {item.qty > 1
-          ? t('views.ORDER_SUMMARY.orderItem.quantity', { qty: item.qty })
-          : null}
+        {t('views.ORDER_SUMMARY.orderItem.quantity', { qty: item.qty })}
       </MenuItem.Caption>
-      <MenuItem.PriceDisplay
-        use={<Heading size="xSmall" />}
-        price={t('views.ORDER_SUMMARY.currency.price', {
-          symbol: token.symbol,
-          amount: tokenValueFormat(amount),
-        })}
-        fiatAmount={t('views.ORDER_SUMMARY.currency.fiat', {
-          amount: fiatAmount,
-        })}
-      />
+      {amount > 0 && (
+        <MenuItem.PriceDisplay
+          use={<Heading size="xSmall" />}
+          price={t('views.ORDER_SUMMARY.currency.price', {
+            symbol: token.symbol,
+            amount: tokenValueFormat(amount),
+          })}
+          fiatAmount={t('views.ORDER_SUMMARY.currency.fiat', {
+            amount: fiatAmount,
+          })}
+        />
+      )}
     </MenuItem>
   );
 }

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/OrderItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/OrderItem.tsx
@@ -3,14 +3,14 @@ import { SaleItem } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
 import { calculateCryptoToFiat, tokenValueFormat } from 'lib/utils';
 import { ReactElement } from 'react';
-import { ClientConfigPricing, FundingBalance } from '../types';
+import { OrderQuotePricing, FundingBalance } from '../types';
 
 export interface OrderItemProps<
   RC extends ReactElement | undefined = undefined,
 > {
   item: SaleItem;
   balance: FundingBalance;
-  pricing: ClientConfigPricing | undefined;
+  pricing: OrderQuotePricing | undefined;
   conversions: Map<string, number>;
   size?: MenuItemSize;
   rc?: RC;

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/OrderItems.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/OrderItems.tsx
@@ -4,13 +4,13 @@ import { listVariants, listItemVariants } from 'lib/animation/listAnimation';
 
 import { motion } from 'framer-motion';
 import { OrderItem } from './OrderItem';
-import { ClientConfigProduct, FundingBalance } from '../types';
+import { OrderQuoteProduct, FundingBalance } from '../types';
 import { getPricingBySymbol } from '../utils/pricing';
 
 type OrderItemsProps = {
   items: SaleItem[];
   balance: FundingBalance;
-  pricing: Record<string, ClientConfigProduct>;
+  pricing: Record<string, OrderQuoteProduct>;
   conversions: Map<string, number>;
 };
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/OrderItems.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/OrderItems.tsx
@@ -4,15 +4,22 @@ import { listVariants, listItemVariants } from 'lib/animation/listAnimation';
 
 import { motion } from 'framer-motion';
 import { OrderItem } from './OrderItem';
-import { FundingBalance } from '../types';
+import { ClientConfigProduct, FundingBalance } from '../types';
+import { getPricingBySymbol } from '../utils/pricing';
 
 type OrderItemsProps = {
   items: SaleItem[];
   balance: FundingBalance;
+  pricing: Record<string, ClientConfigProduct>;
   conversions: Map<string, number>;
 };
 
-export function OrderItems({ items, balance, conversions }: OrderItemsProps) {
+export function OrderItems({
+  items,
+  balance,
+  pricing,
+  conversions,
+}: OrderItemsProps) {
   return (
     <Box
       rc={
@@ -25,6 +32,12 @@ export function OrderItems({ items, balance, conversions }: OrderItemsProps) {
           item={item}
           balance={balance}
           conversions={conversions}
+          size={items.length > 1 ? 'small' : 'medium'}
+          pricing={getPricingBySymbol(
+            balance.fundingItem.token.symbol,
+            pricing?.[item.productId]?.pricing,
+            conversions,
+          )}
           rc={<motion.div variants={listItemVariants} custom={idx} />}
         />
       ))}

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/OrderReview.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/OrderReview.tsx
@@ -104,7 +104,8 @@ export function OrderReview({
           pb: 'base.spacing.x8',
           maxh: '60%',
           height: '100%',
-          overflowY: 'auto',
+          overflowY: 'scroll',
+          scrollbarWidth: 'none',
           rowGap: 'base.spacing.x4',
         }}
       >

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/OrderReview.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/OrderReview.tsx
@@ -13,7 +13,7 @@ import { EventTargetContext } from '../../../context/event-target-context/EventT
 import { sendSaleWidgetCloseEvent } from '../SaleWidgetEvents';
 import { SelectCoinDropdown } from './SelectCoinDropdown';
 import { CoinsDrawer } from './CoinsDrawer';
-import { FundingBalance } from '../types';
+import { ClientConfigProduct, FundingBalance } from '../types';
 import { OrderItems } from './OrderItems';
 import { useSaleEvent } from '../hooks/useSaleEvents';
 
@@ -23,6 +23,7 @@ type OrderReviewProps = {
   conversions: Map<string, number>;
   loadingBalances: boolean;
   items: SaleItem[];
+  pricing: Record<string, ClientConfigProduct>;
   transactionRequirement?: TransactionRequirement;
   onBackButtonClick: () => void;
   onProceedToBuy: (fundingBalance: FundingBalance) => void;
@@ -32,6 +33,7 @@ type OrderReviewProps = {
 
 export function OrderReview({
   items,
+  pricing,
   fundingBalances,
   conversions,
   collectionName,
@@ -82,29 +84,35 @@ export function OrderReview({
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'space-between',
+        height: '0',
       }}
     >
+      <Heading
+        size="small"
+        sx={{
+          px: 'base.spacing.x4',
+          pb: 'base.spacing.x4',
+        }}
+      >
+        {t('views.ORDER_SUMMARY.orderReview.heading')}
+      </Heading>
       <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
-          paddingX: 'base.spacing.x2',
-          paddingY: 'base.spacing.x8',
+          px: 'base.spacing.x2',
+          pb: 'base.spacing.x8',
+          maxh: '60%',
+          height: '100%',
+          overflowY: 'auto',
           rowGap: 'base.spacing.x4',
         }}
       >
-        <Heading
-          size="small"
-          sx={{
-            paddingX: 'base.spacing.x4',
-          }}
-        >
-          {t('views.ORDER_SUMMARY.orderReview.heading')}
-        </Heading>
-        <Box sx={{ paddingX: 'base.spacing.x2' }}>
+        <Box sx={{ px: 'base.spacing.x2' }}>
           <OrderItems
             items={items}
             balance={fundingBalances[selectedCurrencyIndex]}
+            pricing={pricing}
             conversions={conversions}
           />
         </Box>
@@ -116,6 +124,7 @@ export function OrderReview({
         conversions={conversions}
         canOpen={fundingBalances.length > 1}
         loading={loadingBalances}
+        priceDisplay={items.length > 1}
       />
       <CoinsDrawer
         conversions={conversions}

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/OrderReview.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/OrderReview.tsx
@@ -13,7 +13,7 @@ import { EventTargetContext } from '../../../context/event-target-context/EventT
 import { sendSaleWidgetCloseEvent } from '../SaleWidgetEvents';
 import { SelectCoinDropdown } from './SelectCoinDropdown';
 import { CoinsDrawer } from './CoinsDrawer';
-import { ClientConfigProduct, FundingBalance } from '../types';
+import { OrderQuoteProduct, FundingBalance } from '../types';
 import { OrderItems } from './OrderItems';
 import { useSaleEvent } from '../hooks/useSaleEvents';
 
@@ -23,7 +23,7 @@ type OrderReviewProps = {
   conversions: Map<string, number>;
   loadingBalances: boolean;
   items: SaleItem[];
-  pricing: Record<string, ClientConfigProduct>;
+  pricing: Record<string, OrderQuoteProduct>;
   transactionRequirement?: TransactionRequirement;
   onBackButtonClick: () => void;
   onProceedToBuy: (fundingBalance: FundingBalance) => void;

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/SelectCoinDropdown.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/SelectCoinDropdown.tsx
@@ -105,10 +105,7 @@ export function SelectCoinDropdown({
                 ? t('views.ORDER_SUMMARY.currency.fiat', { amount: fiatAmount })
                 : undefined
             }
-            price={t('views.ORDER_SUMMARY.currency.price', {
-              symbol: token.symbol,
-              amount: tokenValueFormat(fundsRequired.formattedAmount),
-            })}
+            price={tokenValueFormat(fundsRequired.formattedAmount)}
           />
         )}
         {canOpen && (

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/WithCard.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/WithCard.tsx
@@ -31,7 +31,7 @@ export function WithCard(props: WithCardProps) {
     signResponse,
     goToErrorView,
     environment,
-    clientConfig,
+    orderQuote,
   } = useSaleContext();
   const executeTxn = signResponse?.transactions.find((txn) => txn.methodCall.startsWith('execute'));
 
@@ -77,7 +77,7 @@ export function WithCard(props: WithCardProps) {
       onOrderFailed={onOrderFailed}
       onFailedToLoad={onFailedToLoad}
       environment={environment}
-      contractId={clientConfig.contractId}
+      contractId={orderQuote.config.contractId}
     />
   );
 }

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -47,7 +47,6 @@ type SaleContextProps = {
   environment: Environment;
   environmentId: string;
   items: SaleItem[];
-  amount: string;
   collectionName: string;
   provider: ConnectLoaderState['provider'];
   checkout: ConnectLoaderState['checkout'];
@@ -101,7 +100,6 @@ type SaleContextValues = SaleContextProps & {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const SaleContext = createContext<SaleContextValues>({
   items: [],
-  amount: '',
   collectionName: '',
   provider: undefined,
   checkout: undefined,
@@ -154,7 +152,6 @@ export function SaleContextProvider(props: {
       environment,
       environmentId,
       items,
-      amount,
       provider,
       checkout,
       passport,
@@ -202,7 +199,7 @@ export function SaleContextProvider(props: {
 
   const { selectedCurrency, clientConfig, clientConfigError } = useClientConfig(
     {
-      amount,
+      items,
       environmentId,
       environment: config.environment,
     },
@@ -337,7 +334,6 @@ export function SaleContextProvider(props: {
     provider,
     checkout,
     items,
-    amount,
     tokenAddress: fromTokenAddress,
   });
 
@@ -379,12 +375,11 @@ export function SaleContextProvider(props: {
 
   useEffect(() => {
     const invalidItems = !items || items.length === 0;
-    const invalidAmount = !amount || amount === '0';
 
-    if (invalidItems || invalidAmount || !collectionName || !environmentId) {
+    if (invalidItems || !collectionName || !environmentId) {
       setInvalidParameters(true);
     }
-  }, [items, amount, collectionName, environmentId]);
+  }, [items, collectionName, environmentId]);
 
   useEffect(() => {
     if (excludePaymentTypes?.length <= 0) return;
@@ -395,7 +390,6 @@ export function SaleContextProvider(props: {
     () => ({
       config,
       items,
-      amount,
       fromTokenAddress,
       sign,
       signResponse,
@@ -434,7 +428,6 @@ export function SaleContextProvider(props: {
       environment,
       environmentId,
       items,
-      amount,
       fromTokenAddress,
       collectionName,
       provider,

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -26,8 +26,8 @@ import {
 import { StrongCheckoutWidgetsConfig } from '../../../lib/withDefaultWidgetConfig';
 import { useSignOrder } from '../hooks/useSignOrder';
 import {
-  ClientConfig,
-  ClientConfigCurrency,
+  OrderQuote,
+  OrderQuoteCurrency,
   ExecuteOrderResponse,
   ExecutedTransaction,
   SaleErrorTypes,
@@ -40,7 +40,7 @@ import {
 import { getTopUpViewData } from '../functions/smartCheckoutUtils';
 
 import { useSmartCheckout } from '../hooks/useSmartCheckout';
-import { useClientConfig, defaultClientConfig } from '../hooks/useClientConfig';
+import { useQuoteOrder, defaultOrderQuote } from '../hooks/useQuoteOrder';
 
 type SaleContextProps = {
   config: StrongCheckoutWidgetsConfig;
@@ -92,9 +92,9 @@ type SaleContextValues = SaleContextProps & {
   disabledPaymentTypes: SalePaymentTypes[];
   invalidParameters: boolean;
   fromTokenAddress: string;
-  clientConfig: ClientConfig;
+  orderQuote: OrderQuote;
   signTokenIds: string[];
-  selectedCurrency: ClientConfigCurrency | undefined;
+  selectedCurrency: OrderQuoteCurrency | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -129,7 +129,7 @@ const SaleContext = createContext<SaleContextValues>({
   disabledPaymentTypes: [],
   invalidParameters: false,
   fromTokenAddress: '',
-  clientConfig: defaultClientConfig,
+  orderQuote: defaultOrderQuote,
   signTokenIds: [],
   excludePaymentTypes: [],
   multicurrency: false,
@@ -197,7 +197,7 @@ export function SaleContextProvider(props: {
 
   const [invalidParameters, setInvalidParameters] = useState<boolean>(false);
 
-  const { selectedCurrency, clientConfig, clientConfigError } = useClientConfig({
+  const { selectedCurrency, orderQuote, orderQuoteError } = useQuoteOrder({
     items,
     provider,
     environmentId,
@@ -325,9 +325,9 @@ export function SaleContextProvider(props: {
   }, [signError]);
 
   useEffect(() => {
-    if (!clientConfigError) return;
-    goToErrorView(clientConfigError.type, clientConfigError.data);
-  }, [clientConfigError]);
+    if (!orderQuoteError) return;
+    goToErrorView(orderQuoteError.type, orderQuoteError.data);
+  }, [orderQuoteError]);
 
   const { smartCheckout, smartCheckoutResult, smartCheckoutError } = useSmartCheckout({
     provider,
@@ -416,7 +416,7 @@ export function SaleContextProvider(props: {
       fundingRoutes,
       disabledPaymentTypes,
       invalidParameters,
-      clientConfig,
+      orderQuote,
       signTokenIds: tokenIds,
       excludePaymentTypes,
       multicurrency,
@@ -449,7 +449,7 @@ export function SaleContextProvider(props: {
       fundingRoutes,
       disabledPaymentTypes,
       invalidParameters,
-      clientConfig,
+      orderQuote,
       tokenIds,
       excludePaymentTypes,
       multicurrency,

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -197,13 +197,12 @@ export function SaleContextProvider(props: {
 
   const [invalidParameters, setInvalidParameters] = useState<boolean>(false);
 
-  const { selectedCurrency, clientConfig, clientConfigError } = useClientConfig(
-    {
-      items,
-      environmentId,
-      environment: config.environment,
-    },
-  );
+  const { selectedCurrency, clientConfig, clientConfigError } = useClientConfig({
+    items,
+    provider,
+    environmentId,
+    environment: config.environment,
+  });
 
   const fromTokenAddress = selectedCurrency?.address || '';
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalances.ts
@@ -2,7 +2,7 @@ import { Web3Provider } from '@ethersproject/providers';
 import { Checkout, TransactionRequirement } from '@imtbl/checkout-sdk';
 import { Environment } from '@imtbl/config';
 import {
-  ClientConfigCurrency,
+  OrderQuoteCurrency,
   FundingBalance,
   FundingBalanceResult,
 } from '../types';
@@ -18,10 +18,10 @@ import {
 export type FundingBalanceParams = {
   provider: Web3Provider;
   checkout: Checkout;
-  currencies: ClientConfigCurrency[];
-  baseCurrency: ClientConfigCurrency;
+  currencies: OrderQuoteCurrency[];
+  baseCurrency: OrderQuoteCurrency;
   routingOptions: { bridge: boolean; onRamp: boolean; swap: boolean };
-  getAmountByCurrency: (currency: ClientConfigCurrency) => string;
+  getAmountByCurrency: (currency: OrderQuoteCurrency) => string;
   getIsGasless: () => boolean;
   onFundingBalance: (balances: FundingBalance[]) => void;
   onFundingRequirement: (

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalancesUtils.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalancesUtils.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { ClientConfigCurrency, FundingBalance } from '../types';
+import { OrderQuoteCurrency, FundingBalance } from '../types';
 import {
   getGasEstimate,
   getERC20ItemRequirement,
@@ -340,7 +340,7 @@ describe('getFnToSortFundingBalancesByPriority', () => {
 
 describe('getFnToPushAndSortFundingBalances', () => {
   let balances: FundingBalance[] = [];
-  let baseCurrency: ClientConfigCurrency;
+  let baseCurrency: OrderQuoteCurrency;
   let pushAndSortByUSDC: (balances: FundingBalance[]) => FundingBalance[];
 
   beforeAll(() => {

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalancesUtils.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalancesUtils.ts
@@ -14,7 +14,7 @@ import { BigNumber } from 'ethers';
 import { getTokenImageByAddress, isNativeToken } from 'lib/utils';
 import { Environment } from '@imtbl/config';
 import {
-  ClientConfigCurrency,
+  OrderQuoteCurrency,
   FundingBalance,
   FundingBalanceType,
   SufficientFundingStep,
@@ -175,7 +175,7 @@ export const getFnToSortFundingBalancesByPriority = (baseSymbol?: string) => (a:
 };
 
 export const getFnToPushAndSortFundingBalances = (
-  baseCurrency: ClientConfigCurrency,
+  baseCurrency: OrderQuoteCurrency,
 ): ((balances: FundingBalance[]) => FundingBalance[]) => {
   let currentBalances: FundingBalance[] = [];
   const sortByBaseAndPriority = getFnToSortFundingBalancesByPriority(

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToClientConfig.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToClientConfig.test.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { ClientConfig, SignPaymentTypes } from '../types';
+import { ClientConfig } from '../types';
 import {
-  ClientConfigResponse,
+  ClientConfigApiResponse,
   transformToClientConfig,
 } from './transformToClientConfig';
 
 describe('transformToClientConfig', () => {
   it('should return input object with camel case keys', () => {
-    const fromClientConfig: ClientConfigResponse = {
-      contract_id: '65696ef06c55501aab4da5e7',
+    const fromClientConfig: ClientConfigApiResponse = {
+      contract_id: '',
       currencies: [
         {
           base: true,
@@ -32,75 +32,131 @@ describe('transformToClientConfig', () => {
           name: 'ETH',
         },
       ],
-      currency_conversion: {
+      products: {
+        lab: {
+          pricing: {
+            ETH: {
+              amount: 0.00317,
+              currency: 'ETH',
+              type: 'crypto',
+            },
+            GOG: {
+              amount: 39.84294,
+              currency: 'GOG',
+              type: 'crypto',
+            },
+            USD: {
+              amount: 9.6096,
+              currency: 'USD',
+              type: 'fiat',
+            },
+            USDC: {
+              amount: 9.6,
+              currency: 'USDC',
+              type: 'crypto',
+            },
+          },
+          product_id: 'lab',
+          quantity: 1,
+        },
+      },
+      total_amount: {
         ETH: {
-          amount: 0.000284,
-          name: 'ETH',
+          amount: 0.00317,
+          currency: 'ETH',
           type: 'crypto',
         },
         GOG: {
-          amount: 6.00203,
-          name: 'GOG',
+          amount: 39.84294,
+          currency: 'GOG',
           type: 'crypto',
         },
         USD: {
-          amount: 0.999392,
-          name: 'USD',
+          amount: 9.6096,
+          currency: 'USD',
           type: 'fiat',
         },
         USDC: {
-          amount: 1,
-          name: 'USDC',
+          amount: 9.6,
+          currency: 'USDC',
           type: 'crypto',
         },
       },
     };
 
     const toClientConfig: ClientConfig = {
-      contractId: '65696ef06c55501aab4da5e7',
+      contractId: '',
       currencies: [
         {
           base: true,
           decimals: 6,
-          name: 'USDC',
           address: '0x3b2d8a1931736fc321c24864bceee981b11c3c57',
           exchangeId: 'usd-coin',
+          name: 'USDC',
         },
         {
           base: false,
           decimals: 18,
-          name: 'GOG',
           address: '0xb8ee289c64c1a0dc0311364721ada8c3180d838c',
           exchangeId: 'guild-of-guardians',
+          name: 'GOG',
         },
         {
           base: false,
           decimals: 18,
-          name: 'ETH',
           address: '0xe9e96d1aad82562b7588f03f49ad34186f996478',
           exchangeId: 'ethereum',
+          name: 'ETH',
         },
       ],
-      currencyConversion: {
+      products: {
+        lab: {
+          pricing: {
+            ETH: {
+              amount: 0.00317,
+              currency: 'ETH',
+              type: 'crypto',
+            },
+            GOG: {
+              amount: 39.84294,
+              currency: 'GOG',
+              type: 'crypto',
+            },
+            USD: {
+              amount: 9.6096,
+              currency: 'USD',
+              type: 'fiat',
+            },
+            USDC: {
+              amount: 9.6,
+              currency: 'USDC',
+              type: 'crypto',
+            },
+          },
+          productId: 'lab',
+          quantity: 1,
+        },
+      },
+      totalAmount: {
         ETH: {
-          amount: 0.000284,
-          name: 'ETH',
-          type: SignPaymentTypes.CRYPTO,
+          amount: 0.00317,
+          currency: 'ETH',
+          type: 'crypto',
         },
         GOG: {
-          amount: 6.00203,
-          name: 'GOG',
-          type: SignPaymentTypes.CRYPTO,
+          amount: 39.84294,
+          currency: 'GOG',
+          type: 'crypto',
         },
         USD: {
-          amount: 0.999392,
-          name: 'USD',
-          type: SignPaymentTypes.FIAT,
+          amount: 9.6096,
+          currency: 'USD',
+          type: 'fiat',
         },
         USDC: {
-          amount: 1,
-          name: 'USDC',
-          type: SignPaymentTypes.CRYPTO,
+          amount: 9.6,
+          currency: 'USDC',
+          type: 'crypto',
         },
       },
     };

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToOrderQuote.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToOrderQuote.test.ts
@@ -1,14 +1,16 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { ClientConfig } from '../types';
+import { OrderQuote } from '../types';
 import {
-  ClientConfigApiResponse,
-  transformToClientConfig,
-} from './transformToClientConfig';
+  OrderQuoteApiResponse,
+  transformToOrderQuote,
+} from './transformToOrderQuote';
 
-describe('transformToClientConfig', () => {
+describe('transformToOrderQuote', () => {
   it('should return input object with camel case keys', () => {
-    const fromClientConfig: ClientConfigApiResponse = {
-      contract_id: '',
+    const from: OrderQuoteApiResponse = {
+      config: {
+        contract_id: '',
+      },
       currencies: [
         {
           base: true,
@@ -84,8 +86,10 @@ describe('transformToClientConfig', () => {
       },
     };
 
-    const toClientConfig: ClientConfig = {
-      contractId: '',
+    const expected: OrderQuote = {
+      config: {
+        contractId: '',
+      },
       currencies: [
         {
           base: true,
@@ -161,8 +165,6 @@ describe('transformToClientConfig', () => {
       },
     };
 
-    expect(transformToClientConfig(fromClientConfig)).toStrictEqual(
-      toClientConfig,
-    );
+    expect(transformToOrderQuote(from)).toStrictEqual(expected);
   });
 });

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToOrderQuote.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToOrderQuote.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {
-  ClientConfig,
-} from '../types';
+import { OrderQuote } from '../types';
 
-export type ClientConfigApiResponse = {
-  contract_id: string;
+export type OrderQuoteApiResponse = {
+  config: {
+    contract_id: string;
+  },
   currencies: Array<{
     base: boolean
     decimals: number
@@ -28,15 +28,17 @@ export type ClientConfigApiResponse = {
   }>
 };
 
-export const transformToClientConfig = (
+export const transformToOrderQuote = (
   {
-    contract_id,
+    config,
     currencies,
     products,
     total_amount,
-  }: ClientConfigApiResponse,
-): ClientConfig => ({
-  contractId: contract_id,
+  }: OrderQuoteApiResponse,
+): OrderQuote => ({
+  config: {
+    contractId: config.contract_id,
+  },
   currencies: currencies.map(({ erc20_address, exchange_id, ...fields }) => ({
     ...fields,
     address: erc20_address,

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useClientConfig.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useClientConfig.ts
@@ -7,9 +7,10 @@ import {
   ClientConfigResponse,
   transformToClientConfig,
 } from '../functions/transformToClientConfig';
+import { SaleItem } from '@imtbl/checkout-sdk';
 
 type UseClientConfigParams = {
-  amount: string;
+  items: SaleItem[];
   environment: Environment;
   environmentId: string;
 };
@@ -26,10 +27,11 @@ export type ConfigError = {
 };
 
 export const useClientConfig = ({
-  amount,
+  items,
   environment,
   environmentId,
 }: UseClientConfigParams) => {
+  const amount = '0';
   const [selectedCurrency, setSelectedCurrency] = useState<
   ClientConfigCurrency | undefined
   >();

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useFundingBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useFundingBalances.ts
@@ -10,7 +10,7 @@ export const useFundingBalances = () => {
   const fetching = useRef(false);
   const {
     fromTokenAddress,
-    clientConfig,
+    orderQuote,
     provider,
     checkout,
     selectedCurrency,
@@ -30,7 +30,7 @@ export const useFundingBalances = () => {
       !fromTokenAddress
       || !provider
       || !checkout
-      || !clientConfig
+      || !orderQuote
       || !selectedCurrency
     ) return;
 
@@ -43,11 +43,11 @@ export const useFundingBalances = () => {
         const results = await fetchFundingBalances({
           provider,
           checkout,
-          currencies: clientConfig.currencies,
+          currencies: orderQuote.currencies,
           routingOptions: { bridge: false, onRamp: false, swap: true },
           baseCurrency: selectedCurrency,
           getAmountByCurrency: (currency) => {
-            const pricing = getPricingBySymbol(currency.name, clientConfig.totalAmount, cryptoFiatState.conversions);
+            const pricing = getPricingBySymbol(currency.name, orderQuote.totalAmount, cryptoFiatState.conversions);
             return pricing ? pricing.amount.toString() : '';
           },
           getIsGasless: () => (provider.provider as any)?.isPassport || false,

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useFundingBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useFundingBalances.ts
@@ -1,8 +1,10 @@
-import { useRef, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import { TransactionRequirement } from '@imtbl/checkout-sdk';
+import { CryptoFiatContext } from 'context/crypto-fiat-context/CryptoFiatContext';
 import { fetchFundingBalances } from '../functions/fetchFundingBalances';
 import { FundingBalance, FundingBalanceResult } from '../types';
 import { useSaleContext } from '../context/SaleContextProvider';
+import { getPricingBySymbol } from '../utils/pricing';
 
 export const useFundingBalances = () => {
   const fetching = useRef(false);
@@ -13,6 +15,7 @@ export const useFundingBalances = () => {
     checkout,
     selectedCurrency,
   } = useSaleContext();
+  const { cryptoFiatState } = useContext(CryptoFiatContext);
   const [transactionRequirement, setTransactionRequirement] = useState<
   TransactionRequirement | undefined
   >();
@@ -43,9 +46,10 @@ export const useFundingBalances = () => {
           currencies: clientConfig.currencies,
           routingOptions: { bridge: false, onRamp: false, swap: true },
           baseCurrency: selectedCurrency,
-          getAmountByCurrency: (currency) => clientConfig.currencyConversion?.[
-            currency.name.toUpperCase()
-          ]?.amount?.toString(),
+          getAmountByCurrency: (currency) => {
+            const pricing = getPricingBySymbol(currency.name, clientConfig.totalAmount, cryptoFiatState.conversions);
+            return pricing ? pricing.amount.toString() : '';
+          },
           getIsGasless: () => (provider.provider as any)?.isPassport || false,
           onFundingBalance: (foundBalances) => {
             setFundingBalances([...foundBalances]);

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSmartCheckout.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSmartCheckout.ts
@@ -15,7 +15,6 @@ type UseSmartCheckoutInput = {
   checkout: Checkout | undefined;
   provider: Web3Provider | undefined;
   items: SaleItem[];
-  amount: string;
   tokenAddress: string;
 };
 
@@ -23,9 +22,10 @@ export const useSmartCheckout = ({
   checkout,
   provider,
   items,
-  amount,
+  
   tokenAddress,
 }: UseSmartCheckoutInput) => {
+  const amount = '0';
   const [smartCheckoutResult, setSmartCheckoutResult] = useState<
   SmartCheckoutResult | undefined
   >(undefined);

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSmartCheckout.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSmartCheckout.ts
@@ -22,7 +22,6 @@ export const useSmartCheckout = ({
   checkout,
   provider,
   items,
-  
   tokenAddress,
 }: UseSmartCheckoutInput) => {
   const amount = '0';

--- a/packages/checkout/widgets-lib/src/widgets/sale/types.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/types.ts
@@ -97,7 +97,7 @@ export enum SmartCheckoutErrorTypes {
   FRACTIONAL_BALANCE_BLOCKED = 'FRACTIONAL_BALANCE_BLOCKED',
 }
 
-export type ClientConfigCurrency = {
+export type OrderQuoteCurrency = {
   base: boolean;
   decimals: number;
   address: string;
@@ -105,23 +105,25 @@ export type ClientConfigCurrency = {
   name: string;
 };
 
-export type ClientConfigPricing = {
+export type OrderQuotePricing = {
   amount: number;
   currency: string;
   type: string;
 };
 
-export type ClientConfigProduct = {
+export type OrderQuoteProduct = {
   productId: string;
   quantity: number;
-  pricing: Record<string, ClientConfigPricing>;
+  pricing: Record<string, OrderQuotePricing>;
 };
 
-export type ClientConfig = {
-  contractId: string;
-  currencies: Array<ClientConfigCurrency>;
-  products: Record<string, ClientConfigProduct>;
-  totalAmount: Record<string, ClientConfigPricing>;
+export type OrderQuote = {
+  config: {
+    contractId: string;
+  },
+  currencies: Array<OrderQuoteCurrency>;
+  products: Record<string, OrderQuoteProduct>;
+  totalAmount: Record<string, OrderQuotePricing>;
 };
 
 export enum SignPaymentTypes {
@@ -141,6 +143,6 @@ export type SufficientFundingStep = {
 export type FundingBalance = FundingStep | SufficientFundingStep;
 
 export type FundingBalanceResult = {
-  currency: ClientConfigCurrency;
+  currency: OrderQuoteCurrency;
   smartCheckoutResult: SmartCheckoutResult;
 };

--- a/packages/checkout/widgets-lib/src/widgets/sale/types.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/types.ts
@@ -105,20 +105,23 @@ export type ClientConfigCurrency = {
   name: string;
 };
 
-export type CurrencyConversionDetail = {
+export type ClientConfigPricing = {
   amount: number;
-  name: string;
-  type: SignPaymentTypes;
+  currency: string;
+  type: string;
 };
 
-export type ClientConfigCurrencyConversion = {
-  [key: string]: CurrencyConversionDetail;
+export type ClientConfigProduct = {
+  productId: string;
+  quantity: number;
+  pricing: Record<string, ClientConfigPricing>;
 };
 
 export type ClientConfig = {
   contractId: string;
-  currencies: ClientConfigCurrency[];
-  currencyConversion: ClientConfigCurrencyConversion;
+  currencies: Array<ClientConfigCurrency>;
+  products: Record<string, ClientConfigProduct>;
+  totalAmount: Record<string, ClientConfigPricing>;
 };
 
 export enum SignPaymentTypes {

--- a/packages/checkout/widgets-lib/src/widgets/sale/utils/pricing.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/utils/pricing.test.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { getPricingBySymbol } from './pricing';
+
+describe('getPricingBySymbol', () => {
+  const mockPrices = {
+    ETH: {
+      amount: 0.000668,
+      currency: 'ETH',
+      type: 'crypto',
+    },
+    GOG: {
+      amount: 8.45852,
+      currency: 'GOG',
+      type: 'crypto',
+    },
+    USD: {
+      amount: 2,
+      currency: 'USD',
+      type: 'fiat',
+    },
+    USDC: {
+      amount: 2,
+      currency: 'USDC',
+      type: 'crypto',
+    },
+  };
+
+  const mockConversions = new Map([
+    ['eth', 2991.29],
+    ['gog', 0.23619],
+    ['imx', 2.05],
+    ['usdc', 0.999787],
+  ]);
+
+  it('returns undefined if prices is undefined', () => {
+    expect(getPricingBySymbol('eth', undefined, mockConversions)).toBeUndefined();
+  });
+
+  it('returns correct pricing without conversion', () => {
+    expect(getPricingBySymbol('eth', mockPrices, mockConversions)).toEqual({
+      currency: 'ETH',
+      type: 'crypto',
+      amount: 0.000668,
+    });
+  });
+
+  it('returns pricing using an overridden symbol from conversions', () => {
+    expect(getPricingBySymbol('tIMX', mockPrices, mockConversions)).toEqual({
+      currency: 'tIMX',
+      type: 'crypto',
+      amount: mockPrices.USDC.amount * mockConversions.get('imx')!,
+    });
+  });
+
+  it('returns undefined if symbol and override are not found', () => {
+    expect(getPricingBySymbol('xyz', mockPrices, mockConversions)).toBeUndefined();
+  });
+});

--- a/packages/checkout/widgets-lib/src/widgets/sale/utils/pricing.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/utils/pricing.ts
@@ -1,0 +1,36 @@
+import { tokenSymbolNameOverrides } from 'lib/utils';
+import { ClientConfigPricing } from '../types';
+
+export const getPricingBySymbol = (
+  symbol: string,
+  prices: Record<string, ClientConfigPricing> | undefined,
+  conversions: Map<string, number>,
+): ClientConfigPricing | undefined => {
+  if (!prices) {
+    return undefined;
+  }
+
+  const lowerSymbol = symbol.toLowerCase();
+  const lowerSymbolOverride = tokenSymbolNameOverrides[lowerSymbol]?.toLowerCase();
+
+  // try to find pricing from config
+  const pricing = Object.values(prices).find(
+    (p) => [lowerSymbol, lowerSymbolOverride].includes(p.currency.toLowerCase()),
+  );
+
+  if (pricing) {
+    return pricing;
+  }
+
+  // try to compute pricing from USDC conversion
+  const conversion = conversions.get(lowerSymbol) || conversions.get(lowerSymbolOverride);
+  if (conversion && prices.USDC) {
+    return {
+      currency: symbol,
+      type: prices.USDC.type,
+      amount: prices.USDC.amount * conversion,
+    };
+  }
+
+  return undefined;
+};

--- a/packages/checkout/widgets-lib/src/widgets/sale/utils/pricing.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/utils/pricing.ts
@@ -1,11 +1,11 @@
 import { tokenSymbolNameOverrides } from 'lib/utils';
-import { ClientConfigPricing } from '../types';
+import { OrderQuotePricing } from '../types';
 
 export const getPricingBySymbol = (
   symbol: string,
-  prices: Record<string, ClientConfigPricing> | undefined,
+  prices: Record<string, OrderQuotePricing> | undefined,
   conversions: Map<string, number>,
-): ClientConfigPricing | undefined => {
+): OrderQuotePricing | undefined => {
   if (!prices) {
     return undefined;
   }

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -46,6 +46,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
     goBackToPaymentMethods,
     sign,
     selectedCurrency,
+    clientConfig,
   } = useSaleContext();
 
   const { viewDispatch, viewState } = useContext(ViewContext);
@@ -208,6 +209,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       {subView === OrderSummarySubViews.REVIEW_ORDER && (
         <OrderReview
           items={items}
+          pricing={clientConfig.products}
           fundingBalances={fundingBalances}
           conversions={cryptoFiatState.conversions}
           collectionName={collectionName}

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -46,7 +46,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
     goBackToPaymentMethods,
     sign,
     selectedCurrency,
-    clientConfig,
+    orderQuote,
   } = useSaleContext();
 
   const { viewDispatch, viewState } = useContext(ViewContext);
@@ -209,7 +209,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       {subView === OrderSummarySubViews.REVIEW_ORDER && (
         <OrderReview
           items={items}
-          pricing={clientConfig.products}
+          pricing={orderQuote.products}
           fundingBalances={fundingBalances}
           conversions={cryptoFiatState.conversions}
           collectionName={collectionName}

--- a/packages/checkout/widgets-sample-app/src/App.tsx
+++ b/packages/checkout/widgets-sample-app/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
         <div>
           <a
             href={
-              "/sale?amount=1&environmentId=249d9b0b-ee16-4dd5-91ee-96bece3b0473&collectionName=Iguanas&excludePaymentTypes=credit&multicurrency=true"
+              "/sale?environmentId=249d9b0b-ee16-4dd5-91ee-96bece3b0473&collectionName=Iguanas&excludePaymentTypes=credit&multicurrency=true"
             }
           >
             Sale Widget

--- a/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
@@ -40,7 +40,6 @@ const useParams = () => {
   const urlParams = new URLSearchParams(window.location.search);
 
   const login = urlParams.get("login") as string;
-  const amount = urlParams.get("amount") as string;
   const environmentId = urlParams.get("environmentId") as string;
   const collectionName = urlParams.get("collectionName") as string;
   const excludePaymentTypes = urlParams
@@ -51,7 +50,6 @@ const useParams = () => {
 
   return {
     login,
-    amount,
     environmentId,
     collectionName,
     excludePaymentTypes,
@@ -91,7 +89,6 @@ export function SaleUI() {
   const params = useParams();
   const {
     login,
-    amount,
     environmentId,
     collectionName,
     excludePaymentTypes,
@@ -123,32 +120,32 @@ export function SaleUI() {
       factory.create(WidgetType.SALE, {
         config: { theme: WidgetTheme.DARK, multicurrency },
       }),
-    [factory, amount, environmentId, collectionName, defaultItems]
+    [factory,  environmentId, collectionName, defaultItems]
   );
   const bridgeWidget = useMemo(
     () =>
       factory.create(WidgetType.BRIDGE, {
         config: { theme: WidgetTheme.DARK },
       }),
-    [factory, amount, environmentId, collectionName, defaultItems]
+    [factory,  environmentId, collectionName, defaultItems]
   );
   const swapWidget = useMemo(
     () =>
       factory.create(WidgetType.SWAP, { config: { theme: WidgetTheme.DARK } }),
-    [factory, amount, environmentId, collectionName, defaultItems]
+    [factory,  environmentId, collectionName, defaultItems]
   );
   const onrampWidget = useMemo(
     () =>
       factory.create(WidgetType.ONRAMP, {
         config: { theme: WidgetTheme.DARK },
       }),
-    [factory, amount, environmentId, collectionName, defaultItems]
+    [factory,  environmentId, collectionName, defaultItems]
   );
 
   // mount sale widget and subscribe to close event
   useEffect(() => {
     saleWidget.mount("sale", {
-      amount,
+      
       environmentId,
       collectionName,
       items: defaultItems,
@@ -250,7 +247,6 @@ export function SaleUI() {
       <button
         onClick={() =>
           saleWidget.mount("sale", {
-            amount,
             environmentId,
             collectionName,
             items: defaultItems,

--- a/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
@@ -31,9 +31,41 @@ const defaultItems: SaleItem[] = [
     qty: 1,
     name: "Biker Iguana",
     image:
-      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-IsR4OA7a9IStLeQ9cPo75tII.png",
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2024/02/img-Qq0Lek5jO8O9ueAZwDmdAImI-600x600-1.png",
     description: "Biker Iguana",
   },
+  {
+    productId: "lab",
+    qty: 3,
+    name: "Lab Iguana",
+    image:
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-IsR4OA7a9IStLeQ9cPo75tII.png",
+    description: "Lab Iguana",
+  },
+  {
+    productId: "baseball",
+    qty: 2,
+    name: "Baseball Iguana",
+    image:
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-tGcvA5pnoUAA2oNANHpA5CXB.png",
+    description: "Baseball Iguana",
+  },
+  {
+    productId: "firefighter",
+    qty: 1,
+    name: "Fire Fighter Iguana",
+    image:
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-NRXmr7k1jH9kZqXr029CEKt4.png",
+    description: "Fire Fighter Iguana",
+  },
+  {
+    productId: "soccer",
+    qty: 5,
+    name: "Soccer Iguana",
+    image:
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-msXHlIXmyy6IhDaMkP2Dp0HY.png",
+    description: "Soccer Iguana",
+  }
 ];
 
 const useParams = () => {


### PR DESCRIPTION
# Summary
Improve how primary sales widget gets the quote and configurations for an order. Instead of the widget knowing which `amount` needs to be paid, it can now instead pass the items `sku` & `qty` to the `/client-config` service, and it will be able to return a response with by item amounts and total amounts including conversions.

**BREAKING CHANGE:**
Requires customers to implement new [Quotes endpoint](https://docs.immutable.com/docs/zkEVM/products/checkout/widgets/primary-sales/backend/byo#quote-endpoint)

# Screenshots
**Before:**
<img width="430" alt="Screenshot 2024-05-09 at 11 18 29 AM" src="https://github.com/immutable/ts-immutable-sdk/assets/2966156/d8c1e4f3-619b-48f0-8434-e173953d2ab1">

**After: Multi item with correct pricing conversion**
<img width="433" alt="Screenshot 2024-05-08 at 1 39 15 PM" src="https://github.com/immutable/ts-immutable-sdk/assets/2966156/91c8a14f-4e09-434e-bcb9-d6afff1d7a9a">

# Detail and impact of the change
## Added 
- Able to list multiple products multiple currency
- Able to quote a price by having the items sku and qty

## Changed
- No longer required to be initialised with the `amount` param

## Removed
- `amount` param

## Fixed
- Item pricing is display correct in the settlement currency selected by customer
