### PR TITLE
chore: Regenerate interal OpenAPI clients

### DIFF
--- a/packages/internal/generated-clients/src/mr-openapi.json
+++ b/packages/internal/generated-clients/src/mr-openapi.json
@@ -1211,6 +1211,17 @@
             "example": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e"
           },
           {
+            "name": "from_updated_at",
+            "in": "query",
+            "description": "Datetime to use as the oldest updated timestamp",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "2022-08-16T17:43:26.991388Z",
+              "format": "date-time"
+            }
+          },
+          {
             "name": "page_cursor",
             "in": "query",
             "description": "Encoded page cursor to retrieve previous or next page. Use the value returned in the response.",
@@ -1522,6 +1533,20 @@
               "testnet": {
                 "value": "imtbl-zkevm-testnet",
                 "summary": "Immutable zkEVM Public Testnet"
+              }
+            }
+          },
+          {
+            "name": "account_address",
+            "in": "query",
+            "required": false,
+            "description": "List of account addresses to filter by",
+            "schema": {
+              "type": "array",
+              "maxItems": 30,
+              "items": {
+                "type": "string",
+                "example": "0xe9b00a87700f660e46b6f5deaa1232836bcc07d3"
               }
             }
           },
@@ -2918,8 +2943,9 @@
     },
     "/v1/chains/{chain_name}/passport/users/{user_id}/linked-addresses": {
       "get": {
+        "deprecated": true,
         "summary": "Get Ethereum linked addresses for a user",
-        "description": "Get all the Ethereum linked addresses for a user based on its userId",
+        "description": "This API has been deprecated, please use https://docs.immutable.com/zkevm/api/reference/#/operations/getUserInfo instead to get a list of linked addresses.",
         "tags": [
           "passport"
         ],
@@ -3609,12 +3635,18 @@
             "description": "An `uint256` token id as string",
             "type": "string",
             "example": "1"
+          },
+          "amount": {
+            "description": "The amount of tokens exchanged",
+            "type": "string",
+            "example": "1"
           }
         },
         "required": [
           "contract_type",
           "contract_address",
-          "token_id"
+          "token_id",
+          "amount"
         ]
       },
       "ActivityToken": {
@@ -5298,9 +5330,16 @@
           },
           "token_id": {
             "type": "string",
-            "description": "An optional `uint256` token id as string. It is recommended to omit token_id for more efficient minting",
+            "description": "An optional `uint256` token id as string. Required for ERC1155 collections.",
             "example": "1",
             "nullable": true
+          },
+          "amount": {
+            "type": "string",
+            "description": "Optional mount of tokens to mint. Required for ERC1155 collections. ERC712 collections can omit this field or set it to 1",
+            "example": "1",
+            "nullable": true,
+            "minLength": 1
           },
           "metadata": {
             "$ref": "#/components/schemas/NFTMetadataRequest"
@@ -5378,6 +5417,12 @@
             "example": "1",
             "nullable": true,
             "description": "An `uint256` token id as string. Only available when the mint request succeeds"
+          },
+          "amount": {
+            "type": "string",
+            "example": "1",
+            "nullable": true,
+            "description": "An `uint256` amount as string. Only relevant for mint requests on ERC1155 contracts"
           },
           "activity_id": {
             "type": "string",
@@ -6954,7 +6999,7 @@
         "properties": {
           "order_type": {
             "type": "string",
-            "description": "Seaport order type",
+            "description": "Seaport order type. Orders containing ERC721 tokens will need to pass in the order type as FULL_RESTRICTED while orders with ERC1155 tokens will need to pass in the order_type as PARTIAL_RESTRICTED",
             "example": "FULL_RESTRICTED",
             "enum": [
               "FULL_RESTRICTED",
@@ -7031,6 +7076,7 @@
         ]
       },
       "FillStatus": {
+        "description": "The ratio of the order that has been filled, an order that has been fully filled will have the same numerator and denominator values.",
         "type": "object",
         "properties": {
           "numerator": {
@@ -7872,17 +7918,7 @@
             ]
           },
           "sell": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SeaportERC721Item"
-            },
-            "example": [
-              {
-                "type": "NATIVE",
-                "amount": "9750000000000000000",
-                "contract_address": "0x0165878A594ca255338adfa4d48449f69242Eb8F"
-              }
-            ]
+            "$ref": "#/components/schemas/SeaportERC721Item"
           },
           "fees": {
             "type": "array",

--- a/packages/internal/generated-clients/src/multi-rollup/domain/nft-owners-api.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/domain/nft-owners-api.ts
@@ -145,13 +145,14 @@ export const NftOwnersApiAxiosParamCreator = function (configuration?: Configura
          * @summary List owners by contract address
          * @param {string} contractAddress The address of contract
          * @param {string} chainName The name of chain
+         * @param {Array<string>} [accountAddress] List of account addresses to filter by
          * @param {string} [fromUpdatedAt] Datetime to use as the oldest updated timestamp
          * @param {string} [pageCursor] Encoded page cursor to retrieve previous or next page. Use the value returned in the response.
          * @param {number} [pageSize] Maximum number of items to return
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listOwnersByContractAddress: async (contractAddress: string, chainName: string, fromUpdatedAt?: string, pageCursor?: string, pageSize?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listOwnersByContractAddress: async (contractAddress: string, chainName: string, accountAddress?: Array<string>, fromUpdatedAt?: string, pageCursor?: string, pageSize?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'contractAddress' is not null or undefined
             assertParamExists('listOwnersByContractAddress', 'contractAddress', contractAddress)
             // verify required parameter 'chainName' is not null or undefined
@@ -169,6 +170,10 @@ export const NftOwnersApiAxiosParamCreator = function (configuration?: Configura
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            if (accountAddress) {
+                localVarQueryParameter['account_address'] = accountAddress;
+            }
 
             if (fromUpdatedAt !== undefined) {
                 localVarQueryParameter['from_updated_at'] = (fromUpdatedAt as any instanceof Date) ?
@@ -239,14 +244,15 @@ export const NftOwnersApiFp = function(configuration?: Configuration) {
          * @summary List owners by contract address
          * @param {string} contractAddress The address of contract
          * @param {string} chainName The name of chain
+         * @param {Array<string>} [accountAddress] List of account addresses to filter by
          * @param {string} [fromUpdatedAt] Datetime to use as the oldest updated timestamp
          * @param {string} [pageCursor] Encoded page cursor to retrieve previous or next page. Use the value returned in the response.
          * @param {number} [pageSize] Maximum number of items to return
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listOwnersByContractAddress(contractAddress: string, chainName: string, fromUpdatedAt?: string, pageCursor?: string, pageSize?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ListCollectionOwnersResult>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listOwnersByContractAddress(contractAddress, chainName, fromUpdatedAt, pageCursor, pageSize, options);
+        async listOwnersByContractAddress(contractAddress: string, chainName: string, accountAddress?: Array<string>, fromUpdatedAt?: string, pageCursor?: string, pageSize?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ListCollectionOwnersResult>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listOwnersByContractAddress(contractAddress, chainName, accountAddress, fromUpdatedAt, pageCursor, pageSize, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -287,7 +293,7 @@ export const NftOwnersApiFactory = function (configuration?: Configuration, base
          * @throws {RequiredError}
          */
         listOwnersByContractAddress(requestParameters: NftOwnersApiListOwnersByContractAddressRequest, options?: AxiosRequestConfig): AxiosPromise<ListCollectionOwnersResult> {
-            return localVarFp.listOwnersByContractAddress(requestParameters.contractAddress, requestParameters.chainName, requestParameters.fromUpdatedAt, requestParameters.pageCursor, requestParameters.pageSize, options).then((request) => request(axios, basePath));
+            return localVarFp.listOwnersByContractAddress(requestParameters.contractAddress, requestParameters.chainName, requestParameters.accountAddress, requestParameters.fromUpdatedAt, requestParameters.pageCursor, requestParameters.pageSize, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -390,6 +396,13 @@ export interface NftOwnersApiListOwnersByContractAddressRequest {
     readonly chainName: string
 
     /**
+     * List of account addresses to filter by
+     * @type {Array<string>}
+     * @memberof NftOwnersApiListOwnersByContractAddress
+     */
+    readonly accountAddress?: Array<string>
+
+    /**
      * Datetime to use as the oldest updated timestamp
      * @type {string}
      * @memberof NftOwnersApiListOwnersByContractAddress
@@ -451,7 +464,7 @@ export class NftOwnersApi extends BaseAPI {
      * @memberof NftOwnersApi
      */
     public listOwnersByContractAddress(requestParameters: NftOwnersApiListOwnersByContractAddressRequest, options?: AxiosRequestConfig) {
-        return NftOwnersApiFp(this.configuration).listOwnersByContractAddress(requestParameters.contractAddress, requestParameters.chainName, requestParameters.fromUpdatedAt, requestParameters.pageCursor, requestParameters.pageSize, options).then((request) => request(this.axios, this.basePath));
+        return NftOwnersApiFp(this.configuration).listOwnersByContractAddress(requestParameters.contractAddress, requestParameters.chainName, requestParameters.accountAddress, requestParameters.fromUpdatedAt, requestParameters.pageCursor, requestParameters.pageSize, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/packages/internal/generated-clients/src/multi-rollup/domain/nfts-api.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/domain/nfts-api.ts
@@ -362,12 +362,13 @@ export const NftsApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {string} accountAddress Account address
          * @param {string} chainName The name of chain
          * @param {string} [contractAddress] The address of contract
+         * @param {string} [fromUpdatedAt] Datetime to use as the oldest updated timestamp
          * @param {string} [pageCursor] Encoded page cursor to retrieve previous or next page. Use the value returned in the response.
          * @param {number} [pageSize] Maximum number of items to return
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listNFTsByAccountAddress: async (accountAddress: string, chainName: string, contractAddress?: string, pageCursor?: string, pageSize?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listNFTsByAccountAddress: async (accountAddress: string, chainName: string, contractAddress?: string, fromUpdatedAt?: string, pageCursor?: string, pageSize?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'accountAddress' is not null or undefined
             assertParamExists('listNFTsByAccountAddress', 'accountAddress', accountAddress)
             // verify required parameter 'chainName' is not null or undefined
@@ -388,6 +389,12 @@ export const NftsApiAxiosParamCreator = function (configuration?: Configuration)
 
             if (contractAddress !== undefined) {
                 localVarQueryParameter['contract_address'] = contractAddress;
+            }
+
+            if (fromUpdatedAt !== undefined) {
+                localVarQueryParameter['from_updated_at'] = (fromUpdatedAt as any instanceof Date) ?
+                    (fromUpdatedAt as any).toISOString() :
+                    fromUpdatedAt;
             }
 
             if (pageCursor !== undefined) {
@@ -509,13 +516,14 @@ export const NftsApiFp = function(configuration?: Configuration) {
          * @param {string} accountAddress Account address
          * @param {string} chainName The name of chain
          * @param {string} [contractAddress] The address of contract
+         * @param {string} [fromUpdatedAt] Datetime to use as the oldest updated timestamp
          * @param {string} [pageCursor] Encoded page cursor to retrieve previous or next page. Use the value returned in the response.
          * @param {number} [pageSize] Maximum number of items to return
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listNFTsByAccountAddress(accountAddress: string, chainName: string, contractAddress?: string, pageCursor?: string, pageSize?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ListNFTsByOwnerResult>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listNFTsByAccountAddress(accountAddress, chainName, contractAddress, pageCursor, pageSize, options);
+        async listNFTsByAccountAddress(accountAddress: string, chainName: string, contractAddress?: string, fromUpdatedAt?: string, pageCursor?: string, pageSize?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ListNFTsByOwnerResult>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listNFTsByAccountAddress(accountAddress, chainName, contractAddress, fromUpdatedAt, pageCursor, pageSize, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -596,7 +604,7 @@ export const NftsApiFactory = function (configuration?: Configuration, basePath?
          * @throws {RequiredError}
          */
         listNFTsByAccountAddress(requestParameters: NftsApiListNFTsByAccountAddressRequest, options?: AxiosRequestConfig): AxiosPromise<ListNFTsByOwnerResult> {
-            return localVarFp.listNFTsByAccountAddress(requestParameters.accountAddress, requestParameters.chainName, requestParameters.contractAddress, requestParameters.pageCursor, requestParameters.pageSize, options).then((request) => request(axios, basePath));
+            return localVarFp.listNFTsByAccountAddress(requestParameters.accountAddress, requestParameters.chainName, requestParameters.contractAddress, requestParameters.fromUpdatedAt, requestParameters.pageCursor, requestParameters.pageSize, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -839,6 +847,13 @@ export interface NftsApiListNFTsByAccountAddressRequest {
     readonly contractAddress?: string
 
     /**
+     * Datetime to use as the oldest updated timestamp
+     * @type {string}
+     * @memberof NftsApiListNFTsByAccountAddress
+     */
+    readonly fromUpdatedAt?: string
+
+    /**
      * Encoded page cursor to retrieve previous or next page. Use the value returned in the response.
      * @type {string}
      * @memberof NftsApiListNFTsByAccountAddress
@@ -941,7 +956,7 @@ export class NftsApi extends BaseAPI {
      * @memberof NftsApi
      */
     public listNFTsByAccountAddress(requestParameters: NftsApiListNFTsByAccountAddressRequest, options?: AxiosRequestConfig) {
-        return NftsApiFp(this.configuration).listNFTsByAccountAddress(requestParameters.accountAddress, requestParameters.chainName, requestParameters.contractAddress, requestParameters.pageCursor, requestParameters.pageSize, options).then((request) => request(this.axios, this.basePath));
+        return NftsApiFp(this.configuration).listNFTsByAccountAddress(requestParameters.accountAddress, requestParameters.chainName, requestParameters.contractAddress, requestParameters.fromUpdatedAt, requestParameters.pageCursor, requestParameters.pageSize, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/packages/internal/generated-clients/src/multi-rollup/domain/passport-api.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/domain/passport-api.ts
@@ -102,11 +102,12 @@ export const PassportApiAxiosParamCreator = function (configuration?: Configurat
             };
         },
         /**
-         * Get all the Ethereum linked addresses for a user based on its userId
+         * This API has been deprecated, please use https://docs.immutable.com/zkevm/api/reference/#/operations/getUserInfo instead to get a list of linked addresses.
          * @summary Get Ethereum linked addresses for a user
          * @param {string} userId The user\&#39;s userId
          * @param {string} chainName 
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         getLinkedAddresses: async (userId: string, chainName: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
@@ -293,11 +294,12 @@ export const PassportApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * Get all the Ethereum linked addresses for a user based on its userId
+         * This API has been deprecated, please use https://docs.immutable.com/zkevm/api/reference/#/operations/getUserInfo instead to get a list of linked addresses.
          * @summary Get Ethereum linked addresses for a user
          * @param {string} userId The user\&#39;s userId
          * @param {string} chainName 
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         async getLinkedAddresses(userId: string, chainName: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetLinkedAddressesRes>> {
@@ -361,10 +363,11 @@ export const PassportApiFactory = function (configuration?: Configuration, baseP
             return localVarFp.createCounterfactualAddressV2(requestParameters.chainName, requestParameters.createCounterfactualAddressRequest, options).then((request) => request(axios, basePath));
         },
         /**
-         * Get all the Ethereum linked addresses for a user based on its userId
+         * This API has been deprecated, please use https://docs.immutable.com/zkevm/api/reference/#/operations/getUserInfo instead to get a list of linked addresses.
          * @summary Get Ethereum linked addresses for a user
          * @param {PassportApiGetLinkedAddressesRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         getLinkedAddresses(requestParameters: PassportApiGetLinkedAddressesRequest, options?: AxiosRequestConfig): AxiosPromise<GetLinkedAddressesRes> {
@@ -522,10 +525,11 @@ export class PassportApi extends BaseAPI {
     }
 
     /**
-     * Get all the Ethereum linked addresses for a user based on its userId
+     * This API has been deprecated, please use https://docs.immutable.com/zkevm/api/reference/#/operations/getUserInfo instead to get a list of linked addresses.
      * @summary Get Ethereum linked addresses for a user
      * @param {PassportApiGetLinkedAddressesRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      * @memberof PassportApi
      */

--- a/packages/internal/generated-clients/src/multi-rollup/models/activity-nft.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/activity-nft.ts
@@ -41,6 +41,12 @@ export interface ActivityNFT {
      * @memberof ActivityNFT
      */
     'token_id': string;
+    /**
+     * The amount of tokens exchanged
+     * @type {string}
+     * @memberof ActivityNFT
+     */
+    'amount': string;
 }
 
 

--- a/packages/internal/generated-clients/src/multi-rollup/models/fill-status.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/fill-status.ts
@@ -15,7 +15,7 @@
 
 
 /**
- * 
+ * The ratio of the order that has been filled, an order that has been fully filled will have the same numerator and denominator values.
  * @export
  * @interface FillStatus
  */

--- a/packages/internal/generated-clients/src/multi-rollup/models/get-mint-request-result.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/get-mint-request-result.ts
@@ -60,6 +60,12 @@ export interface GetMintRequestResult {
      */
     'token_id': string | null;
     /**
+     * An `uint256` amount as string. Only relevant for mint requests on ERC1155 contracts
+     * @type {string}
+     * @memberof GetMintRequestResult
+     */
+    'amount'?: string | null;
+    /**
      * The id of the mint activity associated with this mint request
      * @type {string}
      * @memberof GetMintRequestResult

--- a/packages/internal/generated-clients/src/multi-rollup/models/mint-asset.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/mint-asset.ts
@@ -36,11 +36,17 @@ export interface MintAsset {
      */
     'owner_address': string;
     /**
-     * An optional `uint256` token id as string. It is recommended to omit token_id for more efficient minting
+     * An optional `uint256` token id as string. Required for ERC1155 collections.
      * @type {string}
      * @memberof MintAsset
      */
     'token_id'?: string | null;
+    /**
+     * Optional mount of tokens to mint. Required for ERC1155 collections. ERC712 collections can omit this field or set it to 1
+     * @type {string}
+     * @memberof MintAsset
+     */
+    'amount'?: string | null;
     /**
      * 
      * @type {NFTMetadataRequest}

--- a/packages/internal/generated-clients/src/multi-rollup/models/protocol-data.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/protocol-data.ts
@@ -21,7 +21,7 @@
  */
 export interface ProtocolData {
     /**
-     * Seaport order type
+     * Seaport order type. Orders containing ERC721 tokens will need to pass in the order type as FULL_RESTRICTED while orders with ERC1155 tokens will need to pass in the order_type as PARTIAL_RESTRICTED
      * @type {string}
      * @memberof ProtocolData
      */

--- a/packages/internal/generated-clients/src/multi-rollup/models/seaport-create-listing-metadata.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/seaport-create-listing-metadata.ts
@@ -43,10 +43,10 @@ export interface SeaportCreateListingMetadata {
     'buy': SeaportCreateListingMetadataBuy;
     /**
      * 
-     * @type {Array<SeaportERC721Item>}
+     * @type {SeaportERC721Item}
      * @memberof SeaportCreateListingMetadata
      */
-    'sell': Array<SeaportERC721Item>;
+    'sell': SeaportERC721Item;
     /**
      * 
      * @type {Array<SeaportFee>}


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Regenerate internal OpenAPI clients to be in sync with current production API

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->
- Added `from_updated_at` filter to `ListNFTsByAccountAddress`
- Added `account_address` filter to `ListOwnersByContractAddress`
- Added `amount` field to Sale Activity return type for sales involving ERC1155 tokens
- Added `amount` to `CreateMintRequest` and `ListMintRequest` to support minting on ERC1155 colllections

## Changed
<!-- Section for changes in existing functionality. -->
- `SeaportCreateListingMetadata` only accepts a single sell item instead of an array

## Deprecated
- `getLinkedAddresses` in `passport` package is marked is now deprecated


