### PR TITLE
fix: Coin logos not loading in the Balance Widget

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.tsx
@@ -5,6 +5,8 @@ import {
 import {
   IMTBLWidgetEvents, TokenFilterTypes, TokenInfo, WidgetTheme,
 } from '@imtbl/checkout-sdk';
+import { IMAGE_RESIZER_URL } from 'lib';
+import { Environment } from '@imtbl/config';
 import { ShowMenuItem } from './BalanceItemStyles';
 import { BalanceInfo } from '../../functions/tokenBalances';
 import { WalletContext } from '../../context/WalletContext';
@@ -44,6 +46,7 @@ export function BalanceItem({
   );
 
   const isPassport = isPassportProvider(provider);
+  const environment = checkout?.config.environment ?? Environment.PRODUCTION;
 
   useEffect(() => {
     const getOnRampAllowedTokens = async () => {
@@ -89,8 +92,9 @@ export function BalanceItem({
   return (
     <MenuItem testId={`balance-item-${balanceInfo.symbol}`} emphasized>
       <MenuItem.FramedImage
+        imageResizeServiceUrl={IMAGE_RESIZER_URL[environment]}
         imageUrl={balanceInfo.icon}
-        defaultImageUrl={getDefaultTokenImage(checkout?.config.environment, theme)}
+        defaultImageUrl={getDefaultTokenImage(environment, theme)}
         circularFrame
       />
       <MenuItem.Label>{balanceInfo.symbol}</MenuItem.Label>


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

`MenuItem.FramedImage` uses `CloudImage` under the hood, so you need to pass the `imageResizeServiceUrl` to it in order for the image to load in sandbox and prod.

There are other instances of `MenuItem.FramedImage` that needs this fix, but this PR fixes the known occurrence of this in the Gems Game.

![Screenshot 2024-05-09 at 1 21 21 PM](https://github.com/immutable/ts-immutable-sdk/assets/101608096/13295339-a4a0-42ae-bfb0-f3121821b199)

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
