### PR TITLE
feat: [CM-632][Sale Widget] Add configuration flat to enable/disable transaction finality confirmation

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/configurations/sale.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/configurations/sale.ts
@@ -5,4 +5,5 @@ import { WidgetConfiguration } from './widget';
  */
 export type SaleWidgetConfiguration = {
   multicurrency?: boolean;
+  waitFulfillmentSettlements?: boolean;
 } & WidgetConfiguration;

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -48,7 +48,7 @@ Omit<SaleWidgetParams, 'walletProviderName'>
 type WidgetParams = RequiredWidgetParams &
 OptionalWidgetParams & {
   multicurrency: boolean;
-  waitForFulfillmentSettlements: boolean;
+  waitFulfillmentSettlements: boolean;
 };
 export interface SaleWidgetProps extends WidgetParams {
   config: StrongCheckoutWidgetsConfig;
@@ -64,7 +64,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
     collectionName,
     excludePaymentTypes,
     multicurrency = false,
-    waitForFulfillmentSettlements = false,
+    waitFulfillmentSettlements = true,
   } = props;
   const { connectLoaderState } = useContext(ConnectLoaderContext);
   const { checkout, provider } = connectLoaderState;
@@ -130,7 +130,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
           collectionName,
           excludePaymentTypes,
           multicurrency,
-          waitForFulfillmentSettlements,
+          waitFulfillmentSettlements,
         }}
       >
         <CryptoFiatProvider environment={config.environment}>

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -48,6 +48,7 @@ Omit<SaleWidgetParams, 'walletProviderName'>
 type WidgetParams = RequiredWidgetParams &
 OptionalWidgetParams & {
   multicurrency: boolean;
+  waitForFulfillmentSettlements: boolean;
 };
 export interface SaleWidgetProps extends WidgetParams {
   config: StrongCheckoutWidgetsConfig;
@@ -63,6 +64,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
     collectionName,
     excludePaymentTypes,
     multicurrency = false,
+    waitForFulfillmentSettlements = false,
   } = props;
   const { connectLoaderState } = useContext(ConnectLoaderContext);
   const { checkout, provider } = connectLoaderState;
@@ -128,6 +130,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
           collectionName,
           excludePaymentTypes,
           multicurrency,
+          waitForFulfillmentSettlements,
         }}
       >
         <CryptoFiatProvider environment={config.environment}>

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
@@ -132,6 +132,7 @@ export class Sale extends Base<WidgetType.SALE> {
                   excludePaymentTypes={this.parameters.excludePaymentTypes!}
                   language="en"
                   multicurrency={!!this.properties?.config?.multicurrency}
+                  waitForFulfillmentSettlements={!!this.properties?.config?.waitFulfillmentSettlements}
                 />
               </Suspense>
             </ConnectLoader>

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
@@ -88,7 +88,9 @@ export class Sale extends Base<WidgetType.SALE> {
       validatedParams.collectionName = '';
     }
 
-    if (params.excludePaymentTypes !== undefined && !Array.isArray(params.excludePaymentTypes)) {
+    if (
+      params.excludePaymentTypes !== undefined && !Array.isArray(params.excludePaymentTypes)
+    ) {
       // eslint-disable-next-line no-console
       console.warn('[IMTBL]: invalid "excludePaymentTypes" widget input');
       validatedParams.excludePaymentTypes = [];
@@ -122,7 +124,11 @@ export class Sale extends Base<WidgetType.SALE> {
                 sendSaleWidgetCloseEvent(window);
               }}
             >
-              <Suspense fallback={<LoadingView loadingText={t('views.LOADING_VIEW.text')} />}>
+              <Suspense
+                fallback={
+                  <LoadingView loadingText={t('views.LOADING_VIEW.text')} />
+                }
+              >
                 <SaleWidget
                   config={config}
                   amount={this.parameters.amount!}
@@ -132,7 +138,9 @@ export class Sale extends Base<WidgetType.SALE> {
                   excludePaymentTypes={this.parameters.excludePaymentTypes!}
                   language="en"
                   multicurrency={!!this.properties?.config?.multicurrency}
-                  waitForFulfillmentSettlements={!!this.properties?.config?.waitFulfillmentSettlements}
+                  waitFulfillmentSettlements={
+                    !!this.properties?.config?.waitFulfillmentSettlements
+                  }
                 />
               </Suspense>
             </ConnectLoader>

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
@@ -138,9 +138,7 @@ export class Sale extends Base<WidgetType.SALE> {
                   excludePaymentTypes={this.parameters.excludePaymentTypes!}
                   language="en"
                   multicurrency={!!this.properties?.config?.multicurrency}
-                  waitFulfillmentSettlements={
-                    !!this.properties?.config?.waitFulfillmentSettlements
-                  }
+                  waitFulfillmentSettlements={this.properties?.config?.waitFulfillmentSettlements ?? true}
                 />
               </Suspense>
             </ConnectLoader>

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -54,6 +54,7 @@ type SaleContextProps = {
   passport?: Passport;
   excludePaymentTypes: SalePaymentTypes[];
   multicurrency: boolean;
+  waitForFulfillmentSettlements: boolean;
 };
 
 type SaleContextValues = SaleContextProps & {
@@ -136,6 +137,7 @@ const SaleContext = createContext<SaleContextValues>({
   excludePaymentTypes: [],
   multicurrency: false,
   selectedCurrency: undefined,
+  waitForFulfillmentSettlements: false,
 });
 
 SaleContext.displayName = 'SaleSaleContext';
@@ -161,6 +163,7 @@ export function SaleContextProvider(props: {
       collectionName,
       excludePaymentTypes,
       multicurrency,
+      waitForFulfillmentSettlements,
     },
   } = props;
 
@@ -428,6 +431,7 @@ export function SaleContextProvider(props: {
       excludePaymentTypes,
       multicurrency,
       selectedCurrency,
+      waitForFulfillmentSettlements,
     }),
     [
       config,
@@ -462,6 +466,7 @@ export function SaleContextProvider(props: {
       excludePaymentTypes,
       multicurrency,
       selectedCurrency,
+      waitForFulfillmentSettlements,
     ],
   );
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -136,7 +136,7 @@ const SaleContext = createContext<SaleContextValues>({
   excludePaymentTypes: [],
   multicurrency: false,
   selectedCurrency: undefined,
-  waitFulfillmentSettlements: false,
+  waitFulfillmentSettlements: true,
 });
 
 SaleContext.displayName = 'SaleSaleContext';

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -54,7 +54,7 @@ type SaleContextProps = {
   passport?: Passport;
   excludePaymentTypes: SalePaymentTypes[];
   multicurrency: boolean;
-  waitForFulfillmentSettlements: boolean;
+  waitFulfillmentSettlements: boolean;
 };
 
 type SaleContextValues = SaleContextProps & {
@@ -65,7 +65,6 @@ type SaleContextValues = SaleContextProps & {
   ) => Promise<SignResponse | undefined>;
   execute: (
     signResponse: SignResponse | undefined,
-    waitForTrnsactionSettlement: boolean,
     onTxnSuccess: (txn: ExecutedTransaction) => void,
     onTxnError: (error: any, txns: ExecutedTransaction[]) => void
   ) => Promise<ExecutedTransaction[]>;
@@ -137,7 +136,7 @@ const SaleContext = createContext<SaleContextValues>({
   excludePaymentTypes: [],
   multicurrency: false,
   selectedCurrency: undefined,
-  waitForFulfillmentSettlements: false,
+  waitFulfillmentSettlements: false,
 });
 
 SaleContext.displayName = 'SaleSaleContext';
@@ -163,7 +162,7 @@ export function SaleContextProvider(props: {
       collectionName,
       excludePaymentTypes,
       multicurrency,
-      waitForFulfillmentSettlements,
+      waitFulfillmentSettlements,
     },
   } = props;
 
@@ -255,6 +254,7 @@ export function SaleContextProvider(props: {
     recipientAddress,
     environmentId,
     environment,
+    waitFulfillmentSettlements,
   });
 
   const sign = useCallback(
@@ -431,7 +431,7 @@ export function SaleContextProvider(props: {
       excludePaymentTypes,
       multicurrency,
       selectedCurrency,
-      waitForFulfillmentSettlements,
+      waitFulfillmentSettlements,
     }),
     [
       config,
@@ -466,7 +466,7 @@ export function SaleContextProvider(props: {
       excludePaymentTypes,
       multicurrency,
       selectedCurrency,
-      waitForFulfillmentSettlements,
+      waitFulfillmentSettlements,
     ],
   );
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
@@ -152,7 +152,7 @@ const toSignResponse = (
 
 export const useSignOrder = (input: SignOrderInput) => {
   const {
-    provider, items, environment, environmentId,
+    provider, items, environment, environmentId, waitFulfillmentSettlements,
   } = input;
   const [signError, setSignError] = useState<SignOrderError | undefined>(
     undefined,
@@ -186,7 +186,6 @@ export const useSignOrder = (input: SignOrderInput) => {
       data: string,
       gasLimit: number,
       method: string,
-      waitForTrnsactionSettlement: boolean,
     ): Promise<[hash: string | undefined, error: any]> => {
       let transactionHash: string | undefined;
 
@@ -202,7 +201,7 @@ export const useSignOrder = (input: SignOrderInput) => {
 
         setExecuteTransactions({ method, hash: txnResponse?.hash });
 
-        if (waitForTrnsactionSettlement) {
+        if (waitFulfillmentSettlements) {
           await txnResponse?.wait();
         }
 
@@ -326,7 +325,6 @@ export const useSignOrder = (input: SignOrderInput) => {
 
   const execute = async (
     signData: SignResponse | undefined,
-    waitForTrnsactionSettlement: boolean,
     onTxnSuccess: (txn: ExecutedTransaction) => void,
     onTxnError: (error: any, txns: ExecutedTransaction[]) => void,
   ): Promise<ExecutedTransaction[]> => {
@@ -360,7 +358,6 @@ export const useSignOrder = (input: SignOrderInput) => {
         data,
         gasEstimate,
         method,
-        waitForTrnsactionSettlement,
       );
 
       if (txnError || !hash) {

--- a/packages/checkout/widgets-lib/src/widgets/sale/types.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/types.ts
@@ -52,6 +52,7 @@ export type SignOrderInput = {
   recipientAddress: string;
   environment: string;
   environmentId: string;
+  waitFulfillmentSettlements: boolean;
 };
 
 export type SignOrderError = {

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
@@ -16,7 +16,7 @@ export function PayWithCoins() {
     sendSuccessEvent,
   } = useSaleEvent();
   const {
-    execute, signResponse, executeResponse, signTokenIds, provider,
+    execute, signResponse, executeResponse, signTokenIds,
   } = useSaleContext();
   const executedTxns = executeResponse?.transactions.length || 0;
 
@@ -35,10 +35,8 @@ export function PayWithCoins() {
   }
 
   const sendTransaction = async () => {
-    const waitForTrnsactionSettlement = !('isMetaMask' in (provider?.provider as any) && provider?.provider.isMetaMask);
     execute(
       signResponse,
-      waitForTrnsactionSettlement,
       (txn) => {
         sendTransactionSuccessEvent(txn); // not an analytics event
       },


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

## Added 
<!-- Section for new features. -->
Added `waitFulfillmentSettlements` to sale widget config to enable/disable wait for transaction settlement. `true` by default.


