### PR TITLE
chore: [DX-2802] fix failing publish docs workflow

### DIFF
--- a/.github/scripts/update-docs-link.sh
+++ b/.github/scripts/update-docs-link.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 set -x
@@ -25,8 +25,6 @@ fi
       sed -i -E "s/SDK_VERSION = '.*'/SDK_VERSION = '$VERSION'/g;" $FILE
   fi
 
-  # Update versions in the browserBundle docs (https://docs.immutable.com/docs/x/sdks/typescript/#browser-bundle)
-  FILE=docs/main/sdks/_typescript.mdx
   major=$(echo $VERSION | awk '{ 
     split($0, a, ".");
     print a[1];
@@ -40,45 +38,53 @@ fi
     print a[3];
   }')
   echo "major: $major minor: $minor patch: $patch"
+  # Update versions in the browserBundle docs (https://docs.immutable.com/docs/x/sdks/typescript/#browser-bundle)
+  FILES=(
+    docs/main/zkEVM/sdks/typescript/_zkevmtypescript.mdx
+    docs/main/sdks/typescript/_starkextypescript.mdx
+  )
+  for FILE in "${FILES[@]}"
+  do
+    if [ "$(uname)" == "Darwin" ]; then
+        # Be careful modifying the regexs below.
+        # They have been adapted from the numbered capture group version on the semver website:
+        # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        # If you do modify them, please update the regex101 links in the comments to reflect the changes.
 
-  # On Mac OS, sed requires an empty string as an argument to -i to avoid creating a backup file
-  # sed -i '' -E ...
-  # vs on Linux:
-  # sed -i -E ...
+        # `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1` -> `https://cdn.jsdelivr.net/npm/@imtbl/sdk@2` 
+        # See https://regex101.com/r/OyHYf7/1 for a breakdown of the regex matches
+        sed -i '' -E "s/@imtbl\/sdk@(0|[1-9][0-9]*)/@imtbl\/sdk@$major/g;" $FILE
+        
+        # `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.23` -> `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.24` 
+        # See https://regex101.com/r/RrmTTi/1 for a breakdown of the regex matches
+        sed -i '' -E "s/@imtbl\/sdk@(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)/@imtbl\/sdk@$major.$minor/g;" $FILE
 
-  if [ "$(uname)" == "Darwin" ]; then
-      # Be careful modifying the regexs below.
-      # They have been adapted from the numbered capture group version on the semver website:
-      # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-      # If you do modify them, please update the regex101 links in the comments to reflect the changes.
+        # `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.23.4` -> `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.24.5` 
+        # See https://regex101.com/r/9QZ9JD/1 for a breakdown of the regex matches
+        sed -i '' -E "s/@imtbl\/sdk@(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(.*)/@imtbl\/sdk@$VERSION/g;" $FILE
 
-      # See https://regex101.com/r/FBpHw4/1 for a breakdown of the regex matches
-      sed -i '' -E "s/sdk@(0|[1-9]\d*)\`/sdk@$major\`/g;" $FILE
-      
-      # See https://regex101.com/r/jZeWrd/1 for a breakdown of the regex matches
-      sed -i '' -E "s/sdk@(0|[1-9]\d*)\.(0|[1-9]\d*)\`/sdk@$major.$minor\`/g;" $FILE
+        # See https://regex101.com/r/C3FDZv/1 for a breakdown of the regex matches
+        sed -i '' -E "s/e\.g\. (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(.*)\)/e.g. $VERSION\)/g;" $FILE
+    else
+        # Be careful modifying the regexs below.
+        # They have been adapted from the numbered capture group version on the semver website:
+        # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        # If you do modify them, please update the regex101 links in the comments to reflect the changes.
 
-      # See https://regex101.com/r/2RWnGP/1 for a breakdown of the regex matches
-      sed -i '' -E "s/sdk@(0|[1-9]\d*)\.(0|[1-9]\d*)\.(.*)\`/sdk@$VERSION\`/g;" $FILE
+        # `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1` -> `https://cdn.jsdelivr.net/npm/@imtbl/sdk@2` 
+        # See https://regex101.com/r/OyHYf7/1 for a breakdown of the regex matches
+        sed -i -E "s/@imtbl\/sdk@(0|[1-9][0-9]*)/@imtbl\/sdk@$major/g;" $FILE
+        
+        # `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.23` -> `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.24` 
+        # See https://regex101.com/r/RrmTTi/1 for a breakdown of the regex matches
+        sed -i -E "s/@imtbl\/sdk@(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)/@imtbl\/sdk@$major.$minor/g;" $FILE
 
-      # See https://regex101.com/r/Gep6h6/1 for a breakdown of the regex matches
-      sed -i '' -E "s/e\.g\. (0|[1-9]\d*)\.(0|[1-9]\d*)\.(.*)\)/e.g. $VERSION\)/g;" $FILE
-  else
-      # Be careful modifying the regexs below.
-      # They have been adapted from the numbered capture group version on the semver website:
-      # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-      # If you do modify them, please update the regex101 links in the comments to reflect the changes.
+        # `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.23.4` -> `https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.24.5` 
+        # See https://regex101.com/r/9QZ9JD/1 for a breakdown of the regex matches
+        sed -i -E "s/@imtbl\/sdk@(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(.*)/@imtbl\/sdk@$VERSION/g;" $FILE
 
-      # See https://regex101.com/r/FBpHw4/1 for a breakdown of the regex matches
-      sed -i -E "s/sdk@(0|[1-9]\d*)\`/sdk@$major\`/g;" $FILE
-      
-      # See https://regex101.com/r/jZeWrd/1 for a breakdown of the regex matches
-      sed -i -E "s/sdk@(0|[1-9]\d*)\.(0|[1-9]\d*)\`/sdk@$major.$minor\`/g;" $FILE
-
-      # See https://regex101.com/r/2RWnGP/1 for a breakdown of the regex matches
-      sed -i -E "s/sdk@(0|[1-9]\d*)\.(0|[1-9]\d*)\.(.*)\`/sdk@$VERSION\`/g;" $FILE
-
-      # See https://regex101.com/r/Gep6h6/1 for a breakdown of the regex matches
-      sed -i -E "s/e\.g\. (0|[1-9]\d*)\.(0|[1-9]\d*)\.(.*)\)/e.g. $VERSION\)/g;" $FILE
-  fi
+        # See https://regex101.com/r/C3FDZv/1 for a breakdown of the regex matches
+        sed -i -E "s/e\.g\. (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(.*)\)/e.g. $VERSION\)/g;" $FILE
+    fi
+  done
 )


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
Fix the reference workflow failing. Broken by https://github.com/immutable/docs/pull/928

# Anything else worth calling out?
No code changes. Just CI. 