### PR TITLE
feat: ID-1674 allow L2 token transfers via Checkout bridge widget

### DIFF
--- a/packages/checkout/sdk/src/sdk.ts
+++ b/packages/checkout/sdk/src/sdk.ts
@@ -11,13 +11,17 @@ import * as provider from './provider';
 import * as wallet from './wallet';
 import * as network from './network';
 import * as transaction from './transaction';
+import { handleProviderError } from './transaction';
 import * as gasEstimatorService from './gasEstimate';
 import * as buy from './smartCheckout/buy';
 import * as cancel from './smartCheckout/cancel';
 import * as sell from './smartCheckout/sell';
 import * as smartCheckout from './smartCheckout';
 import {
+  AddNetworkParams,
   BuyParams,
+  BuyResult,
+  CancelResult,
   ChainId,
   CheckConnectionParams,
   CheckConnectionResult,
@@ -26,6 +30,11 @@ import {
   ConnectResult,
   CreateProviderParams,
   CreateProviderResult,
+  EIP6963ProviderDetail,
+  FiatRampParams,
+  GasEstimateBridgeToL2Result,
+  GasEstimateParams,
+  GasEstimateSwapResult,
   GetAllBalancesParams,
   GetAllBalancesResult,
   GetBalanceParams,
@@ -35,29 +44,21 @@ import {
   GetNetworkParams,
   GetTokenAllowListParams,
   GetTokenAllowListResult,
+  GetTokenInfoParams,
   GetWalletAllowListParams,
   GetWalletAllowListResult,
   NetworkInfo,
+  OnRampProviderFees,
+  SellResult,
   SendTransactionParams,
   SendTransactionResult,
+  SmartCheckoutParams,
+  SmartCheckoutResult,
   SwitchNetworkParams,
   SwitchNetworkResult,
-  ValidateProviderOptions,
-  GasEstimateParams,
-  GasEstimateSwapResult,
-  GasEstimateBridgeToL2Result,
-  SmartCheckoutParams,
   TokenFilterTypes,
-  OnRampProviderFees,
-  FiatRampParams,
-  SmartCheckoutResult,
-  CancelResult,
-  BuyResult,
-  SellResult,
   TokenInfo,
-  GetTokenInfoParams,
-  AddNetworkParams,
-  EIP6963ProviderDetail,
+  ValidateProviderOptions,
 } from './types';
 import { CheckoutConfiguration } from './config';
 import { createReadOnlyProviders } from './readOnlyProviders/readOnlyProvider';
@@ -75,7 +76,6 @@ import { WidgetConfiguration } from './widgets/definitions/configurations';
 import { SemanticVersion } from './widgets/definitions/types';
 import { validateAndBuildVersion } from './widgets/version';
 import { InjectedProvidersManager } from './provider/injectedProvidersManager';
-import { handleProviderError } from './transaction';
 
 const SANDBOX_CONFIGURATION = {
   baseConfig: {
@@ -485,10 +485,13 @@ export class Checkout {
   /**
    * Wraps a Web3Provider call to validate the provider and handle errors.
    * @param {Web3Provider} web3Provider - The provider to connect to the network.
-   * @param {(web3Provider: Web3Provider) => T)} block - The block executing the provider call.
+   * @param {(web3Provider: Web3Provider) => Promise<T>)} block - The block executing the provider call.
    * @returns {Promise<T>} Returns the result of the provided block param.
    */
-  public async providerCall<T>(web3Provider: Web3Provider, block: (web3Provider: Web3Provider) => T) {
+  public async providerCall<T>(
+    web3Provider: Web3Provider,
+    block: (web3Provider: Web3Provider) => Promise<T>,
+  ): Promise<T> {
     const validatedProvider = await provider.validateProvider(
       this.config,
       web3Provider,

--- a/packages/checkout/sdk/src/transaction/transaction.ts
+++ b/packages/checkout/sdk/src/transaction/transaction.ts
@@ -21,6 +21,35 @@ export const setTransactionGasLimits = async (
   return rawTx;
 };
 
+export const handleProviderError = (err: any) => {
+  if (err.code === ethers.errors.INSUFFICIENT_FUNDS) {
+    return new CheckoutError(
+      err.message,
+      CheckoutErrorType.INSUFFICIENT_FUNDS,
+      { error: err },
+    );
+  }
+  if (err.code === ethers.errors.ACTION_REJECTED) {
+    return new CheckoutError(
+      err.message,
+      CheckoutErrorType.USER_REJECTED_REQUEST_ERROR,
+      { error: err },
+    );
+  }
+  if (err.code === ethers.errors.UNPREDICTABLE_GAS_LIMIT) {
+    return new CheckoutError(
+      err.message,
+      CheckoutErrorType.UNPREDICTABLE_GAS_LIMIT,
+      { error: err },
+    );
+  }
+  return new CheckoutError(
+    err.message,
+    CheckoutErrorType.TRANSACTION_FAILED,
+    { error: err },
+  );
+};
+
 export const sendTransaction = async (
   web3Provider: Web3Provider,
   transaction: TransactionRequest,
@@ -35,31 +64,6 @@ export const sendTransaction = async (
       transactionResponse,
     };
   } catch (err: any) {
-    if (err.code === ethers.errors.INSUFFICIENT_FUNDS) {
-      throw new CheckoutError(
-        err.message,
-        CheckoutErrorType.INSUFFICIENT_FUNDS,
-        { error: err },
-      );
-    }
-    if (err.code === ethers.errors.ACTION_REJECTED) {
-      throw new CheckoutError(
-        err.message,
-        CheckoutErrorType.USER_REJECTED_REQUEST_ERROR,
-        { error: err },
-      );
-    }
-    if (err.code === ethers.errors.UNPREDICTABLE_GAS_LIMIT) {
-      throw new CheckoutError(
-        err.message,
-        CheckoutErrorType.UNPREDICTABLE_GAS_LIMIT,
-        { error: err },
-      );
-    }
-    throw new CheckoutError(
-      err.message,
-      CheckoutErrorType.TRANSACTION_FAILED,
-      { error: err },
-    );
+    throw handleProviderError(err);
   }
 };

--- a/packages/checkout/widgets-lib/src/context/view-context/BridgeViewContextTypes.ts
+++ b/packages/checkout/widgets-lib/src/context/view-context/BridgeViewContextTypes.ts
@@ -45,6 +45,7 @@ interface BridgeReview extends ViewType {
 interface BridgeInProgress extends ViewType {
   type: BridgeWidgetViews.IN_PROGRESS,
   transactionHash: string,
+  isTransfer: boolean,
 }
 
 interface BridgeFailure extends ViewType {

--- a/packages/checkout/widgets-lib/src/context/view-context/BridgeViewContextTypes.ts
+++ b/packages/checkout/widgets-lib/src/context/view-context/BridgeViewContextTypes.ts
@@ -54,8 +54,8 @@ interface BridgeFailure extends ViewType {
 
 interface BridgeApproveTransaction extends ViewType {
   type: BridgeWidgetViews.APPROVE_TRANSACTION,
-  approveTransaction: ApproveBridgeResponse;
-  transaction: BridgeTxResponse;
+  approveTransaction: ApproveBridgeResponse | undefined;
+  transaction: BridgeTxResponse | undefined;
 }
 
 interface BridgeTransactions extends ViewType {

--- a/packages/checkout/widgets-lib/src/context/view-context/ViewContext.test.ts
+++ b/packages/checkout/widgets-lib/src/context/view-context/ViewContext.test.ts
@@ -196,6 +196,7 @@ describe('view-context', () => {
             {
               type: BridgeWidgetViews.IN_PROGRESS,
               transactionHash: '',
+              isTransfer: false,
             },
             {
               type: BridgeWidgetViews.BRIDGE_FAILURE,
@@ -233,6 +234,7 @@ describe('view-context', () => {
             {
               type: BridgeWidgetViews.IN_PROGRESS,
               transactionHash: '',
+              isTransfer: false,
             },
             {
               type: BridgeWidgetViews.BRIDGE_FAILURE,
@@ -270,6 +272,7 @@ describe('view-context', () => {
             {
               type: BridgeWidgetViews.IN_PROGRESS,
               transactionHash: '',
+              isTransfer: false,
             },
             {
               type: BridgeWidgetViews.BRIDGE_FAILURE,
@@ -292,6 +295,7 @@ describe('view-context', () => {
           {
             type: BridgeWidgetViews.IN_PROGRESS,
             transactionHash: '',
+            isTransfer: false,
           },
           {
             type: BridgeWidgetViews.BRIDGE_FAILURE,

--- a/packages/checkout/widgets-lib/src/locales/en.json
+++ b/packages/checkout/widgets-lib/src/locales/en.json
@@ -442,7 +442,8 @@
       "toFormInput": {
         "heading": "To",
         "selectDefaultText": "Select wallet and network",
-        "walletSelectorHeading": "To wallet"
+        "walletSelectorHeading": "To wallet",
+        "networkSelectorHeading": "To network"
       },
       "submitButton": {
         "text": "Next"

--- a/packages/checkout/widgets-lib/src/locales/en.json
+++ b/packages/checkout/widgets-lib/src/locales/en.json
@@ -515,7 +515,8 @@
     "IN_PROGRESS": {
       "heading": "Move in progress",
       "body1": "Your funds have been sent, with less than 20 mins remaining until they're received. You can return and view progress by clicking on the rocket icon.",
-      "body2": "You can close this window."
+      "body2": "You can close this window.",
+      "transferHeading": "Funds transferred"
     },
     "TRANSACTIONS": {
       "layoutHeading": "In progress",

--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -522,7 +522,8 @@
     "IN_PROGRESS": {
       "heading": "移動進行中",
       "body1": "資金は送信されました。受信まで残り20分未満です。進捗状況は、ロケットアイコンをクリックして戻って確認できます。",
-      "body2": "このウィンドウを閉じてもよろしいです。"
+      "body2": "このウィンドウを閉じてもよろしいです。",
+      "transferHeading": "Funds transferred"
     },
     "TRANSACTIONS": {
       "layoutHeading": "進行中",

--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -449,7 +449,8 @@
       "toFormInput": {
         "heading": "To",
         "selectDefaultText": "ウォレットとネットワークを選択",
-        "walletSelectorHeading": "To wallet"
+        "walletSelectorHeading": "To wallet",
+        "networkSelectorHeading": "To network"
       },
       "submitButton": {
         "text": "次へ"

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -515,7 +515,8 @@
     "IN_PROGRESS": {
       "heading": "이동 중",
       "body1": "자금이 송금되었습니다. 수령까지 남은 시간은 20분 미만입니다. 로켓 아이콘을 클릭하여 진행 상황을 확인할 수 있습니다.",
-      "body2": "이 창을 닫아도 됩니다."
+      "body2": "이 창을 닫아도 됩니다.",
+      "transferHeading": "Funds transferred"
     },
     "TRANSACTIONS": {
       "layoutHeading": "진행 중",

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -442,7 +442,8 @@
       "toFormInput": {
         "heading": "To",
         "selectDefaultText": "지갑과 네트워크를 선택하세요",
-        "walletSelectorHeading": "지갑으로"
+        "walletSelectorHeading": "지갑으로",
+        "networkSelectorHeading": "To network"
       },
       "submitButton": {
         "text": "다음"

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -442,7 +442,8 @@
       "toFormInput": {
         "heading": "至",
         "selectDefaultText": "选择钱包和网络",
-        "walletSelectorHeading": "至钱包"
+        "walletSelectorHeading": "至钱包",
+        "networkSelectorHeading": "To network"
       },
       "submitButton": {
         "text": "下一步"

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -515,7 +515,8 @@
     "IN_PROGRESS": {
       "heading": "转移进行中",
       "body1": "您的资金已经发送，距离收到不到20分钟。您可以点击火箭图标返回并查看进展。",
-      "body2": "您可以关闭这个窗口。"
+      "body2": "您可以关闭这个窗口。",
+      "transferHeading": "Funds transferred"
     },
     "TRANSACTIONS": {
       "layoutHeading": "进行中",

--- a/packages/checkout/widgets-lib/src/widgets/bridge/BridgeWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/BridgeWidget.tsx
@@ -211,6 +211,7 @@ export default function BridgeWidget({
           {viewState.view.type === BridgeWidgetViews.IN_PROGRESS && (
             <MoveInProgress
               transactionHash={viewState.view.transactionHash}
+              isTransfer={viewState.view.isTransfer}
             />
           )}
           {viewState.view.type === BridgeWidgetViews.BRIDGE_FAILURE

--- a/packages/checkout/widgets-lib/src/widgets/bridge/BridgeWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/BridgeWidget.tsx
@@ -242,8 +242,9 @@ export default function BridgeWidget({
 
           {viewState.view.type === BridgeWidgetViews.APPROVE_TRANSACTION && (
             <ApproveTransaction
-              approveTransaction={viewState.view.approveTransaction}
-              transaction={viewState.view.transaction}
+              bridgeTransaction={viewState.view.approveTransaction && viewState.view.transaction
+                ? { approveTransaction: viewState.view.approveTransaction, transaction: viewState.view.transaction }
+                : undefined}
             />
           )}
           {viewState.view.type === BridgeWidgetViews.TRANSACTIONS && (

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
@@ -104,7 +104,7 @@ export function BridgeReviewSummary() {
   // Not enough ETH to cover gas
   const [showNotEnoughGasDrawer, setShowNotEnoughGasDrawer] = useState(false);
 
-  const l2Transfer = useMemo(() => from?.network === to?.network, [from, to]);
+  const isTransfer = useMemo(() => from?.network === to?.network, [from, to]);
   const insufficientFundsForGas = useMemo(() => {
     if (!estimates) return false;
     if (!token) return true;
@@ -240,7 +240,7 @@ export function BridgeReviewSummary() {
     );
   }, [checkout, tokenBridge]);
   useInterval(() => {
-    if (l2Transfer) {
+    if (isTransfer) {
       fetchTransferGasEstimate();
     } else {
       fetchBridgeGasEstimate();
@@ -255,7 +255,7 @@ export function BridgeReviewSummary() {
   useEffect(() => {
     (async () => {
       setLoading(true);
-      if (l2Transfer) {
+      if (isTransfer) {
         await fetchTransferGasEstimate();
       } else {
         await fetchBridgeGasEstimate();
@@ -324,7 +324,7 @@ export function BridgeReviewSummary() {
   }, [insufficientFundsForGas]);
 
   const submitBridge = useCallback(async () => {
-    if (!l2Transfer && (!approveTransaction || !transaction)) return;
+    if (!isTransfer && (!approveTransaction || !transaction)) return;
 
     if (insufficientFundsForGas) {
       setShowNotEnoughGasDrawer(true);
@@ -371,7 +371,7 @@ export function BridgeReviewSummary() {
         amount,
         fiatAmount: fromFiatAmount,
         tokenAddress: token?.address,
-        moveType: l2Transfer ? 'transfer' : 'bridge',
+        moveType: isTransfer ? 'transfer' : 'bridge',
       },
     });
 

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletAndNetworkSelector.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletAndNetworkSelector.tsx
@@ -1,5 +1,8 @@
 import {
-  Drawer, Box, Button, Heading,
+  Box,
+  Button,
+  Drawer,
+  Heading,
 } from '@biom3/react';
 import { BridgeWidgetViews } from 'context/view-context/BridgeViewContextTypes';
 import {
@@ -9,7 +12,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { ChainId, WalletProviderRdns } from '@imtbl/checkout-sdk';
+import { ChainId, WalletProviderName, WalletProviderRdns } from '@imtbl/checkout-sdk';
 import { Web3Provider } from '@ethersproject/providers';
 import {
   connectToProvider,
@@ -23,8 +26,8 @@ import { getChainNameById } from 'lib/chains';
 import { ViewActions, ViewContext } from 'context/view-context/ViewContext';
 import { abbreviateAddress } from 'lib/addressUtils';
 import {
-  UserJourney,
   useAnalytics,
+  UserJourney,
 } from 'context/analytics-provider/SegmentAnalyticsProvider';
 import { useTranslation } from 'react-i18next';
 import {
@@ -95,6 +98,7 @@ export function WalletAndNetworkSelector() {
   const [fromWallet, setFromWallet] = useState<WalletChangeEvent | null>(defaultFromWallet);
 
   /** To wallet local state */
+  const [toNetworkDrawerOpen, setToNetworkDrawerOpen] = useState(false);
   const [toWalletDrawerOpen, setToWalletDrawerOpen] = useState(false);
   const [toWalletWeb3Provider, setToWalletWeb3Provider] = useState<Web3Provider | null>(defaultToWeb3Provider);
   const [toNetwork, setToNetwork] = useState<ChainId | null>(defaultToNetwork);
@@ -121,9 +125,10 @@ export function WalletAndNetworkSelector() {
     providers
       .filter((providerDetail) => (
         providerDetail.info.rdns !== WalletProviderRdns.PASSPORT
-        || (providerDetail.info.rdns === WalletProviderRdns.PASSPORT && fromNetwork === l1NetworkChainId)
+        || (providerDetail.info.rdns === WalletProviderRdns.PASSPORT
+          && fromWallet?.providerDetail?.info?.rdns !== WalletProviderRdns.PASSPORT)
       ))
-  ), [providers, fromNetwork]);
+  ), [providers, fromNetwork, fromWallet]);
 
   useEffect(() => {
     if (!from || !to) return;
@@ -226,11 +231,29 @@ export function WalletAndNetworkSelector() {
     [checkout, fromWalletWeb3Provider],
   );
 
+  const handleToNetworkSelection = useCallback(
+    async (chainId: ChainId) => {
+      if (!toWalletWeb3Provider) return;
+      setToNetworkDrawerOpen(false);
+      setToNetwork(chainId);
+
+      track({
+        userJourney: UserJourney.BRIDGE,
+        screen: 'WalletAndNetwork',
+        control: 'ToNetwork',
+        controlType: 'Select',
+        extras: {
+          chainId,
+        },
+      });
+    },
+    [checkout, toWalletWeb3Provider],
+  );
+
   const handleSettingToNetwork = useCallback(() => {
-    // toNetwork is always the opposite of fromNetwork
-    const theToNetwork = fromNetwork === l1NetworkChainId
-      ? imtblZkEvmNetworkChainId
-      : l1NetworkChainId;
+    // L1 can only transfer to L2 but L2 can transfer to L1 & L2
+    // If the toWallet is Passport the toNetwork can only be L2
+    const theToNetwork = imtblZkEvmNetworkChainId;
     setToNetwork(theToNetwork);
     setToWalletDrawerOpen(false);
 
@@ -494,32 +517,35 @@ export function WalletAndNetworkSelector() {
       {/** From Network Selector, we programmatically open this so there is no target */}
       <Drawer
         headerBarTitle={t(
-          'views.WALLET_NETWORK_SELECTION.fromFormInput.networkSelectorHeading',
+          fromNetworkDrawerOpen ? 'views.WALLET_NETWORK_SELECTION.fromFormInput.networkSelectorHeading'
+            : 'views.WALLET_NETWORK_SELECTION.toFormInput.networkSelectorHeading',
         )}
         size="full"
         onCloseDrawer={() => {
-          setFromNetworkDrawerOpen(false);
+          if (fromNetworkDrawerOpen) {
+            setFromNetworkDrawerOpen(false);
+          } else {
+            setToNetworkDrawerOpen(false);
+          }
         }}
-        visible={fromNetworkDrawerOpen}
+        visible={fromNetworkDrawerOpen || toNetworkDrawerOpen}
       >
         <Drawer.Content sx={{ paddingX: 'base.spacing.x4' }}>
           <NetworkItem
             key={imtblZkEvmNetworkName}
             testId={testId}
             chainName={imtblZkEvmNetworkName}
-            onNetworkClick={handleFromNetworkSelection}
+            onNetworkClick={fromNetworkDrawerOpen ? handleFromNetworkSelection : handleToNetworkSelection}
             chainId={imtblZkEvmNetworkChainId}
           />
           {/** Show L1 option for everything but Passport */}
-          {(fromWallet?.providerDetail.info.rdns !== WalletProviderRdns.PASSPORT) && (
-            <NetworkItem
-              key={l1NetworkName}
-              testId={testId}
-              chainName={l1NetworkName}
-              onNetworkClick={handleFromNetworkSelection}
-              chainId={l1NetworkChainId}
-            />
-          )}
+          <NetworkItem
+            key={l1NetworkName}
+            testId={testId}
+            chainName={l1NetworkName}
+            onNetworkClick={fromNetworkDrawerOpen ? handleFromNetworkSelection : handleToNetworkSelection}
+            chainId={l1NetworkChainId}
+          />
         </Drawer.Content>
       </Drawer>
 
@@ -540,12 +566,14 @@ export function WalletAndNetworkSelector() {
             walletName={toWalletProviderName}
             walletAddress={abbreviateAddress(toWalletAddress)}
             chainId={toNetwork!}
-            disableNetworkButton
+            disableNetworkButton={fromNetwork === l1NetworkChainId
+              || toWalletProviderName === WalletProviderName.PASSPORT.toString()}
             onWalletClick={() => {
               setToWalletDrawerOpen(true);
             }}
-            // eslint-disable-next-line no-console
-            onNetworkClick={() => {}}
+            onNetworkClick={() => {
+              setToNetworkDrawerOpen(true);
+            }}
           />
           <Box sx={submitButtonWrapperStyles}>
             <Button

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletAndNetworkSelector.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletAndNetworkSelector.tsx
@@ -541,8 +541,8 @@ export function WalletAndNetworkSelector() {
             onNetworkClick={fromNetworkDrawerOpen ? handleFromNetworkSelection : handleToNetworkSelection}
             chainId={imtblZkEvmNetworkChainId}
           />
-          {/** Show L1 option for everything but Passport */}
-          {(fromWallet?.providerDetail.info.rdns !== WalletProviderRdns.PASSPORT) && (
+          {/** If selecting from network, show L1 option for everything but Passport */}
+          {(toNetworkDrawerOpen || fromWallet?.providerDetail.info.rdns !== WalletProviderRdns.PASSPORT) && (
             <NetworkItem
               key={l1NetworkName}
               testId={testId}
@@ -573,7 +573,7 @@ export function WalletAndNetworkSelector() {
             chainId={toNetwork!}
             disableNetworkButton={fromNetwork === l1NetworkChainId
               || toWalletProviderName === WalletProviderName.PASSPORT.toString()
-              || from?.walletAddress === to?.walletAddress}
+              || fromWalletAddress === toWalletAddress}
             onWalletClick={() => {
               setToWalletDrawerOpen(true);
             }}

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletAndNetworkSelector.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletAndNetworkSelector.tsx
@@ -251,7 +251,6 @@ export function WalletAndNetworkSelector() {
   );
 
   const handleSettingToNetwork = useCallback((toAddress: string) => {
-    // L1 can only transfer to L2 but L2 can transfer to L1 & L2
     // If the toWallet is Passport the toNetwork can only be L2
     // If the user selects the same wallet (e.g. MetaMask) for from AND to this can only be a bridge
     const theToNetwork = fromWalletAddress === toAddress && fromNetwork === imtblZkEvmNetworkChainId

--- a/packages/checkout/widgets-lib/src/widgets/bridge/functions/TransferErc20.ts
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/functions/TransferErc20.ts
@@ -1,0 +1,7 @@
+import { Contract, Signer } from 'ethers';
+
+export const getErc20Contract = (token: string, signer: Signer) => new Contract(
+  token,
+  ['function transfer(address to, uint amount)'],
+  signer,
+);

--- a/packages/checkout/widgets-lib/src/widgets/bridge/views/ApproveTransaction.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/views/ApproveTransaction.tsx
@@ -192,7 +192,7 @@ export function ApproveTransaction({ bridgeTransaction }: ApproveTransactionProp
 
   const handleApproveBridgeClick = useCallback(async () => {
     let bridgeRejected = false;
-    // Force unwrap as bridgeTransaction being defined is a required for this callback to be invoked
+    // Force unwrap as bridgeTransaction being defined is a requirement for this callback to be invoked
     const { approveTransaction, transaction } = bridgeTransaction!;
     if (!checkout || !from?.web3Provider || !transaction) {
       showErrorView();

--- a/packages/checkout/widgets-lib/src/widgets/bridge/views/ApproveTransaction.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/views/ApproveTransaction.tsx
@@ -168,6 +168,7 @@ export function ApproveTransaction({ bridgeTransaction }: ApproveTransactionProp
           view: {
             type: BridgeWidgetViews.IN_PROGRESS,
             transactionHash: txHash,
+            isTransfer: true,
           },
         },
       });
@@ -264,6 +265,7 @@ export function ApproveTransaction({ bridgeTransaction }: ApproveTransactionProp
           view: {
             type: BridgeWidgetViews.IN_PROGRESS,
             transactionHash: receipt.transactionHash,
+            isTransfer: false,
           },
         },
       });

--- a/packages/checkout/widgets-lib/src/widgets/bridge/views/MoveInProgress.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/views/MoveInProgress.tsx
@@ -18,9 +18,10 @@ import { CryptoFiatContext } from '../../../context/crypto-fiat-context/CryptoFi
 
 export interface MoveInProgressProps {
   transactionHash: string;
+  isTransfer: boolean;
 }
 
-export function MoveInProgress({ transactionHash }: MoveInProgressProps) {
+export function MoveInProgress({ transactionHash, isTransfer }: MoveInProgressProps) {
   const { t } = useTranslation();
   const { eventTargetState: { eventTarget } } = useContext(EventTargetContext);
   const { page } = useAnalytics();
@@ -53,6 +54,7 @@ export function MoveInProgress({ transactionHash }: MoveInProgressProps) {
         amount,
         fiatAmount,
         tokenAddress: token?.address,
+        moveType: isTransfer ? 'transfer' : 'bridge',
       },
     });
   }, []);
@@ -79,15 +81,18 @@ export function MoveInProgress({ transactionHash }: MoveInProgressProps) {
                 }}
                 testId="settings-button"
               />
-              <Badge
-                isAnimated
-                variant="guidance"
-                sx={{
-                  position: 'absolute',
-                  right: 'base.spacing.x14',
-                  top: 'base.spacing.x1',
-                }}
-              />
+              {!isTransfer
+                && (
+                  <Badge
+                    isAnimated
+                    variant="guidance"
+                    sx={{
+                      position: 'absolute',
+                      right: 'base.spacing.x14',
+                      top: 'base.spacing.x1',
+                    }}
+                  />
+                )}
             </>
           )}
         />
@@ -98,8 +103,8 @@ export function MoveInProgress({ transactionHash }: MoveInProgressProps) {
       heroContent={<RocketHero environment={checkout.config.environment} />}
       floatHeader
     >
-      <SimpleTextBody heading={t('views.IN_PROGRESS.heading')}>
-        {t('views.IN_PROGRESS.body1')}
+      <SimpleTextBody heading={t(isTransfer ? 'views.IN_PROGRESS.transferHeading' : 'views.IN_PROGRESS.heading')}>
+        {!isTransfer && t('views.IN_PROGRESS.body1')}
         <br />
         <br />
         {t('views.IN_PROGRESS.body2')}


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
- Create generic `checkout.providerCall` to wrap non-sendTransaction calls and still get validation + error handling  (e.g. ERC20 transfer)
- Reuse existing network drawer to allow "to" network selection with rules: Passport MUST be L2, if the same wallet is selected for to & from it must be a bridge. 
- Estimate gas for an L2 transfer directly in BridgeReviewSummary
- Initiate transfer from ApproveTransaction
- Update MoveInProgress screen to show different success state for transfers. Also don't highlight the "Transactions" button.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
- The Checkout Bridge widget can now be used to transfer tokens between zkEVM wallets!

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
