### PR TITLE
TD-1365: feat: Add ERC1155 & partial fills support to Orderbook

### DIFF
--- a/packages/orderbook/src/openapi/mapper.ts
+++ b/packages/orderbook/src/openapi/mapper.ts
@@ -104,12 +104,21 @@ export function mapFromOpenApiTrade(trade: OpenApiTrade): Trade {
     throw new Error('Buy items must be either ERC20 or NATIVE');
   });
 
-  const sellItems: ERC721Item[] = trade.sell.map((item) => {
+  const sellItems: (ERC721Item | ERC1155Item)[] = trade.sell.map((item) => {
     if (item.type === 'ERC721') {
       return {
         type: 'ERC721',
         contractAddress: item.contract_address,
         tokenId: item.token_id,
+      };
+    }
+
+    if (item.type === 'ERC1155') {
+      return {
+        type: 'ERC1155',
+        contractAddress: item.contract_address,
+        tokenId: item.token_id,
+        amount: item.amount,
       };
     }
 

--- a/packages/orderbook/src/openapi/mapper.ts
+++ b/packages/orderbook/src/openapi/mapper.ts
@@ -9,6 +9,7 @@ import {
   FeeType,
   Page,
   Trade,
+  ERC1155Item,
 } from '../types';
 
 export function mapFromOpenApiOrder(order: OpenApiOrder): Order {
@@ -31,7 +32,7 @@ export function mapFromOpenApiOrder(order: OpenApiOrder): Order {
     throw new Error('Buy items must be either ERC20 or NATIVE');
   });
 
-  const sellItems: ERC721Item[] = order.sell.map((item) => {
+  const sellItems: (ERC721Item | ERC1155Item)[] = order.sell.map((item) => {
     if (item.type === 'ERC721') {
       return {
         type: 'ERC721',
@@ -40,7 +41,16 @@ export function mapFromOpenApiOrder(order: OpenApiOrder): Order {
       };
     }
 
-    throw new Error('Sell items must ERC721');
+    if (item.type === 'ERC1155') {
+      return {
+        type: 'ERC1155',
+        contractAddress: item.contract_address,
+        tokenId: item.token_id,
+        amount: item.amount,
+      };
+    }
+
+    throw new Error('Sell items must ERC721 or ERC1155');
   });
 
   return {
@@ -54,6 +64,7 @@ export function mapFromOpenApiOrder(order: OpenApiOrder): Order {
       recipientAddress: fee.recipient_address,
       type: fee.type as unknown as FeeType,
     })),
+    fillStatus: order.fill_status,
     chain: order.chain,
     createdAt: order.created_at,
     endAt: order.end_at,

--- a/packages/orderbook/src/openapi/sdk/OrderBookClient.ts
+++ b/packages/orderbook/src/openapi/sdk/OrderBookClient.ts
@@ -17,7 +17,7 @@ export class OrderBookClient {
 
   constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = AxiosHttpRequest) {
     this.request = new HttpRequest({
-      BASE: config?.BASE ?? 'https://api.sandbox.immutable.com',
+      BASE: config?.BASE ?? 'https://api.immutable.com',
       VERSION: config?.VERSION ?? '1.0.0',
       WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
       CREDENTIALS: config?.CREDENTIALS ?? 'include',

--- a/packages/orderbook/src/openapi/sdk/core/OpenAPI.ts
+++ b/packages/orderbook/src/openapi/sdk/core/OpenAPI.ts
@@ -19,7 +19,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-  BASE: 'https://api.sandbox.immutable.com',
+  BASE: 'https://api.immutable.com',
   VERSION: '1.0.0',
   WITH_CREDENTIALS: false,
   CREDENTIALS: 'include',

--- a/packages/orderbook/src/openapi/sdk/index.ts
+++ b/packages/orderbook/src/openapi/sdk/index.ts
@@ -25,6 +25,7 @@ export type { ExpiredOrderStatus } from './models/ExpiredOrderStatus';
 export { FailedOrderCancellation } from './models/FailedOrderCancellation';
 export { Fee } from './models/Fee';
 export type { FilledOrderStatus } from './models/FilledOrderStatus';
+export type { FillStatus } from './models/FillStatus';
 export type { FulfillableOrder } from './models/FulfillableOrder';
 export type { FulfillmentDataRequest } from './models/FulfillmentDataRequest';
 export type { InactiveOrderStatus } from './models/InactiveOrderStatus';

--- a/packages/orderbook/src/openapi/sdk/models/FillStatus.ts
+++ b/packages/orderbook/src/openapi/sdk/models/FillStatus.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type FillStatus = {
+  /**
+   * The numerator of the fill status
+   */
+  numerator: string;
+  /**
+   * The denominator of the fill status
+   */
+  denominator: string;
+};
+

--- a/packages/orderbook/src/openapi/sdk/models/Order.ts
+++ b/packages/orderbook/src/openapi/sdk/models/Order.ts
@@ -4,6 +4,7 @@
 
 import type { Chain } from './Chain';
 import type { Fee } from './Fee';
+import type { FillStatus } from './FillStatus';
 import type { Item } from './Item';
 import type { OrderStatus } from './OrderStatus';
 import type { ProtocolData } from './ProtocolData';
@@ -49,6 +50,7 @@ export type Order = {
    * Time the Order is last updated
    */
   updated_at: string;
+  fill_status: FillStatus;
 };
 
 export namespace Order {

--- a/packages/orderbook/src/openapi/sdk/models/ProtocolData.ts
+++ b/packages/orderbook/src/openapi/sdk/models/ProtocolData.ts
@@ -32,6 +32,7 @@ export namespace ProtocolData {
    */
   export enum order_type {
     FULL_RESTRICTED = 'FULL_RESTRICTED',
+    PARTIAL_RESTRICTED = 'PARTIAL_RESTRICTED',
   }
 
 

--- a/packages/orderbook/src/orderbook.ts
+++ b/packages/orderbook/src/orderbook.ts
@@ -209,12 +209,15 @@ export class Orderbook {
    * @param {string} listingId - The listingId to fulfil.
    * @param {string} takerAddress - The address of the account fulfilling the order.
    * @param {FeeValue[]} takerFees - Taker ecosystem fees to be paid.
+   * @param {string} amountToFill - Amount of the order to fill, defaults to sell item amount.
+   *                                Only applies to ERC1155 orders
    * @return {FulfillOrderResponse} Approval and fulfilment transactions.
    */
   async fulfillOrder(
     listingId: string,
     takerAddress: string,
     takerFees: FeeValue[],
+    amountToFill?: string,
   ): Promise<FulfillOrderResponse> {
     const fulfillmentDataRes = await this.apiClient.fulfillmentData([
       {
@@ -246,7 +249,7 @@ export class Orderbook {
       );
     }
 
-    return this.seaport.fulfillOrder(orderResult, takerAddress, extraData);
+    return this.seaport.fulfillOrder(orderResult, takerAddress, extraData, amountToFill);
   }
 
   async fulfillBulkOrders(

--- a/packages/orderbook/src/seaport/map-to-seaport-order.ts
+++ b/packages/orderbook/src/seaport/map-to-seaport-order.ts
@@ -5,7 +5,7 @@ import {
 } from '@opensea/seaport-js/lib/types';
 import { constants } from 'ethers';
 import { ItemType, OrderType } from './constants';
-import { ERC721Item, Order } from '../openapi/sdk';
+import { ERC721Item, ERC1155Item, Order } from '../openapi/sdk';
 
 export function mapImmutableOrderToSeaportOrderComponents(
   order: Order,
@@ -61,14 +61,29 @@ export function mapImmutableOrderToSeaportOrderComponents(
       conduitKey: constants.HashZero,
       consideration: [...considerationItems],
       offer: order.sell.map((sellItem) => {
-        const erc721Item = sellItem as ERC721Item;
-        return {
-          startAmount: '1',
-          endAmount: '1',
-          itemType: ItemType.ERC721,
-          token: erc721Item.contract_address!,
-          identifierOrCriteria: erc721Item.token_id,
-        };
+        let tokenItem;
+        switch (sellItem.type) {
+          case 'ERC1155':
+            tokenItem = sellItem as ERC1155Item;
+            return {
+              startAmount: tokenItem.amount,
+              endAmount: tokenItem.amount,
+              itemType: ItemType.ERC1155,
+              recipient: order.account_address,
+              token: tokenItem.contract_address!,
+              identifierOrCriteria: tokenItem.token_id,
+            };
+          default: // ERC721
+            tokenItem = sellItem as ERC721Item;
+            return {
+              startAmount: '1',
+              endAmount: '1',
+              itemType: ItemType.ERC721,
+              recipient: order.account_address,
+              token: tokenItem.contract_address!,
+              identifierOrCriteria: tokenItem.token_id,
+            };
+        }
       }),
       counter,
       endTime: Math.round(new Date(order.end_at).getTime() / 1000).toString(),
@@ -80,7 +95,7 @@ export function mapImmutableOrderToSeaportOrderComponents(
       zone: zoneAddress,
       // this should be the fee exclusive number of items the user signed for
       totalOriginalConsiderationItems: considerationItems.length,
-      orderType: OrderType.FULL_RESTRICTED,
+      orderType: order.sell[0].type === 'ERC1155' ? OrderType.PARTIAL_RESTRICTED : OrderType.FULL_RESTRICTED,
       zoneHash: constants.HashZero,
     },
     tips: fees,

--- a/packages/orderbook/src/seaport/seaport.test.ts
+++ b/packages/orderbook/src/seaport/seaport.test.ts
@@ -400,6 +400,7 @@ describe('Seaport', () => {
         chain: { id: '1', name: 'imtbl-zkevm-local' },
         created_at: new Date().toISOString(),
         end_at: new Date().toISOString(),
+        fill_status: { numerator: '0', denominator: '0' },
         id: '1',
         order_hash: randomAddress(),
         protocol_data: {
@@ -466,6 +467,7 @@ describe('Seaport', () => {
                     parameters: anything(),
                     signature: immutableOrder.signature,
                   },
+                  unitsToFill: undefined,
                   extraData: fakeExtraData,
                   tips: [],
                 },

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -290,7 +290,7 @@ export class Seaport {
 
     return seaportLib.createOrder(
       {
-        allowPartialFills: false,
+        allowPartialFills: listingItem.type === 'ERC1155',
         offer: [offerItem],
         consideration: [
           {

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -1,6 +1,7 @@
 import { Seaport as SeaportLib } from '@opensea/seaport-js';
 import {
   ApprovalAction,
+  CreateInputItem,
   CreateOrderAction,
   ExchangeAction,
   OrderComponents,
@@ -12,6 +13,7 @@ import { mapFromOpenApiOrder } from 'openapi/mapper';
 import {
   Action,
   ActionType,
+  ERC1155Item,
   ERC20Item,
   ERC721Item,
   FulfillOrderResponse,
@@ -45,7 +47,7 @@ export class Seaport {
 
   async prepareSeaportOrder(
     offerer: string,
-    listingItem: ERC721Item,
+    listingItem: ERC721Item | ERC1155Item,
     considerationItem: ERC20Item | NativeItem,
     orderStart: Date,
     orderExpiry: Date,
@@ -104,6 +106,7 @@ export class Seaport {
     order: Order,
     account: string,
     extraData: string,
+    unitsToFill?: string,
   ): Promise<FulfillOrderResponse> {
     const { orderComponents, tips } = this.mapImmutableOrderToSeaportOrderComponents(order);
     const seaportLib = this.getSeaportLib(order);
@@ -116,6 +119,7 @@ export class Seaport {
             parameters: orderComponents,
             signature: order.signature,
           },
+          unitsToFill,
           extraData,
           tips,
         },
@@ -264,22 +268,30 @@ export class Seaport {
 
   private createSeaportOrder(
     offerer: string,
-    listingItem: ERC721Item,
+    listingItem: ERC721Item | ERC1155Item,
     considerationItem: ERC20Item | NativeItem,
     orderStart: Date,
     orderExpiry: Date,
   ): Promise<OrderUseCase<CreateOrderAction>> {
     const seaportLib = this.getSeaportLib();
+
+    const offerItem: CreateInputItem = listingItem.type === 'ERC721'
+      ? {
+        itemType: ItemType.ERC721,
+        token: listingItem.contractAddress,
+        identifier: listingItem.tokenId,
+      }
+      : {
+        itemType: ItemType.ERC1155,
+        token: listingItem.contractAddress,
+        identifier: listingItem.tokenId,
+        amount: listingItem.amount,
+      };
+
     return seaportLib.createOrder(
       {
         allowPartialFills: false,
-        offer: [
-          {
-            itemType: ItemType.ERC721,
-            token: listingItem.contractAddress,
-            identifier: listingItem.tokenId,
-          },
-        ],
+        offer: [offerItem],
         consideration: [
           {
             token:

--- a/packages/orderbook/src/types.ts
+++ b/packages/orderbook/src/types.ts
@@ -5,6 +5,13 @@ import { Fee as OpenapiFee, OrdersService, OrderStatus } from './openapi/sdk';
 // Strictly re-export only the OrderStatusName enum from the openapi types
 export { OrderStatusName } from './openapi/sdk';
 
+export interface ERC1155Item {
+  type: 'ERC1155';
+  contractAddress: string;
+  tokenId: string;
+  amount: string;
+}
+
 export interface ERC721Item {
   type: 'ERC721';
   contractAddress: string;
@@ -29,7 +36,7 @@ export interface RoyaltyInfo {
 
 export interface PrepareListingParams {
   makerAddress: string;
-  sell: ERC721Item;
+  sell: ERC721Item | ERC1155Item;
   buy: ERC20Item | NativeItem;
   orderExpiry?: Date;
 }
@@ -162,7 +169,7 @@ export interface Order {
   type: 'LISTING';
   accountAddress: string;
   buy: (ERC20Item | NativeItem)[];
-  sell: ERC721Item[];
+  sell: (ERC721Item | ERC1155Item)[];
   fees: Fee[];
   chain: {
     id: string;
@@ -170,6 +177,10 @@ export interface Order {
   };
   createdAt: string;
   updatedAt: string;
+  fillStatus: {
+    numerator: string,
+    denominator: string,
+  };
   /**
    * Time after which the Order is considered active
    */
@@ -180,7 +191,7 @@ export interface Order {
   endAt: string;
   orderHash: string;
   protocolData: {
-    orderType: 'FULL_RESTRICTED';
+    orderType: 'FULL_RESTRICTED' | 'PARTIAL_RESTRICTED';
     zoneAddress: string;
     counter: string;
     seaportAddress: string;
@@ -219,7 +230,7 @@ export interface Trade {
     name: string;
   };
   buy: (ERC20Item | NativeItem)[];
-  sell: ERC721Item[];
+  sell: (ERC721Item | ERC1155Item)[];
   buyerFees: Fee[];
   sellerAddress: string;
   buyerAddress: string;


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [X] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Adding ERC1155 token support to the orderbook to enable orders containing ERC1155 tokens to be created and filled using the SDK.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->
* ERC1155 support to the orderbook.
* Partials order fulfillment for ERC1155 orders.

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
