### PR TITLE
fix: [CM-616] Checkout widgets cloud image component refactor

### DIFF
--- a/packages/checkout/widgets-lib/src/components/ChangedYourMindDrawer/ChangedYourMindDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/ChangedYourMindDrawer/ChangedYourMindDrawer.tsx
@@ -11,7 +11,6 @@ import { Checkout } from '@imtbl/checkout-sdk';
 import { Environment } from '@imtbl/config';
 import { getRemoteImage } from 'lib/utils';
 import { useTranslation } from 'react-i18next';
-import { IMAGE_RESIZER_URL } from '../../lib';
 
 export interface ChangedYourMindDrawerProps {
   visible: boolean;
@@ -57,9 +56,13 @@ export function ChangedYourMindDrawer({
           }}
         >
           <CloudImage
-            imageUrl={walletErrorRedUrl}
-            imageResizeServiceUrl={IMAGE_RESIZER_URL[checkout.config.environment]}
             sx={{ paddingTop: 'base.spacing.x4', paddingBottom: 'base.spacing.x9' }}
+            use={(
+              <img
+                src={walletErrorRedUrl}
+                alt={t('drawers.walletConnectionError.changedYourMind.heading')}
+              />
+            )}
           />
           <ButtCon
             icon="Close"

--- a/packages/checkout/widgets-lib/src/components/CoinSelector/CoinSelectorOption.tsx
+++ b/packages/checkout/widgets-lib/src/components/CoinSelector/CoinSelectorOption.tsx
@@ -1,5 +1,6 @@
 import { MenuItem, AllIconKeys } from '@biom3/react';
 import { useTranslation } from 'react-i18next';
+import { useMemo, useState } from 'react';
 
 export interface CoinSelectorOptionProps {
   testId?: string;
@@ -18,18 +19,25 @@ export interface CoinSelectorOptionProps {
 export function CoinSelectorOption({
   onClick, icon, name, symbol, balance, defaultTokenImage, testId, id,
 }: CoinSelectorOptionProps) {
+  const [iconError, setIconError] = useState<boolean>(false);
   const { t } = useTranslation();
+  const tokenUrl = useMemo(
+    () => ((!icon || iconError) ? defaultTokenImage : icon),
+    [icon, iconError, defaultTokenImage],
+  );
 
   return (
     <MenuItem testId={`${testId}-coin-selector__option-${id}`} emphasized size="small" onClick={onClick}>
-      {!icon && <MenuItem.Icon icon="Coins" variant="bold" />}
-      {icon && (
-        <MenuItem.FramedImage
-          imageUrl={icon}
-          circularFrame
-          defaultImageUrl={defaultTokenImage}
-        />
-      )}
+      <MenuItem.FramedImage
+        circularFrame
+        use={(
+          <img
+            src={tokenUrl}
+            alt={name}
+            onError={() => setIconError(true)}
+          />
+        )}
+      />
 
       <MenuItem.Label>{name}</MenuItem.Label>
       <MenuItem.Caption>{symbol}</MenuItem.Caption>

--- a/packages/checkout/widgets-lib/src/components/FormComponents/SelectInput/SelectInput.tsx
+++ b/packages/checkout/widgets-lib/src/components/FormComponents/SelectInput/SelectInput.tsx
@@ -1,4 +1,6 @@
 import { Box, OptionKey } from '@biom3/react';
+import { WidgetTheme } from '@imtbl/checkout-sdk';
+import { Environment } from '@imtbl/config';
 import {
   inputStyle,
   selectInputBoxStyle,
@@ -31,6 +33,8 @@ interface SelectInputProps {
   onSelectChange: (value: OptionKey) => void;
   selectedOption?: OptionKey;
   defaultTokenImage: string;
+  environment?: Environment;
+  theme?: WidgetTheme;
 }
 
 export function SelectInput({
@@ -56,6 +60,8 @@ export function SelectInput({
   selectedOption,
   coinSelectorHeading,
   defaultTokenImage,
+  environment,
+  theme,
 }: SelectInputProps) {
   return (
     <Box sx={selectInputBoxStyle}>
@@ -71,6 +77,8 @@ export function SelectInput({
           selectedOption={selectedOption}
           coinSelectorHeading={coinSelectorHeading}
           defaultTokenImage={defaultTokenImage}
+          environment={environment}
+          theme={theme}
         />
       </Box>
       <Box sx={inputStyle}>

--- a/packages/checkout/widgets-lib/src/components/NetworkSwitchDrawer/NetworkSwitchDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/NetworkSwitchDrawer/NetworkSwitchDrawer.tsx
@@ -110,8 +110,14 @@ export function NetworkSwitchDrawer({
       >
         <AspectRatioImage
           aspectRatio="21:9"
-          responsiveSizes={[450, 512, 640, 720, 860, 1024, 1280, 1440]}
-          imageUrl={showEthImage ? ethImageUrl : zkevmImageUrl}
+          use={(
+            <img
+              src={showEthImage ? ethImageUrl : zkevmImageUrl}
+              alt={t('drawers.networkSwitch.heading', {
+                wallet: walletDisplayName,
+              })}
+            />
+          )}
         />
         <ButtCon
           icon="Close"

--- a/packages/checkout/widgets-lib/src/components/NotEnoughGas/NotEnoughGas.tsx
+++ b/packages/checkout/widgets-lib/src/components/NotEnoughGas/NotEnoughGas.tsx
@@ -3,7 +3,7 @@ import {
   Drawer, Box, Button, Heading, CloudImage,
 } from '@biom3/react';
 import { useCallback, useState } from 'react';
-import { ETH_TOKEN_SYMBOL, IMAGE_RESIZER_URL } from 'lib';
+import { ETH_TOKEN_SYMBOL } from 'lib';
 import { Environment } from '@imtbl/config';
 import { getRemoteImage } from 'lib/utils';
 import { useTranslation } from 'react-i18next';
@@ -66,13 +66,15 @@ NotEnoughGasProps) {
     >
       <Drawer.Content testId="not-enough-gas-bottom-sheet" sx={containerStyles}>
         <CloudImage
-          imageUrl={
-              tokenSymbol === ETH_TOKEN_SYMBOL
-                ? notEnoughEth
-                : notEnoughImx
-            }
-          imageResizeServiceUrl={IMAGE_RESIZER_URL[environment]}
           sx={{ w: '90px', h: tokenSymbol === ETH_TOKEN_SYMBOL ? '110px' : '90px' }}
+          use={(
+            <img
+              src={tokenSymbol === ETH_TOKEN_SYMBOL
+                ? notEnoughEth
+                : notEnoughImx}
+              alt={heading}
+            />
+          )}
         />
         <Heading
           size="small"

--- a/packages/checkout/widgets-lib/src/components/NotEnoughImx/NotEnoughImx.tsx
+++ b/packages/checkout/widgets-lib/src/components/NotEnoughImx/NotEnoughImx.tsx
@@ -12,7 +12,6 @@ import {
   actionButtonContainerStyles,
   logoContainerStyles,
 } from './NotEnoughImxStyles';
-import { IMAGE_RESIZER_URL } from '../../lib';
 
 type NotEnoughImxProps = {
   environment: Environment;
@@ -45,9 +44,13 @@ export function NotEnoughImx({
       <Drawer.Content>
         <Box testId="not-enough-gas-bottom-sheet" sx={containerStyles}>
           <CloudImage
-            imageUrl={imxLogo}
-            imageResizeServiceUrl={IMAGE_RESIZER_URL[environment]}
             sx={{ w: 'base.icon.size.600', h: 'base.icon.size.600' }}
+            use={(
+              <img
+                src={imxLogo}
+                alt={t(`drawers.notEnoughImx.content.${hasZeroImx ? 'noImx' : 'insufficientImx'}.heading`)}
+              />
+            )}
           />
           <Heading
             size="small"

--- a/packages/checkout/widgets-lib/src/components/Transactions/ChangeWallet.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/ChangeWallet.tsx
@@ -64,9 +64,13 @@ export function ChangeWallet({ onChangeWalletClick }: ChangeWalletProps) {
         {(isWalletConnect && walletLogoUrl) ? (
           <Box sx={wcWalletLogoWrapperStyles}>
             <FramedImage
-              imageUrl={walletLogoUrl}
-              alt="walletconnect"
               sx={wcWalletLogoStyles}
+              use={(
+                <img
+                  src={walletLogoUrl}
+                  alt="walletconnect"
+                />
+              )}
             />
             <Logo logo="WalletConnectSymbol" sx={wcStickerLogoStyles} />
           </Box>

--- a/packages/checkout/widgets-lib/src/components/Transactions/NotEnoughEthToWithdraw.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/NotEnoughEthToWithdraw.tsx
@@ -2,7 +2,7 @@ import {
   Body,
   Box, Button, CloudImage, Drawer, Heading,
 } from '@biom3/react';
-import { ETH_TOKEN_SYMBOL, IMAGE_RESIZER_URL } from 'lib';
+import { ETH_TOKEN_SYMBOL } from 'lib';
 import { useTranslation } from 'react-i18next';
 import { useContext } from 'react';
 import { BridgeContext } from 'widgets/bridge/context/BridgeContext';
@@ -38,9 +38,13 @@ export function NotEnoughEthToWithdraw({
       <Drawer.Content>
         <Box testId="not-enough-eth-drawer" sx={containerStyles}>
           <CloudImage
-            imageUrl={ethLogo}
-            imageResizeServiceUrl={IMAGE_RESIZER_URL[checkout.config.environment]}
             sx={{ w: 'base.icon.size.600', h: 'base.icon.size.600' }}
+            use={(
+              <img
+                src={ethLogo}
+                alt="ETH"
+              />
+            )}
           />
           <Heading
             size="small"

--- a/packages/checkout/widgets-lib/src/components/Transactions/TransactionItem.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/TransactionItem.tsx
@@ -7,7 +7,7 @@ import {
 } from '@biom3/react';
 import { UserJourney, useAnalytics } from 'context/analytics-provider/SegmentAnalyticsProvider';
 import { Transaction } from 'lib/clients/checkoutApiType';
-import { MouseEvent, useMemo } from 'react';
+import { MouseEvent, useMemo, useState } from 'react';
 import { containerStyles } from './transactionItemStyles';
 import { TransactionDetails } from './TransactionDetails';
 
@@ -35,7 +35,11 @@ export function TransactionItem({
   defaultTokenImage,
 }: TransactionItemProps) {
   const { track } = useAnalytics();
-
+  const [iconError, setIconError] = useState<boolean>(false);
+  const tokenUrl = useMemo(
+    () => ((!icon || iconError) ? defaultTokenImage : icon),
+    [icon, iconError, defaultTokenImage],
+  );
   const txnDetailsLink = useMemo(() => `${details.link}${details.hash}`, [details]);
 
   const handleDetailsLinkClick = (
@@ -79,7 +83,16 @@ export function TransactionItem({
       >
         <Accordion.TargetLeftSlot sx={{ pr: 'base.spacing.x2' }}>
           <MenuItem size="xSmall">
-            <MenuItem.FramedImage imageUrl={icon} circularFrame defaultImageUrl={defaultTokenImage} />
+            <MenuItem.FramedImage
+              circularFrame
+              use={(
+                <img
+                  src={tokenUrl}
+                  alt={label}
+                  onError={() => setIconError(true)}
+                />
+              )}
+            />
             <MenuItem.Label>
               {label}
             </MenuItem.Label>

--- a/packages/checkout/widgets-lib/src/components/Transactions/TransactionItemWithdrawPending.tsx
+++ b/packages/checkout/widgets-lib/src/components/Transactions/TransactionItemWithdrawPending.tsx
@@ -9,7 +9,7 @@ import {
 } from '@biom3/react';
 import { UserJourney, useAnalytics } from 'context/analytics-provider/SegmentAnalyticsProvider';
 import { Transaction, TransactionStatus } from 'lib/clients/checkoutApiType';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BridgeWidgetViews } from 'context/view-context/BridgeViewContextTypes';
 import { ViewActions, ViewContext } from 'context/view-context/ViewContext';
@@ -36,7 +36,11 @@ export function TransactionItemWithdrawPending({
   const { viewDispatch } = useContext(ViewContext);
   const { track } = useAnalytics();
   const translation = useTranslation();
-
+  const [iconError, setIconError] = useState<boolean>(false);
+  const tokenUrl = useMemo(
+    () => ((!icon || iconError) ? defaultTokenImage : icon),
+    [icon, iconError, defaultTokenImage],
+  );
   const dateNowUnixMs = useMemo(() => new Date().getTime(), []);
   const withdrawalReadyDate = useMemo(
     () => (transaction.details.current_status.withdrawal_ready_at
@@ -150,7 +154,16 @@ export function TransactionItemWithdrawPending({
       >
         <Accordion.TargetLeftSlot sx={{ pr: 'base.spacing.x2' }}>
           <MenuItem size="xSmall">
-            <MenuItem.FramedImage imageUrl={icon} circularFrame defaultImageUrl={defaultTokenImage} />
+            <MenuItem.FramedImage
+              circularFrame
+              use={(
+                <img
+                  src={tokenUrl}
+                  alt={label}
+                  onError={() => setIconError(true)}
+                />
+              )}
+            />
             <MenuItem.Label>
               {label}
             </MenuItem.Label>

--- a/packages/checkout/widgets-lib/src/components/UnableToConnectDrawer/UnableToConnectDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/UnableToConnectDrawer/UnableToConnectDrawer.tsx
@@ -11,7 +11,6 @@ import { Checkout } from '@imtbl/checkout-sdk';
 import { Environment } from '@imtbl/config';
 import { getRemoteImage } from 'lib/utils';
 import { useTranslation } from 'react-i18next';
-import { IMAGE_RESIZER_URL } from '../../lib';
 
 export interface UnableToConnectDrawerProps {
   visible: boolean;
@@ -57,9 +56,13 @@ export function UnableToConnectDrawer({
           }}
         >
           <CloudImage
-            imageUrl={walletErrorYellowUrl}
-            imageResizeServiceUrl={IMAGE_RESIZER_URL[checkout.config.environment]}
             sx={{ paddingTop: 'base.spacing.x4', paddingBottom: 'base.spacing.x9' }}
+            use={(
+              <img
+                src={walletErrorYellowUrl}
+                alt={t('drawers.walletConnectionError.unableToConnect.heading')}
+              />
+            )}
           />
           <ButtCon
             icon="Close"

--- a/packages/checkout/widgets-lib/src/widgets/bridge/BridgeWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/BridgeWidget.tsx
@@ -203,7 +203,12 @@ export default function BridgeWidget({
             <WalletNetworkSelectionView />
           )}
           {viewState.view.type === BridgeWidgetViews.BRIDGE_FORM && (
-            <Bridge amount={amount} tokenAddress={tokenAddress} defaultTokenImage={defaultTokenImage} />
+            <Bridge
+              amount={amount}
+              tokenAddress={tokenAddress}
+              defaultTokenImage={defaultTokenImage}
+              theme={theme}
+            />
           )}
           {viewState.view.type === BridgeWidgetViews.BRIDGE_REVIEW && (
             <BridgeReview />

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
@@ -5,13 +5,14 @@ import {
   OptionKey,
 } from '@biom3/react';
 import {
-  GetBalanceResult,
+  GetBalanceResult, WidgetTheme,
 } from '@imtbl/checkout-sdk';
 import {
   useCallback, useContext, useEffect, useMemo, useRef, useState,
 } from 'react';
 import { UserJourney, useAnalytics } from 'context/analytics-provider/SegmentAnalyticsProvider';
 import { useTranslation } from 'react-i18next';
+import { Environment } from '@imtbl/config';
 import { amountInputValidation } from '../../../lib/validations/amountInputValidations';
 import { BridgeActions, BridgeContext } from '../context/BridgeContext';
 import {
@@ -44,6 +45,8 @@ interface BridgeFormProps {
   defaultTokenAddress?: string;
   isTokenBalancesLoading?: boolean;
   defaultTokenImage: string;
+  environment?: Environment;
+  theme?: WidgetTheme;
 }
 
 export function BridgeForm(props: BridgeFormProps) {
@@ -69,6 +72,8 @@ export function BridgeForm(props: BridgeFormProps) {
     defaultTokenAddress,
     isTokenBalancesLoading,
     defaultTokenImage,
+    environment,
+    theme,
   } = props;
 
   const { track } = useAnalytics();
@@ -314,6 +319,8 @@ export function BridgeForm(props: BridgeFormProps) {
               errorMessage={t(tokenError)}
               onSelectChange={(option) => handleSelectTokenChange(option)}
               defaultTokenImage={defaultTokenImage}
+              environment={environment}
+              theme={theme}
             />
             <TextInputForm
               testId="bridge-amount"

--- a/packages/checkout/widgets-lib/src/widgets/bridge/views/Bridge.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/views/Bridge.tsx
@@ -4,7 +4,7 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { TokenFilterTypes } from '@imtbl/checkout-sdk';
+import { TokenFilterTypes, WidgetTheme } from '@imtbl/checkout-sdk';
 import { UserJourney, useAnalytics } from 'context/analytics-provider/SegmentAnalyticsProvider';
 import { useTranslation } from 'react-i18next';
 import { sendBridgeWidgetCloseEvent } from '../BridgeWidgetEvents';
@@ -23,9 +23,15 @@ export interface BridgeProps {
   amount?: string;
   tokenAddress?: string;
   defaultTokenImage: string;
+  theme: WidgetTheme;
 }
 
-export function Bridge({ amount, tokenAddress, defaultTokenImage }: BridgeProps) {
+export function Bridge({
+  amount,
+  tokenAddress,
+  defaultTokenImage,
+  theme,
+}: BridgeProps) {
   const { t } = useTranslation();
   const { bridgeState, bridgeDispatch } = useContext(BridgeContext);
   const { checkout, from } = bridgeState;
@@ -115,6 +121,8 @@ export function Bridge({ amount, tokenAddress, defaultTokenImage }: BridgeProps)
         defaultTokenAddress={tokenAddress}
         isTokenBalancesLoading={isTokenBalancesLoading}
         defaultTokenImage={defaultTokenImage}
+        environment={checkout?.config.environment}
+        theme={theme}
       />
     </SimpleLayout>
   );

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -722,6 +722,8 @@ export function SwapForm({ data, theme }: SwapFromProps) {
                 : undefined}
               coinSelectorHeading={t('views.SWAP.swapForm.from.selectorTitle')}
               defaultTokenImage={defaultTokenImage}
+              environment={checkout?.config.environment}
+              theme={theme}
             />
           </Box>
 
@@ -770,6 +772,8 @@ export function SwapForm({ data, theme }: SwapFromProps) {
                 : undefined}
               coinSelectorHeading={t('views.SWAP.swapForm.to.selectorTitle')}
               defaultTokenImage={defaultTokenImage}
+              environment={checkout?.config.environment}
+              theme={theme}
             />
           </Box>
         </Box>

--- a/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/components/BalanceItem/BalanceItem.tsx
@@ -5,7 +5,6 @@ import {
 import {
   IMTBLWidgetEvents, TokenFilterTypes, TokenInfo, WidgetTheme,
 } from '@imtbl/checkout-sdk';
-import { IMAGE_RESIZER_URL } from 'lib';
 import { Environment } from '@imtbl/config';
 import { ShowMenuItem } from './BalanceItemStyles';
 import { BalanceInfo } from '../../functions/tokenBalances';
@@ -44,9 +43,15 @@ export function BalanceItem({
   const [onRampAllowedTokens, setOnRampAllowedTokens] = useState<TokenInfo[]>(
     [],
   );
+  const [iconError, setIconError] = useState<boolean>(false);
 
   const isPassport = isPassportProvider(provider);
-  const environment = checkout?.config.environment ?? Environment.PRODUCTION;
+
+  const tokenUrl = useMemo(() => {
+    if (!checkout) return '';
+    const environment = checkout?.config.environment ?? Environment.PRODUCTION;
+    return iconError ? getDefaultTokenImage(environment, theme) : balanceInfo.icon;
+  }, [balanceInfo.icon, checkout, theme, iconError]);
 
   useEffect(() => {
     const getOnRampAllowedTokens = async () => {
@@ -92,9 +97,13 @@ export function BalanceItem({
   return (
     <MenuItem testId={`balance-item-${balanceInfo.symbol}`} emphasized>
       <MenuItem.FramedImage
-        imageResizeServiceUrl={IMAGE_RESIZER_URL[environment]}
-        imageUrl={balanceInfo.icon}
-        defaultImageUrl={getDefaultTokenImage(environment, theme)}
+        use={(
+          <img
+            src={tokenUrl}
+            alt={balanceInfo.symbol}
+            onError={() => setIconError(true)}
+          />
+        )}
         circularFrame
       />
       <MenuItem.Label>{balanceInfo.symbol}</MenuItem.Label>


### PR DESCRIPTION
# Summary
Updates to all token images and use of the Biome Cloud Image component to skip the Immutable Image Resizer.
[CM-616](https://immutable.atlassian.net/browse/CM-616)

# Detail and impact of the change
## Fixed
All token images loading now correctly display when loaded outside of an immutable.com domain.


[CM-616]: https://immutable.atlassian.net/browse/CM-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ