### PR TITLE
feat: [ID-1585] get signers after confirmation popup

### DIFF
--- a/packages/passport/sdk-sample-app/src/context/ImmutableProvider.tsx
+++ b/packages/passport/sdk-sample-app/src/context/ImmutableProvider.tsx
@@ -126,7 +126,7 @@ const getPassportConfig = (environment: EnvironmentNames): PassportModuleConfigu
           authenticationDomain: 'https://auth.dev.immutable.com',
           magicPublishableApiKey: 'pk_live_4058236363130CA9',
           magicProviderId: 'C9odf7hU4EQ5EufcfgYfcBaT5V6LhocXyiPRhIjw2EY=',
-          passportDomain: 'https://passport.dev.immutable.com',
+          passportDomain: 'passport.dev.immutable.com',
           imxPublicApiDomain: 'https://api.dev.immutable.com',
           imxApiClients: new ImxApiClients(createConfig({
             basePath: 'https://api.dev.immutable.com',

--- a/packages/passport/sdk/src/starkEx/passportImxProvider.ts
+++ b/packages/passport/sdk/src/starkEx/passportImxProvider.ts
@@ -1,10 +1,8 @@
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import {
   AnyToken,
-  EthSigner,
   IMXClient,
   NftTransferDetails,
-  StarkSigner,
   TokenAmount,
   UnsignedExchangeTransferRequest,
   UnsignedOrderRequest,
@@ -20,7 +18,8 @@ import TypedEventEmitter from '../utils/typedEventEmitter';
 import AuthManager from '../authManager';
 import GuardianClient from '../guardian';
 import {
-  PassportEventMap, PassportEvents, UserImx, User, IMXSigners, isUserImx,
+  PassportEventMap, PassportEvents, User, IMXSigners, isUserImx,
+  RegisteredUserAndSigners,
 } from '../types';
 import { PassportError, PassportErrorType } from '../errors/passportError';
 import {
@@ -38,12 +37,6 @@ export interface PassportImxProviderOptions {
   imxApiClients: ImxApiClients;
   guardianClient: GuardianClient;
 }
-
-export type RegisteredUserAndSigners = {
-  user: UserImx;
-  starkSigner: StarkSigner;
-  ethSigner: EthSigner;
-};
 
 export class PassportImxProvider implements IMXProvider {
   protected readonly authManager: AuthManager;

--- a/packages/passport/sdk/src/starkEx/passportImxProvider.ts
+++ b/packages/passport/sdk/src/starkEx/passportImxProvider.ts
@@ -39,7 +39,7 @@ export interface PassportImxProviderOptions {
   guardianClient: GuardianClient;
 }
 
-type RegisteredUserAndSigners = {
+export type RegisteredUserAndSigners = {
   user: UserImx;
   starkSigner: StarkSigner;
   ethSigner: EthSigner;
@@ -172,14 +172,11 @@ export class PassportImxProvider implements IMXProvider {
   }
 
   async transfer(request: UnsignedTransferRequest): Promise<imx.CreateTransferResponseV1> {
-    const { user, starkSigner } = await this.#getRegisteredImxUserAndSigners();
-
     return transfer({
       request,
-      user,
-      starkSigner,
       transfersApi: this.immutableXClient.transfersApi,
       guardianClient: this.guardianClient,
+      getRegisteredImxUserAndSigners: () => this.#getRegisteredImxUserAndSigners(),
     });
   }
 
@@ -213,67 +210,52 @@ export class PassportImxProvider implements IMXProvider {
   }
 
   async createOrder(request: UnsignedOrderRequest): Promise<imx.CreateOrderResponse> {
-    const { user, starkSigner } = await this.#getRegisteredImxUserAndSigners();
-
     return createOrder({
       request,
-      user,
-      starkSigner,
       ordersApi: this.immutableXClient.ordersApi,
       guardianClient: this.guardianClient,
+      getRegisteredImxUserAndSigners: () => this.#getRegisteredImxUserAndSigners(),
     });
   }
 
   async cancelOrder(
     request: imx.GetSignableCancelOrderRequest,
   ): Promise<imx.CancelOrderResponse> {
-    const { user, starkSigner } = await this.#getRegisteredImxUserAndSigners();
-
     return cancelOrder({
       request,
-      user,
-      starkSigner,
       ordersApi: this.immutableXClient.ordersApi,
       guardianClient: this.guardianClient,
+      getRegisteredImxUserAndSigners: () => this.#getRegisteredImxUserAndSigners(),
     });
   }
 
   async createTrade(request: imx.GetSignableTradeRequest): Promise<imx.CreateTradeResponse> {
-    const { user, starkSigner } = await this.#getRegisteredImxUserAndSigners();
-
     return createTrade({
       request,
-      user,
-      starkSigner,
       tradesApi: this.immutableXClient.tradesApi,
       guardianClient: this.guardianClient,
+      getRegisteredImxUserAndSigners: () => this.#getRegisteredImxUserAndSigners(),
     });
   }
 
   async batchNftTransfer(
     request: NftTransferDetails[],
   ): Promise<imx.CreateTransferResponse> {
-    const { user, starkSigner } = await this.#getRegisteredImxUserAndSigners();
-
     return batchNftTransfer({
       request,
-      user,
-      starkSigner,
       transfersApi: this.immutableXClient.transfersApi,
       guardianClient: this.guardianClient,
+      getRegisteredImxUserAndSigners: () => this.#getRegisteredImxUserAndSigners(),
     });
   }
 
   async exchangeTransfer(
     request: UnsignedExchangeTransferRequest,
   ): Promise<imx.CreateTransferResponseV1> {
-    const { user, starkSigner } = await this.#getRegisteredImxUserAndSigners();
-
     return exchangeTransfer({
       request,
-      user,
-      starkSigner,
       exchangesApi: this.immutableXClient.exchangeApi,
+      getRegisteredImxUserAndSigners: () => this.#getRegisteredImxUserAndSigners(),
     });
   }
 

--- a/packages/passport/sdk/src/starkEx/workflows/exchange.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/exchange.ts
@@ -1,26 +1,24 @@
 import { imx } from '@imtbl/generated-clients';
 import {
-  StarkSigner,
   UnsignedExchangeTransferRequest,
 } from '@imtbl/x-client';
 import { convertToSignableToken } from '@imtbl/toolkit';
+import { RegisteredUserAndSigners } from 'starkEx/passportImxProvider';
 import { PassportErrorType, withPassportError } from '../../errors/passportError';
-import { UserImx } from '../../types';
 
 type TransfersParams = {
-  user: UserImx;
-  starkSigner: StarkSigner;
   request: UnsignedExchangeTransferRequest;
   exchangesApi: imx.ExchangesApi;
+  getRegisteredImxUserAndSigners: () => Promise<RegisteredUserAndSigners>
 };
 
 export async function exchangeTransfer({
-  user,
-  starkSigner,
   request,
   exchangesApi,
+  getRegisteredImxUserAndSigners,
 }: TransfersParams): Promise<imx.CreateTransferResponseV1> {
   return withPassportError<imx.CreateTransferResponseV1>(async () => {
+    const { user, starkSigner } = await getRegisteredImxUserAndSigners();
     const { ethAddress } = user.imx;
     const transferAmount = request.amount;
     const signableResult = await exchangesApi.getExchangeSignableTransfer({

--- a/packages/passport/sdk/src/starkEx/workflows/exchange.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/exchange.ts
@@ -3,7 +3,7 @@ import {
   UnsignedExchangeTransferRequest,
 } from '@imtbl/x-client';
 import { convertToSignableToken } from '@imtbl/toolkit';
-import { RegisteredUserAndSigners } from 'types';
+import { RegisteredUserAndSigners } from '../../types';
 import { PassportErrorType, withPassportError } from '../../errors/passportError';
 
 type TransfersParams = {

--- a/packages/passport/sdk/src/starkEx/workflows/exchange.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/exchange.ts
@@ -3,7 +3,7 @@ import {
   UnsignedExchangeTransferRequest,
 } from '@imtbl/x-client';
 import { convertToSignableToken } from '@imtbl/toolkit';
-import { RegisteredUserAndSigners } from 'starkEx/passportImxProvider';
+import { RegisteredUserAndSigners } from 'types';
 import { PassportErrorType, withPassportError } from '../../errors/passportError';
 
 type TransfersParams = {

--- a/packages/passport/sdk/src/starkEx/workflows/order.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/order.ts
@@ -3,7 +3,7 @@ import {
   UnsignedOrderRequest,
 } from '@imtbl/x-client';
 import { convertToSignableToken } from '@imtbl/toolkit';
-import { RegisteredUserAndSigners } from 'starkEx/passportImxProvider';
+import { RegisteredUserAndSigners } from 'types';
 import { PassportErrorType, withPassportError } from '../../errors/passportError';
 import GuardianClient from '../../guardian';
 

--- a/packages/passport/sdk/src/starkEx/workflows/order.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/order.ts
@@ -3,7 +3,7 @@ import {
   UnsignedOrderRequest,
 } from '@imtbl/x-client';
 import { convertToSignableToken } from '@imtbl/toolkit';
-import { RegisteredUserAndSigners } from 'types';
+import { RegisteredUserAndSigners } from '../../types';
 import { PassportErrorType, withPassportError } from '../../errors/passportError';
 import GuardianClient from '../../guardian';
 

--- a/packages/passport/sdk/src/starkEx/workflows/trades.test.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/trades.test.ts
@@ -1,6 +1,8 @@
 import { imx } from '@imtbl/generated-clients';
 import { createTrade } from './trades';
-import { mockErrorMessage, mockStarkSignature, mockUserImx } from '../../test/mocks';
+import {
+  mockErrorMessage, mockGetRegisteredImxUserAndSigners, mockStarkSignature, mockStarkSigner, mockUserImx,
+} from '../../test/mocks';
 import { PassportError, PassportErrorType } from '../../errors/passportError';
 import GuardianClient from '../../guardian';
 
@@ -55,10 +57,6 @@ const mockReturnValue = {
   status: 'success',
   trade_id: 123,
 };
-const mockStarkSigner = {
-  signMessage: jest.fn(),
-  getAddress: jest.fn(),
-};
 
 describe('Trades', () => {
   const mockGuardianClient = new GuardianClient({} as any);
@@ -87,10 +85,9 @@ describe('Trades', () => {
 
       const result = await createTrade({
         tradesApi: mockTradesApi,
-        starkSigner: mockStarkSigner,
-        user: mockUserImx,
         request: mockSignableTradeRequest.getSignableTradeRequest,
         guardianClient: mockGuardianClient,
+        getRegisteredImxUserAndSigners: mockGetRegisteredImxUserAndSigners,
       });
 
       expect(mockGetSignableTrade).toBeCalledWith(mockSignableTradeRequest, mockHeader);
@@ -111,10 +108,9 @@ describe('Trades', () => {
 
       await expect(() => createTrade({
         tradesApi: mockTradesApi,
-        starkSigner: mockStarkSigner,
-        user: mockUserImx,
         request: mockSignableTradeRequest.getSignableTradeRequest,
         guardianClient: mockGuardianClient,
+        getRegisteredImxUserAndSigners: mockGetRegisteredImxUserAndSigners,
       })).rejects.toThrowError('Transaction rejected by user');
 
       expect(mockGuardianClient.withDefaultConfirmationScreenTask).toBeCalled();
@@ -127,10 +123,9 @@ describe('Trades', () => {
 
       await expect(() => createTrade({
         tradesApi: mockTradesApi,
-        starkSigner: mockStarkSigner,
-        user: mockUserImx,
         request: mockSignableTradeRequest.getSignableTradeRequest,
         guardianClient: mockGuardianClient,
+        getRegisteredImxUserAndSigners: mockGetRegisteredImxUserAndSigners,
       })).rejects.toThrow(
         new PassportError(
           mockErrorMessage,

--- a/packages/passport/sdk/src/starkEx/workflows/trades.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/trades.ts
@@ -1,25 +1,23 @@
 import { imx } from '@imtbl/generated-clients';
-import { StarkSigner } from '@imtbl/x-client';
+import { RegisteredUserAndSigners } from 'starkEx';
 import { PassportErrorType, withPassportError } from '../../errors/passportError';
-import { UserImx } from '../../types';
 import GuardianClient from '../../guardian';
 
 type CreateTradeParams = {
   request: imx.GetSignableTradeRequest;
   tradesApi: imx.TradesApi;
-  user: UserImx;
-  starkSigner: StarkSigner;
   guardianClient: GuardianClient,
+  getRegisteredImxUserAndSigners: () => Promise<RegisteredUserAndSigners>;
 };
 
 export async function createTrade({
   request,
   tradesApi,
-  user,
-  starkSigner,
   guardianClient,
+  getRegisteredImxUserAndSigners,
 }: CreateTradeParams): Promise<imx.CreateTradeResponse> {
   return withPassportError<imx.CreateTradeResponse>(guardianClient.withDefaultConfirmationScreenTask(async () => {
+    const { user, starkSigner } = await getRegisteredImxUserAndSigners();
     const { ethAddress } = user.imx;
     const getSignableTradeRequest: imx.GetSignableTradeRequest = {
       expiration_timestamp: request.expiration_timestamp,

--- a/packages/passport/sdk/src/starkEx/workflows/trades.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/trades.ts
@@ -1,5 +1,5 @@
 import { imx } from '@imtbl/generated-clients';
-import { RegisteredUserAndSigners } from 'types';
+import { RegisteredUserAndSigners } from '../../types';
 import { PassportErrorType, withPassportError } from '../../errors/passportError';
 import GuardianClient from '../../guardian';
 

--- a/packages/passport/sdk/src/starkEx/workflows/trades.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/trades.ts
@@ -1,5 +1,5 @@
 import { imx } from '@imtbl/generated-clients';
-import { RegisteredUserAndSigners } from 'starkEx';
+import { RegisteredUserAndSigners } from 'types';
 import { PassportErrorType, withPassportError } from '../../errors/passportError';
 import GuardianClient from '../../guardian';
 

--- a/packages/passport/sdk/src/starkEx/workflows/transfer.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/transfer.ts
@@ -4,7 +4,7 @@ import {
   UnsignedTransferRequest,
 } from '@imtbl/x-client';
 import { convertToSignableToken } from '@imtbl/toolkit';
-import { RegisteredUserAndSigners } from 'types';
+import { RegisteredUserAndSigners } from '../../types';
 import {
   PassportErrorType,
   withPassportError,

--- a/packages/passport/sdk/src/starkEx/workflows/transfer.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/transfer.ts
@@ -4,7 +4,7 @@ import {
   UnsignedTransferRequest,
 } from '@imtbl/x-client';
 import { convertToSignableToken } from '@imtbl/toolkit';
-import { RegisteredUserAndSigners } from 'starkEx';
+import { RegisteredUserAndSigners } from 'types';
 import {
   PassportErrorType,
   withPassportError,

--- a/packages/passport/sdk/src/starkEx/workflows/workflows.test.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/workflows.test.ts
@@ -39,7 +39,7 @@ describe('passportImxProvider auth tests', () => {
 
   const mockGuardianClient = {
     withDefaultConfirmationScreenTask: (task: () => any) => task,
-    withConfirmationScreenTask: (task: () => any) => (() => task()),
+    withConfirmationScreenTask: () => (task: () => any) => task,
   };
 
   const passportImxProvider = new PassportImxProvider({
@@ -77,7 +77,7 @@ describe('passportImxProvider auth tests', () => {
     });
   });
 
-  describe.only.each([
+  describe.each([
     ['transfer' as const, {} as UnsignedTransferRequest],
     ['createOrder' as const, {} as UnsignedOrderRequest],
     ['cancelOrder' as const, {} as imx.GetSignableCancelOrderRequest],

--- a/packages/passport/sdk/src/starkEx/workflows/workflows.test.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/workflows.test.ts
@@ -1,0 +1,105 @@
+import { ImxApiClients, imx } from '@imtbl/generated-clients';
+import {
+  Environment,
+  IMXClient,
+  ImmutableConfiguration,
+  NftTransferDetails,
+  UnsignedExchangeTransferRequest,
+  UnsignedOrderRequest,
+  UnsignedTransferRequest,
+} from '@imtbl/x-client';
+import AuthManager from 'authManager';
+import { PassportError, PassportErrorType } from 'errors/passportError';
+import GuardianClient from 'guardian';
+import MagicAdapter from 'magicAdapter';
+import { PassportImxProvider } from 'starkEx/passportImxProvider';
+import { PassportEventMap, PassportEvents } from 'types';
+import TypedEventEmitter from 'utils/typedEventEmitter';
+
+describe('passportImxProvider auth tests', () => {
+  const mockAuthManager = {
+    login: jest.fn(),
+    getUser: jest.fn(),
+    forceUserRefresh: jest.fn(),
+  };
+
+  const immutableXClient = new IMXClient({
+    baseConfig: new ImmutableConfiguration({
+      environment: Environment.SANDBOX,
+    }),
+  });
+
+  const passportEventEmitter = new TypedEventEmitter<PassportEventMap>();
+
+  const magicAdapterMock = {
+    login: jest.fn(),
+  };
+
+  const imxApiClients = new ImxApiClients({} as any);
+
+  const mockGuardianClient = {
+    withDefaultConfirmationScreenTask: (task: () => any) => task,
+    withConfirmationScreenTask: (task: () => any) => (() => task()),
+  };
+
+  const passportImxProvider = new PassportImxProvider({
+    authManager: mockAuthManager as unknown as AuthManager,
+    magicAdapter: magicAdapterMock as unknown as MagicAdapter,
+    guardianClient: mockGuardianClient as unknown as GuardianClient,
+    immutableXClient,
+    passportEventEmitter,
+    imxApiClients,
+  });
+
+  describe.each([
+    ['transfer' as const, {} as UnsignedTransferRequest],
+    ['createOrder' as const, {} as UnsignedOrderRequest],
+    ['cancelOrder' as const, {} as imx.GetSignableCancelOrderRequest],
+    ['createTrade' as const, {} as imx.GetSignableTradeRequest],
+    ['batchNftTransfer' as const, [] as NftTransferDetails[]],
+    ['exchangeTransfer' as const, {} as UnsignedExchangeTransferRequest],
+    ['getAddress' as const, {} as any],
+    ['isRegisteredOffchain' as const, {} as any],
+  ])('when the user has been logged out - %s', (methodName, args) => {
+    beforeEach(() => {
+      passportEventEmitter.emit(PassportEvents.LOGGED_OUT);
+    });
+
+    it(`should return an error for ${methodName}`, async () => {
+      expect(async () => await passportImxProvider[methodName!](args))
+        .rejects
+        .toThrow(
+          new PassportError(
+            'User has been logged out',
+            PassportErrorType.NOT_LOGGED_IN_ERROR,
+          ),
+        );
+    });
+  });
+
+  describe.only.each([
+    ['transfer' as const, {} as UnsignedTransferRequest],
+    ['createOrder' as const, {} as UnsignedOrderRequest],
+    ['cancelOrder' as const, {} as imx.GetSignableCancelOrderRequest],
+    ['createTrade' as const, {} as imx.GetSignableTradeRequest],
+    ['batchNftTransfer' as const, [] as NftTransferDetails[]],
+    ['exchangeTransfer' as const, {} as UnsignedExchangeTransferRequest],
+    ['getAddress' as const, {} as any],
+    ['isRegisteredOffchain' as const, {} as any],
+  ])('when the user\'s access token is expired and cannot be retrieved', (methodName, args) => {
+    beforeEach(() => {
+      mockAuthManager.getUser.mockResolvedValue(null);
+    });
+
+    it(`should return an error for ${methodName}`, async () => {
+      await expect(async () => passportImxProvider[methodName!](args))
+        .rejects
+        .toThrow(
+          new PassportError(
+            'User has been logged out',
+            PassportErrorType.NOT_LOGGED_IN_ERROR,
+          ),
+        );
+    });
+  });
+});

--- a/packages/passport/sdk/src/starkEx/workflows/workflows.test.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/workflows.test.ts
@@ -78,13 +78,16 @@ describe('passportImxProvider auth tests', () => {
     });
 
     it(`should return an error for ${methodName}`, async () => {
+      let message = '';
+      let type = '';
       try {
         await passportImxProvider[methodName!](args);
       } catch (err: any) {
-        const { message, type } = err;
-        expect(message).toEqual('User has been logged out');
-        expect(type).toEqual(WorkflowErrorMap[methodName]);
+        message = err.message;
+        type = err.type;
       }
+      expect(message).toEqual('User has been logged out');
+      expect(type).toEqual(WorkflowErrorMap[methodName]);
     });
   });
 
@@ -103,13 +106,16 @@ describe('passportImxProvider auth tests', () => {
     });
 
     it(`should return an error for ${methodName}`, async () => {
+      let message = '';
+      let type = '';
       try {
         await passportImxProvider[methodName!](args);
       } catch (err: any) {
-        const { message, type } = err;
-        expect(message).toEqual('User has been logged out');
-        expect(type).toEqual(WorkflowErrorMap[methodName]);
+        message = err.message;
+        type = err.type;
       }
+      expect(message).toEqual('User has been logged out');
+      expect(type).toEqual(WorkflowErrorMap[methodName]);
     });
   });
 });

--- a/packages/passport/sdk/src/starkEx/workflows/workflows.test.ts
+++ b/packages/passport/sdk/src/starkEx/workflows/workflows.test.ts
@@ -9,12 +9,24 @@ import {
   UnsignedTransferRequest,
 } from '@imtbl/x-client';
 import AuthManager from 'authManager';
-import { PassportError, PassportErrorType } from 'errors/passportError';
+import { PassportErrorType } from 'errors/passportError';
 import GuardianClient from 'guardian';
 import MagicAdapter from 'magicAdapter';
 import { PassportImxProvider } from 'starkEx/passportImxProvider';
 import { PassportEventMap, PassportEvents } from 'types';
 import TypedEventEmitter from 'utils/typedEventEmitter';
+
+enum WorkflowErrorMap {
+  transfer = PassportErrorType.TRANSFER_ERROR,
+  createOrder = PassportErrorType.CREATE_ORDER_ERROR,
+  cancelOrder = PassportErrorType.CANCEL_ORDER_ERROR,
+  createTrade = PassportErrorType.CREATE_TRADE_ERROR,
+  batchNftTransfer = PassportErrorType.TRANSFER_ERROR,
+  exchangeTransfer = PassportErrorType.EXCHANGE_TRANSFER_ERROR,
+  getAddress = PassportErrorType.NOT_LOGGED_IN_ERROR,
+  isRegisteredOffchain = PassportErrorType.NOT_LOGGED_IN_ERROR,
+
+}
 
 describe('passportImxProvider auth tests', () => {
   const mockAuthManager = {
@@ -66,14 +78,13 @@ describe('passportImxProvider auth tests', () => {
     });
 
     it(`should return an error for ${methodName}`, async () => {
-      expect(async () => await passportImxProvider[methodName!](args))
-        .rejects
-        .toThrow(
-          new PassportError(
-            'User has been logged out',
-            PassportErrorType.NOT_LOGGED_IN_ERROR,
-          ),
-        );
+      try {
+        await passportImxProvider[methodName!](args);
+      } catch (err: any) {
+        const { message, type } = err;
+        expect(message).toEqual('User has been logged out');
+        expect(type).toEqual(WorkflowErrorMap[methodName]);
+      }
     });
   });
 
@@ -92,14 +103,13 @@ describe('passportImxProvider auth tests', () => {
     });
 
     it(`should return an error for ${methodName}`, async () => {
-      await expect(async () => passportImxProvider[methodName!](args))
-        .rejects
-        .toThrow(
-          new PassportError(
-            'User has been logged out',
-            PassportErrorType.NOT_LOGGED_IN_ERROR,
-          ),
-        );
+      try {
+        await passportImxProvider[methodName!](args);
+      } catch (err: any) {
+        const { message, type } = err;
+        expect(message).toEqual('User has been logged out');
+        expect(type).toEqual(WorkflowErrorMap[methodName]);
+      }
     });
   });
 });

--- a/packages/passport/sdk/src/test/mocks.ts
+++ b/packages/passport/sdk/src/test/mocks.ts
@@ -1,6 +1,7 @@
 import { Environment, ImmutableConfiguration } from '@imtbl/config';
-import { RegisteredUserAndSigners } from 'starkEx';
-import { User, UserImx, UserZkEvm } from '../types';
+import {
+  RegisteredUserAndSigners, User, UserImx, UserZkEvm,
+} from '../types';
 import { PassportConfiguration } from '../config';
 import { ChainId } from '../network/chains';
 

--- a/packages/passport/sdk/src/test/mocks.ts
+++ b/packages/passport/sdk/src/test/mocks.ts
@@ -1,4 +1,5 @@
 import { Environment, ImmutableConfiguration } from '@imtbl/config';
+import { RegisteredUserAndSigners } from 'starkEx';
 import { User, UserImx, UserZkEvm } from '../types';
 import { PassportConfiguration } from '../config';
 import { ChainId } from '../network/chains';
@@ -71,3 +72,15 @@ export const mockListChains = {
     ],
   },
 };
+
+export const mockStarkSigner = {
+  getAddress: jest.fn(),
+  signMessage: jest.fn(),
+};
+
+export const mockRegisteredImxUserAndSigners = {
+  starkSigner: mockStarkSigner,
+  user: mockUserImx,
+} as unknown as RegisteredUserAndSigners;
+
+export const mockGetRegisteredImxUserAndSigners = () => Promise.resolve(mockRegisteredImxUserAndSigners);

--- a/packages/passport/sdk/src/types.ts
+++ b/packages/passport/sdk/src/types.ts
@@ -150,3 +150,9 @@ export type IMXSigners = {
   starkSigner: StarkSigner,
   ethSigner: EthSigner;
 };
+
+export type RegisteredUserAndSigners = {
+  user: UserImx;
+  starkSigner: StarkSigner;
+  ethSigner: EthSigner;
+};


### PR DESCRIPTION
# Summary
[Jira ticket](https://immutable.atlassian.net/browse/ID-1585)
Moved initialisation of starkex signers after the confirmation popup is initialised, in order to avoid possible popup blocking issues