### PR TITLE
fix: rename zkEVM job

### DIFF
--- a/.github/workflows/functional-tests-zkevm.yml
+++ b/.github/workflows/functional-tests-zkevm.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  funcTestZkevm:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Rename the zkEVM function test job name so I can be excluded from the required status checks. 


