### PR TITLE
fix: Safely handle empty Swap fees

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.test.ts
@@ -133,4 +133,51 @@ describe('formatQuoteConversionRate', () => {
       fee: 1,
     });
   });
+
+  it('should handle an empty fee array', () => {
+    const fromAmount = '1.50';
+    const fromToken = {
+      name: 'ETH',
+      symbol: 'ETH',
+      address: '0x123',
+      chainId: 1,
+      decimals: 18,
+    } as TokenInfo;
+    const mockQuote = {
+      quote: {
+        amount: {
+          value: BigNumber.from('2000000000000000000'),
+          token: {
+            symbol: 'DAI',
+            address: '0x456',
+            chainId: 1,
+            decimals: 18,
+          },
+        } as Amount,
+        amountWithMaxSlippage: {} as Amount,
+        slippage: 0,
+        fees: [],
+      } as Quote,
+      swap: {
+        gasFeeEstimate: {
+          value: BigNumber.from(100),
+        },
+      },
+      approval: {
+        gasFeeEstimate: {
+          value: BigNumber.from(50),
+        },
+      },
+    } as TransactionResponse;
+    const labelKey = 'conversion.label';
+
+    formatQuoteConversionRate(fromAmount, fromToken, mockQuote, labelKey, mockTranslate as unknown as TFunction);
+
+    expect(mockTranslate).toHaveBeenCalledWith(labelKey, {
+      fromSymbol: 'ETH',
+      toSymbol: 'DAI',
+      rate: '1.33',
+      fee: 0,
+    });
+  });
 });

--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.ts
@@ -54,6 +54,6 @@ export const formatQuoteConversionRate = (
     fromSymbol: fromToken.symbol,
     toSymbol: toToken.symbol,
     rate: formattedConversion,
-    fee: secondaryFee.basisPoints / 100,
+    fee: (secondaryFee?.basisPoints ?? 0) / 100,
   });
 };


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
* Handles uncaught exception showing Swap Fees when `quotesProcessor` returns no fees

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
* On dev environments, the `fees` array is empty when swapping `tIMX > WIMX`, causing the Swap widget to crash


## Fixed
<!-- Section for any bug fixes. -->
* Fallback to 0 if this fees are not available when displaying Swap secondary fees

https://github.com/immutable/ts-immutable-sdk/assets/13159042/185b4a32-87eb-4404-9374-2f667c55ffd7




