### PR TITLE
feat: Switch to tenderly estimation

### DIFF
--- a/packages/internal/bridge/sdk/src/constants/bridges.ts
+++ b/packages/internal/bridge/sdk/src/constants/bridges.ts
@@ -157,9 +157,9 @@ export const axelarAPIEndpoints:Record<string, string> = {
  * @typedef {Object} tenderlyAPIEndpoints - API endpoints for the testnet & mainnet Axelar environment configurations
  */
 export const tenderlyAPIEndpoints:Record<string, string> = {
-  mainnet: 'https://bridge-api.immutable.com/v1/tenderly/simulate',
-  testnet: 'https://bridge-api.sandbox.immutable.com/v1/tenderly/simulate',
-  devnet: 'https://bridge-api.dev.immutable.com/v1/tenderly/simulate',
+  mainnet: 'https://bridge-api.immutable.com/v1/tenderly/estimate',
+  testnet: 'https://bridge-api.sandbox.immutable.com/v1/tenderly/estimate',
+  devnet: 'https://bridge-api.dev.immutable.com/v1/tenderly/estimate',
 };
 
 /**

--- a/packages/internal/bridge/sdk/src/types/tenderly.ts
+++ b/packages/internal/bridge/sdk/src/types/tenderly.ts
@@ -1,11 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 export type TenderlySimulation = {
-  network_id: string;
-  estimate_gas: boolean;
-  simulation_type: string;
   from: string;
   to: string;
-  input: string;
+  data?: string;
   value?: string;
-  state_objects?: Record<string, Record<string, Record<string, string>>>;
 };


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Currently, we are using tenderly simulate batch API to estimate gas but Tenderly team has recently implemented estimate gas API that is faster and 10x less expensive.
This PR switches the usage of simulation to estimation in the bridge SDK.

# Detail and impact of the change
## Changed
<!-- Section for changes in existing functionality. -->
This PR changed from tenderly simulation API to tenderly node estimation API inside the bridge dynamic gas estimation.