### PR TITLE
fix: [CM-638] Include quote basis Points on smartCheckout response

### DIFF
--- a/packages/checkout/sdk/src/smartCheckout/routing/swap/swapRoute.test.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/swap/swapRoute.test.ts
@@ -274,6 +274,7 @@ describe('swapRoute', () => {
               type: FeeType.SWAP_FEE,
               amount: BigNumber.from(3),
               formattedAmount: utils.formatUnits(BigNumber.from(3), 18),
+              basisPoints: 0,
               token: {
                 decimals: 18,
                 name: 'IMX',
@@ -404,6 +405,7 @@ describe('swapRoute', () => {
               type: FeeType.SWAP_FEE,
               amount: BigNumber.from(3),
               formattedAmount: utils.formatUnits(BigNumber.from(3), 18),
+              basisPoints: 0,
               token: {
                 decimals: 18,
                 name: 'IMX',
@@ -546,6 +548,7 @@ describe('swapRoute', () => {
               type: FeeType.SWAP_FEE,
               amount: BigNumber.from(3),
               formattedAmount: utils.formatUnits(BigNumber.from(3), 18),
+              basisPoints: 0,
               token: {
                 decimals: 18,
                 name: 'IMX',
@@ -599,6 +602,7 @@ describe('swapRoute', () => {
               type: FeeType.SWAP_FEE,
               amount: BigNumber.from(3),
               formattedAmount: utils.formatUnits(BigNumber.from(3), 18),
+              basisPoints: 0,
               token: {
                 decimals: 18,
                 name: 'IMX',

--- a/packages/checkout/sdk/src/smartCheckout/routing/swap/swapRoute.ts
+++ b/packages/checkout/sdk/src/smartCheckout/routing/swap/swapRoute.ts
@@ -4,6 +4,7 @@ import { CheckoutConfiguration, getL2ChainId } from '../../../config';
 import {
   AvailableRoutingOptions,
   ChainId,
+  Fee as SwapFee,
   FeeType,
   FundingStepType,
   GetBalanceResult,
@@ -51,12 +52,13 @@ const constructFees = (
     };
   }
 
-  const fees = [];
+  const fees: SwapFee[] = [];
   for (const swapFee of swapFees) {
     fees.push({
       type: FeeType.SWAP_FEE,
       amount: swapFee.amount.value,
       formattedAmount: utils.formatUnits(swapFee.amount.value, swapFee.amount.token.decimals),
+      basisPoints: swapFee.basisPoints,
       token: {
         name: swapFee.amount.token.name ?? '',
         symbol: swapFee.amount.token.symbol ?? '',

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -739,6 +739,8 @@ export type Fee = {
   formattedAmount: string;
   /** The token info for the fee */
   token?: TokenInfo;
+  /** The basis points for the secondary fee */
+  basisPoints?: number;
 };
 
 /**


### PR DESCRIPTION
# Summary
Including field `basisPoints` from `quote` on smart checkout response, to allow consumer to calculate % fee applied on secondary fees.
