### PR TITLE
[fix][sale widget] cm-658 hide more options divider if no fiat payment options are available

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/components/CoinsDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/CoinsDrawer.tsx
@@ -112,18 +112,22 @@ export function CoinsDrawer({
                 />
               )}
             >
-              <Divider
-                size="small"
-                rc={<Caption />}
-                sx={{ my: 'base.spacing.x4' }}
-              >
-                {t('views.ORDER_SUMMARY.coinsDrawer.divider')}
-              </Divider>
+              {(disabledPaymentTypes?.includes(SalePaymentTypes.CREDIT)
+                && disabledPaymentTypes?.includes(SalePaymentTypes.DEBIT)) ?? (
+                <Divider
+                  size="small"
+                  rc={<Caption />}
+                  sx={{ my: 'base.spacing.x4' }}
+                >
+                  {t('views.ORDER_SUMMARY.coinsDrawer.divider')}
+                </Divider>
+              )}
               <PaymentOptions
                 onClick={onPayWithCard}
-                paymentOptions={[SalePaymentTypes.DEBIT, SalePaymentTypes.CREDIT].filter(
-                  (type) => !disabledPaymentTypes?.includes(type),
-                )}
+                paymentOptions={[
+                  SalePaymentTypes.DEBIT,
+                  SalePaymentTypes.CREDIT,
+                ].filter((type) => !disabledPaymentTypes?.includes(type))}
                 captions={{
                   [SalePaymentTypes.DEBIT]: t(
                     'views.ORDER_SUMMARY.coinsDrawer.payWithCard.caption',


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

## Fixed
<!-- Section for any bug fixes. -->
Hide more options divider from sale widget coins drawer if no fiat payments options are available.
