### PR TITLE
feat:[CM-532][Bridge Widget] Rename Bridge Service Fee Labels

### DIFF
--- a/packages/checkout/widgets-lib/src/locales/en.json
+++ b/packages/checkout/widgets-lib/src/locales/en.json
@@ -636,7 +636,8 @@
           "label": "{{amount}} Swap fee (factored into quote)"
         },
         "serviceFee": {
-          "label": "Service fee"
+          "depositLabel": "zkEVM gas fees",
+          "withdrawLabel": "Ethereum gas fees"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -623,7 +623,8 @@
           "label": "{{amount}} スワップ手数料（見積もりに含まれる）"
         },
         "serviceFee": {
-          "label": "サービス手数料"
+          "depositLabel": "zkEVM ガス手数料",
+          "withdrawLabel": "Ethereum ガス手数料"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -616,7 +616,8 @@
           "label": "{{amount}} 스왑 수수료 (견적에 포함)"
         },
         "serviceFee": {
-          "label": "서비스 수수료"
+          "depositLabel": "zkEVM 가스 수수료",
+          "withdrawLabel": "Ethereum 가스 수수료"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -616,7 +616,8 @@
           "label": "{{amount}} 交换费（已计入报价）"
         },
         "serviceFee": {
-          "label": "服务费"
+          "depositLabel": "zkEVM 气体费用",
+          "withdrawLabel": "Ethereum 气体费用"
         }
       }
     },

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
@@ -25,6 +25,7 @@ import {
   NATIVE,
   addChainChangedListener,
   getL1ChainId,
+  getL2ChainId,
   networkIcon,
   removeChainChangedListener,
 } from 'lib';
@@ -105,6 +106,10 @@ export function BridgeReviewSummary() {
   const [showNotEnoughGasDrawer, setShowNotEnoughGasDrawer] = useState(false);
 
   const isTransfer = useMemo(() => from?.network === to?.network, [from, to]);
+  const isDeposit = useMemo(
+    () => (getL2ChainId(checkout.config) === to?.network),
+    [from, to, checkout],
+  );
   const insufficientFundsForGas = useMemo(() => {
     if (!estimates) return false;
     if (!token) return true;
@@ -231,7 +236,6 @@ export function BridgeReviewSummary() {
       },
       token: checkout.config.networkMap.get(from!.network)?.nativeCurrency,
     } as GasEstimateBridgeToL2Result;
-
     setEstimates(gasEstimateResult);
     const estimatedAmount = utils.formatUnits(
       gasEstimateResult?.fees.totalFees || 0,
@@ -256,8 +260,8 @@ export function BridgeReviewSummary() {
   }, DEFAULT_QUOTE_REFRESH_INTERVAL);
 
   const formatFeeBreakdown = useCallback(
-    () => formatBridgeFees(estimates, cryptoFiatState, t),
-    [estimates],
+    () => formatBridgeFees(estimates, isDeposit, cryptoFiatState, t),
+    [estimates, isDeposit],
   );
 
   useEffect(() => {

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
@@ -80,7 +80,7 @@ export function BridgeReviewSummary() {
 
   const { cryptoFiatState } = useContext(CryptoFiatContext);
   const [loading, setLoading] = useState(false);
-  const [estimates, setEstimates] = useState<any | undefined>(undefined);
+  const [estimates, setEstimates] = useState<GasEstimateBridgeToL2Result | undefined>(undefined);
   const [gasFee, setGasFee] = useState<string>('');
   const [gasFeeFiatValue, setGasFeeFiatValue] = useState<string>('');
   const [approveTransaction, setApproveTransaction] = useState<

--- a/packages/checkout/widgets-lib/src/widgets/bridge/functions/BridgeFees.ts
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/functions/BridgeFees.ts
@@ -6,6 +6,7 @@ import { CryptoFiatState } from '../../../context/crypto-fiat-context/CryptoFiat
 
 export const formatBridgeFees = (
   estimates: GasEstimateBridgeToL2Result | undefined,
+  isDeposit: boolean,
   cryptoFiatState: CryptoFiatState,
   t,
 ): any[] => {
@@ -17,7 +18,9 @@ export const formatBridgeFees = (
   if (estimates.fees.imtblFee) serviceFee = serviceFee.add(estimates.fees.imtblFee);
   if (serviceFee.gt(0)) {
     fees.push({
-      label: t('drawers.feesBreakdown.fees.serviceFee.label'),
+      label: isDeposit
+        ? t('drawers.feesBreakdown.fees.serviceFee.depositLabel')
+        : t('drawers.feesBreakdown.fees.serviceFee.withdrawLabel'),
       fiatAmount: `≈ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${calculateCryptoToFiat(
         utils.formatUnits(serviceFee, estimates.token.decimals),
         estimates.token.symbol,

--- a/packages/checkout/widgets-lib/src/widgets/bridge/functions/BridgeFees.ts
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/functions/BridgeFees.ts
@@ -9,7 +9,7 @@ export const formatBridgeFees = (
   isDeposit: boolean,
   cryptoFiatState: CryptoFiatState,
   t,
-): any[] => {
+): FormattedFee[] => {
   const fees: FormattedFee[] = [];
   if (!estimates?.fees || !estimates.token) return fees;
 

--- a/packages/checkout/widgets-lib/src/widgets/bridge/functions/BridgeFees.ts
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/functions/BridgeFees.ts
@@ -2,8 +2,13 @@ import { BigNumber, utils } from 'ethers';
 import { GasEstimateBridgeToL2Result } from '@imtbl/checkout-sdk';
 import { calculateCryptoToFiat, tokenValueFormat } from '../../../lib/utils';
 import { FormattedFee } from '../../swap/functions/swapFees';
+import { CryptoFiatState } from '../../../context/crypto-fiat-context/CryptoFiatContext';
 
-export const formatBridgeFees = (estimates: GasEstimateBridgeToL2Result | undefined, cryptoFiatState, t): any[] => {
+export const formatBridgeFees = (
+  estimates: GasEstimateBridgeToL2Result | undefined,
+  cryptoFiatState: CryptoFiatState,
+  t,
+): any[] => {
   const fees: FormattedFee[] = [];
   if (!estimates?.fees || !estimates.token) return fees;
 


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Renames Bridge Service Fee labels.

# Detail and impact of the change
## Changed
<!-- Section for changes in existing functionality. -->
* Replaces `Service Fees` with 
* * `Ethereum gas fees` when withdrawing
* * `zkEVM gas fees` when depositing
* Improves typing

https://immutable.atlassian.net/browse/CM-532

**L2 -> L1**
![image](https://github.com/immutable/ts-immutable-sdk/assets/13159042/bdf1b6ef-8357-47b8-a238-62bdb4d41eee)

**L1 -> L2**
![image](https://github.com/immutable/ts-immutable-sdk/assets/13159042/082c26a4-7bc3-486e-8423-c7b012bac92c)

