### PR TITLE
fix: update the checkout.Sell interface to allow undefined type property

### DIFF
--- a/packages/checkout/sdk/src/smartCheckout/sell/sell.ts
+++ b/packages/checkout/sdk/src/smartCheckout/sell/sell.ts
@@ -6,6 +6,7 @@ import {
   Orderbook,
   PrepareListingResponse,
   constants,
+  ERC721Item as OrderbookERC721Item,
 } from '@imtbl/orderbook';
 import { BigNumber, Contract, utils } from 'ethers';
 import {
@@ -130,7 +131,8 @@ export const sell = async (
     orderbook = instance.createOrderbookInstance(config);
     const { seaportContractAddress } = orderbook.config();
     spenderAddress = seaportContractAddress;
-    const sellItem = sellToken.type === ItemType.ERC1155
+
+    const sellItem = 'type' in sellToken && sellToken.type === ItemType.ERC1155
       ? {
         type: sellToken.type,
         contractAddress: sellToken.collectionAddress,
@@ -138,11 +140,10 @@ export const sell = async (
         amount: sellToken.amount,
       }
       : {
-        // For backwards compatibility type can be undefined for ERC721
-        type: sellToken.type || ItemType.ERC721,
+        type: ItemType.ERC721,
         contractAddress: sellToken.collectionAddress,
         tokenId: sellToken.id,
-      };
+      } as OrderbookERC721Item;
 
     listing = await measureAsyncExecution<PrepareListingResponse>(
       config,
@@ -167,7 +168,7 @@ export const sell = async (
   }
 
   const itemRequirements = [
-    sellToken.type === ItemType.ERC1155
+    'type' in sellToken && sellToken.type === ItemType.ERC1155
       ? getERC1155Requirement(sellToken.id, sellToken.collectionAddress, spenderAddress, sellToken.amount)
       : getERC721Requirement(sellToken.id, sellToken.collectionAddress, spenderAddress),
   ];

--- a/packages/checkout/sdk/src/smartCheckout/sell/sell.ts
+++ b/packages/checkout/sdk/src/smartCheckout/sell/sell.ts
@@ -122,6 +122,7 @@ export const sell = async (
   }
 
   const buyTokenOrNative = getBuyToken(buyToken, decimals);
+  const sellTokenHasType = 'type' in sellToken;
 
   try {
     const walletAddress = await measureAsyncExecution<string>(
@@ -133,8 +134,7 @@ export const sell = async (
     const { seaportContractAddress } = orderbook.config();
     spenderAddress = seaportContractAddress;
 
-    const hasType = 'type' in sellToken;
-    const sellItem: OrderbookERC721Item | OrderbookERC1155Item = hasType && sellToken.type === ItemType.ERC1155
+    const sellItem: OrderbookERC721Item | OrderbookERC1155Item = sellTokenHasType && sellToken.type === ItemType.ERC1155
       ? {
         type: ItemType.ERC1155,
         contractAddress: sellToken.collectionAddress,
@@ -170,7 +170,7 @@ export const sell = async (
   }
 
   const itemRequirements: (ERC721Item | ERC1155Item)[] = [];
-  if ('type' in sellToken && sellToken.type === ItemType.ERC1155) {
+  if (sellTokenHasType && sellToken.type === ItemType.ERC1155) {
     const erc1155ItemRequirement = getERC1155Requirement(
       sellToken.id,
       sellToken.collectionAddress,

--- a/packages/checkout/sdk/src/smartCheckout/sell/sell.ts
+++ b/packages/checkout/sdk/src/smartCheckout/sell/sell.ts
@@ -130,17 +130,18 @@ export const sell = async (
     orderbook = instance.createOrderbookInstance(config);
     const { seaportContractAddress } = orderbook.config();
     spenderAddress = seaportContractAddress;
-    const sellItem = sellToken.type === ItemType.ERC721
+    const sellItem = sellToken.type === ItemType.ERC1155
       ? {
         type: sellToken.type,
         contractAddress: sellToken.collectionAddress,
         tokenId: sellToken.id,
+        amount: sellToken.amount,
       }
       : {
-        type: sellToken.type,
+        // For backwards compatibility type can be undefined for ERC721
+        type: sellToken.type || ItemType.ERC721,
         contractAddress: sellToken.collectionAddress,
         tokenId: sellToken.id,
-        amount: sellToken.amount,
       };
 
     listing = await measureAsyncExecution<PrepareListingResponse>(
@@ -166,9 +167,9 @@ export const sell = async (
   }
 
   const itemRequirements = [
-    sellToken.type === ItemType.ERC721
-      ? getERC721Requirement(sellToken.id, sellToken.collectionAddress, spenderAddress)
-      : getERC1155Requirement(sellToken.id, sellToken.collectionAddress, spenderAddress, sellToken.amount),
+    sellToken.type === ItemType.ERC1155
+      ? getERC1155Requirement(sellToken.id, sellToken.collectionAddress, spenderAddress, sellToken.amount)
+      : getERC721Requirement(sellToken.id, sellToken.collectionAddress, spenderAddress),
   ];
 
   let smartCheckoutResult;

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -324,7 +324,7 @@ export type SellToken = ERC721SellToken | ERC1155SellToken;
  * @property {string} collectionAddress
  */
 export type ERC721SellToken = {
-  type: ItemType.ERC721;
+  type: ItemType.ERC721 | undefined;
   /**  The ERC721 token id */
   id: string;
   /** The ERC721 collection address */

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -316,7 +316,7 @@ export type ERC20BuyToken = {
  * Represents the token listed for sale.
  * ERC721SellToken or ERC1155SellToken {@link Checkout.smartCheckout}.
  */
-export type SellToken = ERC721SellToken | ERC1155SellToken;
+export type SellToken = DeprecatedERC721SellToken | ERC721SellToken | ERC1155SellToken;
 
 /**
  * The ERC721SellToken type

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -270,7 +270,7 @@ export type BuyOrder = {
  */
 export type SellOrder = {
   /** the token to be listed for sale */
-  sellToken: ERC721SellToken | ERC1155SellToken;
+  sellToken: DeprecatedERC721SellToken | ERC721SellToken | ERC1155SellToken;
   /** the token info of the price of the item */
   buyToken: BuyToken;
   /** optional array of makerFees to be applied to the listing */
@@ -324,7 +324,20 @@ export type SellToken = ERC721SellToken | ERC1155SellToken;
  * @property {string} collectionAddress
  */
 export type ERC721SellToken = {
-  type: ItemType.ERC721 | undefined;
+  type: ItemType.ERC721;
+  /**  The ERC721 token id */
+  id: string;
+  /** The ERC721 collection address */
+  collectionAddress: string;
+};
+
+/**
+ * The original ERC721SellToken type, before the introduction of the ItemType enum
+ * @property {string} id
+ * @property {string} collectionAddress
+ * @deprecated
+ */
+export type DeprecatedERC721SellToken = {
   /**  The ERC721 token id */
   id: string;
   /** The ERC721 collection address */

--- a/packages/checkout/sdk/src/types/smartCheckout.ts
+++ b/packages/checkout/sdk/src/types/smartCheckout.ts
@@ -270,7 +270,7 @@ export type BuyOrder = {
  */
 export type SellOrder = {
   /** the token to be listed for sale */
-  sellToken: DeprecatedERC721SellToken | ERC721SellToken | ERC1155SellToken;
+  sellToken: SellToken;
   /** the token info of the price of the item */
   buyToken: BuyToken;
   /** optional array of makerFees to be applied to the listing */


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

A previous change introduced a minor type break. This restores backwards compatibility by introducing a deprecated type that matches the previous type, and ensure the code behaves as expected when that type is provided

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->

## Fixed
Backwards compatible SellItem type

