### PR TITLE
fix: [CM-645] Remove Top up view footer

### DIFF
--- a/packages/checkout/widgets-lib/src/views/top-up/TopUpView.tsx
+++ b/packages/checkout/widgets-lib/src/views/top-up/TopUpView.tsx
@@ -19,7 +19,6 @@ import { BridgeWidgetViews } from 'context/view-context/BridgeViewContextTypes';
 import { Web3Provider } from '@ethersproject/providers';
 import { useTranslation } from 'react-i18next';
 import { $Dictionary } from 'i18next/typescript/helpers';
-import { FooterLogo } from '../../components/Footer/FooterLogo';
 import { HeaderNavigation } from '../../components/Header/HeaderNavigation';
 import { SimpleLayout } from '../../components/SimpleLayout/SimpleLayout';
 import {
@@ -337,7 +336,6 @@ export function TopUpView({
           showBack
         />
       )}
-      footer={<FooterLogo />}
     >
       <Box sx={{ paddingX: 'base.spacing.x4', paddingY: 'base.spacing.x4' }}>
         <Heading size="small">{title}</Heading>


### PR DESCRIPTION
**Footer is removed**
![image](https://github.com/immutable/ts-immutable-sdk/assets/641712/27f2fa3e-8efb-4b51-a9a1-78b3a6abde0d)

**Which fixes Immutable logo being cut off at bottom**
<img width="487" alt="image" src="https://github.com/immutable/ts-immutable-sdk/assets/641712/17639b4e-5826-4cc4-aa76-df02114ca376">
