### PR TITLE
[fix]cm-663 swap conversion bug fix scientific notation

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.test.ts
@@ -134,7 +134,7 @@ describe('formatQuoteConversionRate', () => {
     });
   });
 
-  it('should handle fromAmount greater than 1000', () => {
+  it('should handle fromAmount greater than 1000 (with 18 decimals)', () => {
     const fromAmount = '1000.50';
     const fromToken = {
       name: 'ETH',

--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, utils } from 'ethers';
 import {
   Amount,
   Fee,
@@ -130,6 +130,73 @@ describe('formatQuoteConversionRate', () => {
       fromSymbol: 'ETH',
       toSymbol: 'DAI',
       rate: '1.33',
+      fee: 1,
+    });
+  });
+
+  it('should handle fromAmount greater than 1000', () => {
+    const fromAmount = '1000.50';
+    const fromToken = {
+      name: 'ETH',
+      symbol: 'ETH',
+      address: '0x123',
+      chainId: 1,
+      decimals: 18,
+    } as TokenInfo;
+    const mockQuote = {
+      quote: {
+        amount: {
+          value: utils.parseEther('500'),
+          token: {
+            symbol: 'DAI',
+            address: '0x456',
+            chainId: 1,
+            decimals: 18,
+          },
+        } as Amount,
+        amountWithMaxSlippage: {} as Amount,
+        slippage: 0,
+        fees: [
+          {
+            recipient: '0x000',
+            basisPoints: 100,
+            amount: {
+              value: BigNumber.from('150000000000000000'),
+              token: {
+                symbol: 'ETH',
+                address: '0x123',
+                chainId: 1,
+                decimals: 18,
+              },
+            },
+          } as Fee,
+        ],
+      } as Quote,
+      swap: {
+        gasFeeEstimate: {
+          value: BigNumber.from(100),
+        },
+      },
+      approval: {
+        gasFeeEstimate: {
+          value: BigNumber.from(50),
+        },
+      },
+    } as TransactionResponse;
+    const labelKey = 'conversion.label';
+
+    formatQuoteConversionRate(
+      fromAmount,
+      fromToken,
+      mockQuote,
+      labelKey,
+      mockTranslate as unknown as TFunction,
+    );
+
+    expect(mockTranslate).toHaveBeenCalledWith(labelKey, {
+      fromSymbol: 'ETH',
+      toSymbol: 'DAI',
+      rate: '0.499750',
       fee: 1,
     });
   });

--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.ts
@@ -19,8 +19,7 @@ export const formatQuoteConversionRate = (
 
   // Parse the fromAmount input, multiply by 10^decimals to convert to integer units
   const parsedFromAmount = parseFloat(amount);
-  const expandedFromAmount = utils.parseUnits(parsedFromAmount.toString(), fromToken.decimals);
-  const relativeFromAmount = expandedFromAmount;
+  const relativeFromAmount = utils.parseUnits(parsedFromAmount.toString(), fromToken.decimals);
   const relativeToAmount = BigNumber.from(quote.quote.amount.value);
 
   // Determine the maximum decimal places to equalize to

--- a/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/functions/swapConversionRate.ts
@@ -19,8 +19,8 @@ export const formatQuoteConversionRate = (
 
   // Parse the fromAmount input, multiply by 10^decimals to convert to integer units
   const parsedFromAmount = parseFloat(amount);
-  const expandedFromAmount = parsedFromAmount * (10 ** fromToken.decimals);
-  const relativeFromAmount = BigNumber.from(expandedFromAmount.toFixed(0));
+  const expandedFromAmount = utils.parseUnits(parsedFromAmount.toString(), fromToken.decimals);
+  const relativeFromAmount = expandedFromAmount;
   const relativeToAmount = BigNumber.from(quote.quote.amount.value);
 
   // Determine the maximum decimal places to equalize to


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
`expandedFromAmount` had a scientific notation format (e.g. `1e+21`) when the amount was >= 10^21. When it was passed to `BigNumber.from` it caused an `invalid BigNumber` error.

## Fixed
<!-- Section for any bug fixes. -->
Use `parseUnits` from `ethers` to convert `fromAmount` to integer.
