### PR TITLE
feat: [Sale Widget] Filter other currencies if preferred currency applied

### DIFF
--- a/packages/checkout/widgets-lib/src/lib/utils.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.ts
@@ -182,3 +182,7 @@ export function abbreviateWalletAddress(address: string, separator = '.....', fi
   const lastPart = address.slice(-lastChars);
   return `${firstPart}${separator}${lastPart}`;
 }
+
+export function compareStr(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToOrderQuote.test.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToOrderQuote.test.ts
@@ -6,8 +6,11 @@ import {
 } from './transformToOrderQuote';
 
 describe('transformToOrderQuote', () => {
-  it('should return input object with camel case keys', () => {
-    const from: OrderQuoteApiResponse = {
+  let quoteResponse: OrderQuoteApiResponse;
+  let expectedResponse: OrderQuote;
+
+  beforeEach(() => {
+    quoteResponse = {
       config: {
         contract_id: '',
       },
@@ -86,7 +89,7 @@ describe('transformToOrderQuote', () => {
       },
     };
 
-    const expected: OrderQuote = {
+    expectedResponse = {
       config: {
         contractId: '',
       },
@@ -164,7 +167,31 @@ describe('transformToOrderQuote', () => {
         },
       },
     };
+  });
 
-    expect(transformToOrderQuote(from)).toStrictEqual(expected);
+  it('should transform response into order quote object', () => {
+    expect(transformToOrderQuote(quoteResponse)).toStrictEqual(
+      expectedResponse,
+    );
+  });
+
+  it('should filter currencies by preferred currency (no case sensitive)', () => {
+    const result = transformToOrderQuote(quoteResponse, 'goG');
+    expect(result.currencies.length).toBe(1);
+    expect(result.currencies).toStrictEqual([
+      {
+        base: true,
+        decimals: 18,
+        address: '0xb8ee289c64c1a0dc0311364721ada8c3180d838c',
+        exchangeId: 'guild-of-guardians',
+        name: 'GOG',
+      },
+    ]);
+  });
+
+  it('should not filter if invalid preferred currency', () => {
+    expect(transformToOrderQuote(quoteResponse, 'tIMX')).toStrictEqual(
+      expectedResponse,
+    );
   });
 });

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToOrderQuote.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/transformToOrderQuote.ts
@@ -1,52 +1,90 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { compareStr } from 'lib/utils';
 import { OrderQuote } from '../types';
 
 export type OrderQuoteApiResponse = {
   config: {
     contract_id: string;
-  },
+  };
   currencies: Array<{
-    base: boolean
-    decimals: number
-    erc20_address: string
-    exchange_id: string
-    name: string
-  }>
-  products: Record<string, {
-    pricing: Record<string, {
-      amount: number
-      currency: string
-      type: string
-    }>
-    product_id: string
-    quantity: number
+    base: boolean;
+    decimals: number;
+    erc20_address: string;
+    exchange_id: string;
+    name: string;
   }>;
-  total_amount: Record<string, {
-    amount: number
-    currency: string
-    type: string
-  }>
+  products: Record<
+  string,
+  {
+    pricing: Record<
+    string,
+    {
+      amount: number;
+      currency: string;
+      type: string;
+    }
+    >;
+    product_id: string;
+    quantity: number;
+  }
+  >;
+  total_amount: Record<
+  string,
+  {
+    amount: number;
+    currency: string;
+    type: string;
+  }
+  >;
+};
+
+const transformCurrencies = (
+  currencies: OrderQuoteApiResponse['currencies'],
+  preferredCurrency?: string,
+): OrderQuote['currencies'] => {
+  const invalidPreferredCurrency = currencies.findIndex(({ name }) => compareStr(name, preferredCurrency || '')) === -1;
+
+  if (preferredCurrency && invalidPreferredCurrency) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[IMTBL]: invalid "preferredCurrency=${preferredCurrency}" widget input`,
+    );
+  }
+
+  if (preferredCurrency && !invalidPreferredCurrency) {
+    return currencies
+      .filter(({ name }) => compareStr(name, preferredCurrency))
+      .map(({ erc20_address, exchange_id, ...fields }) => ({
+        ...fields,
+        base: true,
+        address: erc20_address,
+        exchangeId: exchange_id,
+      }));
+  }
+
+  return currencies.map(({ erc20_address, exchange_id, ...fields }) => ({
+    ...fields,
+    address: erc20_address,
+    exchangeId: exchange_id,
+  }));
 };
 
 export const transformToOrderQuote = (
   {
-    config,
-    currencies,
-    products,
-    total_amount,
+    config, currencies, products, total_amount,
   }: OrderQuoteApiResponse,
+  preferredCurrency?: string,
 ): OrderQuote => ({
   config: {
     contractId: config.contract_id,
   },
-  currencies: currencies.map(({ erc20_address, exchange_id, ...fields }) => ({
-    ...fields,
-    address: erc20_address,
-    exchangeId: exchange_id,
-  })),
-  products: Object.entries(products).reduce((acc, [productId, { product_id, ...fields }]) => ({
-    ...acc,
-    [productId]: { productId, ...fields },
-  }), {}),
+  currencies: transformCurrencies(currencies, preferredCurrency),
+  products: Object.entries(products).reduce(
+    (acc, [productId, { product_id, ...fields }]) => ({
+      ...acc,
+      [productId]: { productId, ...fields },
+    }),
+    {},
+  ),
   totalAmount: total_amount,
 });

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useQuoteOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useQuoteOrder.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Environment } from '@imtbl/config';
 import { SaleItem } from '@imtbl/checkout-sdk';
 import { Web3Provider } from '@ethersproject/providers';
+import { compareStr } from 'lib/utils';
 import { PRIMARY_SALES_API_BASE_URL } from '../utils/config';
 
 import { OrderQuote, OrderQuoteCurrency, SaleErrorTypes } from '../types';
@@ -96,7 +97,10 @@ export const useQuoteOrder = ({
           throw new Error(`${response.status} - ${response.statusText}`);
         }
 
-        const config = transformToOrderQuote(await response.json());
+        const config = transformToOrderQuote(
+          await response.json(),
+          preferredCurrency,
+        );
         setOrderQuote(config);
       } catch (error) {
         setError(error);
@@ -111,7 +115,7 @@ export const useQuoteOrder = ({
     if (orderQuote.currencies.length === 0) return;
 
     const baseCurrencyOverride = preferredCurrency
-      ? orderQuote.currencies.find((c) => c.name === preferredCurrency)
+      ? orderQuote.currencies.find((c) => compareStr(c.name, preferredCurrency))
       : undefined;
 
     const defaultSelectedCurrency = baseCurrencyOverride

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -150,7 +150,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
         },
       });
     } catch (error: any) {
-      goToErrorView(SaleErrorTypes.FUNDING_ROUTE_EXECUTE_ERROR, error);
+      goToErrorView(SaleErrorTypes.SERVICE_BREAKDOWN, error);
     }
   }, [fundingBalances, loadingBalances, fundingBalancesResult]);
 


### PR DESCRIPTION
# Summary
When `preferredCurrency` is given, the override should apply but only remove other currencies as the intention is to only settle the coin on the preferred currency.

For example:
- Accepted currencies: USDC, ETH, GOG
- If, preferred currency = GOG, then Accepted currencies = GOG only

# Detail and impact of the change

## Changed
- `preferredCurrency` will filter other currencies, causing quote to only consider that single coin. if insufficient balance, user will go thru a Top up experience.

## Screenshots
**Before: Accepted (USDC default) | ETH | GOG**
<img width="431" alt="Screenshot 2024-05-22 at 9 25 03 AM" src="https://github.com/immutable/ts-immutable-sdk/assets/2966156/f3b79414-215d-49bb-aed6-c9e896ced394">

**After: Accepted (USDC default) | ETH | (GOG preference)**
Only GOG will be used in quote, coins swappable to GOG will only show if found (not in this case)
<img width="430" alt="Screenshot 2024-05-22 at 9 27 03 AM" src="https://github.com/immutable/ts-immutable-sdk/assets/2966156/6515f927-4dad-4302-b30e-5a5740856f44">


