### PR TITLE
feat: [Sale Widget] Add config to hide disabled payment types

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/configurations/sale.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/configurations/sale.ts
@@ -5,4 +5,5 @@ import { WidgetConfiguration } from './widget';
  */
 export type SaleWidgetConfiguration = {
   waitFulfillmentSettlements?: boolean;
+  hideExcludedPaymentTypes?: boolean;
 } & WidgetConfiguration;

--- a/packages/checkout/sdk/src/widgets/definitions/parameters/sale.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/parameters/sale.ts
@@ -24,6 +24,8 @@ export type SaleWidgetParams = {
   language?: WidgetLanguage;
   /** The disabled payment types */
   excludePaymentTypes?: SalePaymentTypes[];
+  /** Preferred currency, replacing the backend's base currency */
+  preferredCurrency?: string;
 };
 
 /**

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -46,6 +46,7 @@ Omit<SaleWidgetParams, 'walletProviderName'>
 
 type WidgetParams = RequiredWidgetParams &
 OptionalWidgetParams & {
+  hideExcludedPaymentTypes: boolean;
   waitFulfillmentSettlements: boolean;
 };
 export interface SaleWidgetProps extends WidgetParams {
@@ -61,6 +62,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
     collectionName,
     excludePaymentTypes,
     preferredCurrency,
+    hideExcludedPaymentTypes,
     waitFulfillmentSettlements = true,
   } = props;
 
@@ -128,6 +130,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
           excludePaymentTypes,
           preferredCurrency,
           waitFulfillmentSettlements,
+          hideExcludedPaymentTypes,
         }}
       >
         <CryptoFiatProvider environment={config.environment}>

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -60,8 +60,10 @@ export default function SaleWidget(props: SaleWidgetProps) {
     environmentId,
     collectionName,
     excludePaymentTypes,
+    preferredCurrency,
     waitFulfillmentSettlements = true,
   } = props;
+
   const { connectLoaderState } = useContext(ConnectLoaderContext);
   const { checkout, provider } = connectLoaderState;
   const chainId = useRef<ChainId>();
@@ -124,6 +126,7 @@ export default function SaleWidget(props: SaleWidgetProps) {
           passport: checkout?.passport,
           collectionName,
           excludePaymentTypes,
+          preferredCurrency,
           waitFulfillmentSettlements,
         }}
       >

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
@@ -128,6 +128,7 @@ export class Sale extends Base<WidgetType.SALE> {
                   environmentId={this.parameters.environmentId!}
                   collectionName={this.parameters.collectionName!}
                   excludePaymentTypes={this.parameters.excludePaymentTypes!}
+                  preferredCurrency={this.parameters.preferredCurrency!}
                   language="en"
                   waitFulfillmentSettlements={this.properties?.config?.waitFulfillmentSettlements ?? true}
                 />

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetRoot.tsx
@@ -124,12 +124,13 @@ export class Sale extends Base<WidgetType.SALE> {
               >
                 <SaleWidget
                   config={config}
+                  language="en"
                   items={this.parameters.items!}
                   environmentId={this.parameters.environmentId!}
                   collectionName={this.parameters.collectionName!}
                   excludePaymentTypes={this.parameters.excludePaymentTypes!}
                   preferredCurrency={this.parameters.preferredCurrency!}
-                  language="en"
+                  hideExcludedPaymentTypes={this.properties?.config?.hideExcludedPaymentTypes ?? false}
                   waitFulfillmentSettlements={this.properties?.config?.waitFulfillmentSettlements ?? true}
                 />
               </Suspense>

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -46,6 +46,7 @@ type SaleContextProps = {
   excludePaymentTypes: SalePaymentTypes[];
   preferredCurrency?: string;
   waitFulfillmentSettlements: boolean;
+  hideExcludedPaymentTypes: boolean;
 };
 
 type SaleContextValues = SaleContextProps & {
@@ -119,6 +120,7 @@ const SaleContext = createContext<SaleContextValues>({
   preferredCurrency: undefined,
   selectedCurrency: undefined,
   waitFulfillmentSettlements: true,
+  hideExcludedPaymentTypes: false,
 });
 
 SaleContext.displayName = 'SaleSaleContext';
@@ -144,6 +146,7 @@ export function SaleContextProvider(props: {
       excludePaymentTypes,
       preferredCurrency,
       waitFulfillmentSettlements,
+      hideExcludedPaymentTypes,
     },
   } = props;
 
@@ -360,6 +363,7 @@ export function SaleContextProvider(props: {
       excludePaymentTypes,
       selectedCurrency,
       waitFulfillmentSettlements,
+      hideExcludedPaymentTypes,
     }),
     [
       config,
@@ -390,6 +394,7 @@ export function SaleContextProvider(props: {
       excludePaymentTypes,
       selectedCurrency,
       waitFulfillmentSettlements,
+      hideExcludedPaymentTypes,
     ],
   );
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -44,6 +44,7 @@ type SaleContextProps = {
   checkout: ConnectLoaderState['checkout'];
   passport?: Passport;
   excludePaymentTypes: SalePaymentTypes[];
+  preferredCurrency?: string;
   waitFulfillmentSettlements: boolean;
 };
 
@@ -115,6 +116,7 @@ const SaleContext = createContext<SaleContextValues>({
   orderQuote: defaultOrderQuote,
   signTokenIds: [],
   excludePaymentTypes: [],
+  preferredCurrency: undefined,
   selectedCurrency: undefined,
   waitFulfillmentSettlements: true,
 });
@@ -140,6 +142,7 @@ export function SaleContextProvider(props: {
       passport,
       collectionName,
       excludePaymentTypes,
+      preferredCurrency,
       waitFulfillmentSettlements,
     },
   } = props;
@@ -182,6 +185,7 @@ export function SaleContextProvider(props: {
     provider,
     environmentId,
     environment: config.environment,
+    preferredCurrency,
   });
 
   const fromTokenAddress = selectedCurrency?.address || '';

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useQuoteOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useQuoteOrder.ts
@@ -12,6 +12,7 @@ type UseQuoteOrderParams = {
   environmentId: string;
   environment: Environment;
   provider: Web3Provider | undefined;
+  preferredCurrency?: string;
 };
 
 export const defaultOrderQuote: OrderQuote = {
@@ -33,6 +34,7 @@ export const useQuoteOrder = ({
   environment,
   environmentId,
   provider,
+  preferredCurrency,
 }: UseQuoteOrderParams) => {
   const [selectedCurrency, setSelectedCurrency] = useState<
   OrderQuoteCurrency | undefined
@@ -108,7 +110,12 @@ export const useQuoteOrder = ({
     // Set default currency
     if (orderQuote.currencies.length === 0) return;
 
-    const defaultSelectedCurrency = orderQuote.currencies.find((c) => c.base)
+    const baseCurrencyOverride = preferredCurrency
+      ? orderQuote.currencies.find((c) => c.name === preferredCurrency)
+      : undefined;
+
+    const defaultSelectedCurrency = baseCurrencyOverride
+      || orderQuote.currencies.find((c) => c.base)
       || orderQuote.currencies?.[0];
 
     setSelectedCurrency(defaultSelectedCurrency);

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
@@ -29,8 +29,9 @@ export function PaymentMethods() {
     goToErrorView,
     paymentMethod,
     setPaymentMethod,
-    disabledPaymentTypes,
     invalidParameters,
+    disabledPaymentTypes,
+    hideExcludedPaymentTypes,
   } = useSaleContext();
   const { sendPageView, sendCloseEvent, sendSelectedPaymentMethod } = useSaleEvent();
 
@@ -117,6 +118,7 @@ export function PaymentMethods() {
         </Heading>
         <Box sx={{ paddingX: 'base.spacing.x2' }}>
           <PaymentOptions
+            hideDisabledOptions={hideExcludedPaymentTypes}
             disabledOptions={disabledPaymentTypes}
             onClick={handleOptionClick}
           />

--- a/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
@@ -78,17 +78,19 @@ const useParams = () => {
     .get("excludePaymentTypes")
     ?.split(",") as SalePaymentTypes[];
 
-  const multicurrency = urlParams.get("multicurrency") === "true";
-
-  const preferredCurrency = urlParams.get("preferredCurrency") as string ?? undefined;
+  const preferredCurrency =
+    (urlParams.get("preferredCurrency") as string) ?? undefined;
+  const hideExcludedPaymentTypes = Boolean(
+    urlParams.get("hideExcludedPaymentTypes")
+  );
 
   return {
     login,
     environmentId,
     collectionName,
     excludePaymentTypes,
-    multicurrency,
     preferredCurrency,
+    hideExcludedPaymentTypes,
   };
 };
 
@@ -127,8 +129,8 @@ export function SaleUI() {
     environmentId,
     collectionName,
     excludePaymentTypes,
-    multicurrency,
     preferredCurrency,
+    hideExcludedPaymentTypes,
   } = params;
   const [passportConfig, setPassportConfig] = useState(
     JSON.stringify(defaultPassportConfig, null, 2)
@@ -154,28 +156,28 @@ export function SaleUI() {
   const saleWidget = useMemo(
     () =>
       factory.create(WidgetType.SALE, {
-        config: { theme: WidgetTheme.DARK },
+        config: { theme: WidgetTheme.DARK, hideExcludedPaymentTypes },
       }),
-    [factory,  environmentId, collectionName, defaultItems]
+    [factory, environmentId, collectionName, defaultItems]
   );
   const bridgeWidget = useMemo(
     () =>
       factory.create(WidgetType.BRIDGE, {
         config: { theme: WidgetTheme.DARK },
       }),
-    [factory,  environmentId, collectionName, defaultItems]
+    [factory, environmentId, collectionName, defaultItems]
   );
   const swapWidget = useMemo(
     () =>
       factory.create(WidgetType.SWAP, { config: { theme: WidgetTheme.DARK } }),
-    [factory,  environmentId, collectionName, defaultItems]
+    [factory, environmentId, collectionName, defaultItems]
   );
   const onrampWidget = useMemo(
     () =>
       factory.create(WidgetType.ONRAMP, {
         config: { theme: WidgetTheme.DARK },
       }),
-    [factory,  environmentId, collectionName, defaultItems]
+    [factory, environmentId, collectionName, defaultItems]
   );
 
   // mount sale widget and subscribe to close event

--- a/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
@@ -80,12 +80,15 @@ const useParams = () => {
 
   const multicurrency = urlParams.get("multicurrency") === "true";
 
+  const preferredCurrency = urlParams.get("preferredCurrency") as string ?? undefined;
+
   return {
     login,
     environmentId,
     collectionName,
     excludePaymentTypes,
     multicurrency,
+    preferredCurrency,
   };
 };
 
@@ -125,6 +128,7 @@ export function SaleUI() {
     collectionName,
     excludePaymentTypes,
     multicurrency,
+    preferredCurrency,
   } = params;
   const [passportConfig, setPassportConfig] = useState(
     JSON.stringify(defaultPassportConfig, null, 2)
@@ -177,11 +181,11 @@ export function SaleUI() {
   // mount sale widget and subscribe to close event
   useEffect(() => {
     saleWidget.mount("sale", {
-
       environmentId,
       collectionName,
       items: defaultItems,
       excludePaymentTypes,
+      preferredCurrency,
     });
     saleWidget.addListener(SaleEventType.CLOSE_WIDGET, () => {
       saleWidget.unmount();
@@ -283,6 +287,7 @@ export function SaleUI() {
             collectionName,
             items: defaultItems,
             excludePaymentTypes,
+            preferredCurrency,
           })
         }
       >


### PR DESCRIPTION
# Summary
Add `hideExcludedPaymentTypes` to sale widget config, this flag will allow to hide disabledPaymentTypes.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
- A  `hideExcludedPaymentTypes: boolean` flag, defaults to `false`

## Changed
- When true, disabled payment types will not be rendered
- When false, disabled payment types will render but will not be clickable if disabled.

## Screenshots
Given both debit & credit are disabled

**hideExcludedPaymentTypes=false**
<img width="429" alt="Screenshot 2024-05-22 at 11 22 26 AM" src="https://github.com/immutable/ts-immutable-sdk/assets/2966156/59a53a62-a333-414a-8ff0-a7c11a2fb2cd">

**hideExcludedPaymentTypes=true**

<img width="430" alt="Screenshot 2024-05-22 at 11 21 54 AM" src="https://github.com/immutable/ts-immutable-sdk/assets/2966156/f511c9ba-0539-4007-ab68-e2781fbca53a">
