### PR TITLE
fix: [Sale Widget] Duplicated balances quotes

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalances.ts
@@ -1,6 +1,7 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { Checkout, TransactionRequirement } from '@imtbl/checkout-sdk';
 import { Environment } from '@imtbl/config';
+import { compareStr } from 'lib/utils';
 import {
   OrderQuoteCurrency,
   FundingBalance,
@@ -59,6 +60,8 @@ export const fetchFundingBalances = async (
     }
   };
 
+  const isBaseCurrency = (name: string) => compareStr(name, baseCurrency.name);
+
   const balancePromises: Promise<FundingBalanceResult>[] = currencies
     .map(async (currency) => {
       const amount = getAmountByCurrency(currency);
@@ -77,20 +80,24 @@ export const fetchFundingBalances = async (
         ? undefined
         : getGasEstimate();
 
+      const handleOnComplete = () => {
+        onComplete?.(pushToFoundBalances([]));
+      };
+
+      const handleOnFundingRoute = (route) => {
+        updateFundingBalances(getAlternativeFundingSteps([route], environment));
+      };
+
       const smartCheckoutResult = await checkout.smartCheckout({
         provider,
         itemRequirements,
         transactionOrGasAmount,
         routingOptions: { bridge: false, onRamp: false, swap: true },
         fundingRouteFullAmount: true,
-        onComplete: () => {
-          onComplete?.(pushToFoundBalances([]));
-        },
-        onFundingRoute: (route) => {
-          updateFundingBalances(
-            getAlternativeFundingSteps([route], environment),
-          );
-        },
+        onComplete: isBaseCurrency(currency.name)
+          ? handleOnComplete
+          : undefined,
+        onFundingRoute: handleOnFundingRoute,
       });
 
       return { currency, smartCheckoutResult };
@@ -104,7 +111,7 @@ export const fetchFundingBalances = async (
         getFundingBalances(smartCheckoutResult, environment),
       );
 
-      if (currency.base) {
+      if (isBaseCurrency(currency.name)) {
         const fundingItemRequirement = smartCheckoutResult.transactionRequirements[0];
         onFundingRequirement(fundingItemRequirement);
       }

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useFundingBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useFundingBalances.ts
@@ -8,7 +8,6 @@ import { getPricingBySymbol } from '../utils/pricing';
 
 export const useFundingBalances = () => {
   const fetching = useRef(false);
-  const completedCount = useRef(0);
   const {
     fromTokenAddress,
     orderQuote,
@@ -56,11 +55,7 @@ export const useFundingBalances = () => {
             setFundingBalances([...foundBalances]);
           },
           onComplete: () => {
-            completedCount.current += 1;
-            if (completedCount.current === orderQuote.currencies.length) {
-              setLoadingBalances(false);
-              completedCount.current = 0;
-            }
+            setLoadingBalances(false);
           },
           onFundingRequirement: (requirement) => {
             setTransactionRequirement(requirement);


### PR DESCRIPTION
# Summary
Fix issue where balances where quoted for all currencies. Instead, it should only quote funding routes for the base currency.

**Before: Duplicated routes**
<img width="375" alt="Screenshot 2024-05-24 at 4 48 25 PM" src="https://github.com/immutable/ts-immutable-sdk/assets/2966156/6d84204c-eaf5-4096-af81-91c14058d5fe">

**After: Only routes for base currency**
<img width="375" alt="Screenshot 2024-05-24 at 4 48 25 PM" src="https://github.com/immutable/ts-immutable-sdk/assets/2966156/83ccfd8a-d1a7-4b73-ade2-50dc5df6c374">

