### PR TITLE
fix: [Sale Widget] Remove SWAP options for funding tokens that are not base currency

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalances.ts
@@ -97,7 +97,9 @@ export const fetchFundingBalances = async (
         onComplete: isBaseCurrency(currency.name)
           ? handleOnComplete
           : undefined,
-        onFundingRoute: handleOnFundingRoute,
+        onFundingRoute: isBaseCurrency(currency.name)
+          ? handleOnFundingRoute
+          : undefined,
       });
 
       return { currency, smartCheckoutResult };
@@ -107,13 +109,15 @@ export const fetchFundingBalances = async (
   const results = await wrapPromisesWithOnResolve(
     balancePromises,
     ({ currency, smartCheckoutResult }) => {
-      updateFundingBalances(
-        getFundingBalances(smartCheckoutResult, environment),
-      );
-
       if (isBaseCurrency(currency.name)) {
         const fundingItemRequirement = smartCheckoutResult.transactionRequirements[0];
         onFundingRequirement(fundingItemRequirement);
+      }
+
+      if (smartCheckoutResult.sufficient) {
+        updateFundingBalances(
+          getFundingBalances(smartCheckoutResult, environment),
+        );
       }
     },
   );

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -45,6 +45,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
     goBackToPaymentMethods,
     sign,
     selectedCurrency,
+    setPaymentMethod,
   } = useSaleContext();
 
   const { viewDispatch, viewState } = useContext(ViewContext);
@@ -140,6 +141,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       const data = getTopUpViewData(
         smartCheckoutResult.transactionRequirements,
       );
+      setPaymentMethod(undefined);
       viewDispatch({
         payload: {
           type: ViewActions.UPDATE_VIEW,

--- a/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/sale/sale.tsx
@@ -27,45 +27,45 @@ const defaultPassportConfig = {
 
 const defaultItems: SaleItem[] = [
   {
-    productId: "biker",
+    productId: "kangaroo",
     qty: 1,
-    name: "Biker Iguana",
+    name: "Kangaroo",
     image:
-      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2024/02/img-Qq0Lek5jO8O9ueAZwDmdAImI-600x600-1.png",
-    description: "Biker Iguana",
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2024/05/character-image-10-1.png",
+    description: "Kangaroo",
   },
   {
-    productId: "lab",
+    productId: "kookaburra",
     qty: 3,
-    name: "Lab Iguana",
+    name: "Kookaburra",
     image:
-      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-IsR4OA7a9IStLeQ9cPo75tII.png",
-    description: "Lab Iguana",
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2024/05/character-image-4-1.png",
+    description: "Kookaburra",
   },
   {
-    productId: "baseball",
+    productId: "quokka",
     qty: 2,
-    name: "Baseball Iguana",
+    name: "Quokka",
     image:
-      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-tGcvA5pnoUAA2oNANHpA5CXB.png",
-    description: "Baseball Iguana",
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2024/05/character-image-8-1.png",
+    description: "Quokka",
   },
   {
-    productId: "firefighter",
+    productId: "ibis",
     qty: 1,
-    name: "Fire Fighter Iguana",
+    name: "Ibis",
     image:
-      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-NRXmr7k1jH9kZqXr029CEKt4.png",
-    description: "Fire Fighter Iguana",
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2024/05/character-image-1-1.png",
+    description: "Ibis",
   },
   {
-    productId: "soccer",
+    productId: "emu",
     qty: 5,
-    name: "Soccer Iguana",
+    name: "Emu",
     image:
-      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2023/12/img-msXHlIXmyy6IhDaMkP2Dp0HY.png",
-    description: "Soccer Iguana",
-  }
+      "https://iguanas.mystagingwebsite.com/wp-content/uploads/2024/05/character-image-5-1.png",
+    description: "Emu",
+  },
 ];
 
 const useParams = () => {


### PR DESCRIPTION
# Summary
- Fix to only suggest swapping tokens for base currency
- Fix to reset select payment method when no coins found. fixes bug with clicking back button when on Top Up View.
