### PR TITLE
feat: [CM-676] Checkout widgets handover loader component

### DIFF
--- a/packages/checkout/widgets-lib/src/components/Handover/Handover.tsx
+++ b/packages/checkout/widgets-lib/src/components/Handover/Handover.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import {
+  LoadingOverlay,
   Stack,
 } from '@biom3/react';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -21,7 +22,7 @@ const contentAnimation = {
 };
 
 export function Handover({ id, children }: { id: string, children?: React.ReactNode }) {
-  const { handover } = useHandover({ id });
+  const { handover, loader } = useHandover({ id });
 
   let renderChildren: any = [];
   if (handover?.children) {
@@ -35,6 +36,16 @@ export function Handover({ id, children }: { id: string, children?: React.ReactN
   return (
     <>
       {children}
+      {(loader && (
+        <LoadingOverlay visible>
+          <LoadingOverlay.Content>
+            <LoadingOverlay.Content.LoopingText
+              text={[...loader.text]}
+              textDuration={loader.duration}
+            />
+          </LoadingOverlay.Content>
+        </LoadingOverlay>
+      ))}
       {(handover && (renderChildren || handover.animationUrl) && (
         <Stack
           sx={{

--- a/packages/checkout/widgets-lib/src/context/handover-context/HandoverContext.ts
+++ b/packages/checkout/widgets-lib/src/context/handover-context/HandoverContext.ts
@@ -6,22 +6,35 @@ export enum HandoverTarget {
   LOADER = 'loader',
 }
 
-export interface HandoverContent {
+export type HandoverContent = {
   children?: React.ReactNode;
   animationUrl?: string;
   animationName?: string;
   onAnimationComplete?: () => void;
   duration?: number; // in milliseconds
-}
+};
 
-interface HandoverContextProps {
+export type HandoverLoader = {
+  text: string | string[];
+  duration?: number;
+};
+
+export type HandoverContextProps = {
+  loader: HandoverLoader | null;
+  isLoading: boolean;
+  showLoader: (loader: HandoverLoader) => void;
+  hideLoader: () => void;
   handovers: { [id: string]: HandoverContent };
   addHandover: (handoverContent: HandoverContent, handoverTarget?: HandoverTarget) => void;
   closeHandover: (handoverTarget?: HandoverTarget) => void;
-}
+};
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const HandoverContext = createContext<HandoverContextProps>({
+  loader: null,
+  isLoading: false,
+  showLoader: () => {},
+  hideLoader: () => {},
   handovers: {},
   addHandover: () => {},
   closeHandover: () => {},

--- a/packages/checkout/widgets-lib/src/context/handover-context/HandoverProvider.tsx
+++ b/packages/checkout/widgets-lib/src/context/handover-context/HandoverProvider.tsx
@@ -4,7 +4,12 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { HandoverContent, HandoverContext, HandoverTarget } from './HandoverContext';
+import {
+  HandoverContent,
+  HandoverContext,
+  HandoverLoader,
+  HandoverTarget,
+} from './HandoverContext';
 import { Handover } from '../../components/Handover/Handover';
 
 interface HandoverProviderProps {
@@ -25,6 +30,12 @@ export function HandoverProvider({ children }: HandoverProviderProps) {
   const [handovers, setHandovers] = useState<HandoverState>({});
   const [handoverQueue, setHandoverQueue] = useState<HandoverQueue>({});
   const [handoverBusy, setHandoverBusy] = useState<{ [key in HandoverTarget]?: boolean }>({});
+
+  const [loader, setLoader] = useState<HandoverLoader | null>(null);
+  const isLoading = useMemo(() => loader !== null, [loader]);
+  const hideLoader = useCallback(() => {
+    setLoader(null);
+  }, [setLoader]);
 
   const closeHandover = useCallback(
     (handoverId: HandoverTarget = HandoverTarget.GLOBAL) => {
@@ -105,10 +116,17 @@ export function HandoverProvider({ children }: HandoverProviderProps) {
   }, [handoverQueue, handoverBusy, processQueue]);
 
   const value = useMemo(() => ({
+    loader,
+    isLoading,
+    hideLoader,
+    showLoader: (handoverLoader: HandoverLoader) => {
+      const text = Array.isArray(handoverLoader.text) ? handoverLoader.text : [handoverLoader.text];
+      setLoader({ ...handoverLoader, text: [...text] });
+    },
     handovers,
     addHandover,
     closeHandover,
-  }), [handovers]);
+  }), [loader, isLoading, hideLoader, handovers, addHandover, closeHandover]);
 
   return (
     <HandoverContext.Provider value={value}>

--- a/packages/checkout/widgets-lib/src/lib/hooks/useHandover.ts
+++ b/packages/checkout/widgets-lib/src/lib/hooks/useHandover.ts
@@ -7,11 +7,23 @@ export const useHandover = ({ id }: { id?: string } = {}) => {
     throw new Error('useHandover must be used within a HandoverProvider');
   }
 
-  const { handovers, closeHandover, addHandover } = context;
+  const {
+    handovers,
+    closeHandover,
+    addHandover,
+    loader,
+    isLoading,
+    showLoader,
+    hideLoader,
+  } = context;
   const handover = useMemo(() => handovers[id ?? 'global'], [id, handovers]);
   const getHandover = useCallback((handoverId: string) => handovers[handoverId], [handovers]);
 
   return {
+    loader,
+    isLoading,
+    showLoader,
+    hideLoader,
     handover,
     getHandover,
     addHandover,

--- a/packages/checkout/widgets-lib/src/widgets/swap/GeoblockLoader.cy.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/GeoblockLoader.cy.tsx
@@ -17,12 +17,11 @@ describe('GeoblockLoader', () => {
       <GeoblockLoader
         widget={<div id="inner-widget">Inner Widget</div>}
         serviceUnavailableView={<div id="unavailable-view">Service Unavailable</div>}
-        loadingView={<div id="loading-view">Loading</div>}
         checkout={checkout}
       />,
     );
 
-    cy.get('#loading-view').should('exist');
+    cy.get('span').contains('Loading').should('exist');
     cy.get('#unavailable-view').should('not.exist');
     cy.get('#inner-widget').should('not.exist');
   });
@@ -36,14 +35,13 @@ describe('GeoblockLoader', () => {
       <GeoblockLoader
         widget={<div id="inner-widget">Inner Widget</div>}
         serviceUnavailableView={<div id="unavailable-view">Service Unavailable</div>}
-        loadingView={<div id="loading-view">Loading</div>}
         checkout={checkout}
       />,
     );
 
     cy.get('#inner-widget').should('exist');
     cy.get('#unavailable-view').should('not.exist');
-    cy.get('#loading-view').should('not.exist');
+    cy.get('span').contains('Loading').should('not.exist');
   });
 
   it('should show service unavailable view if service is unavailable', () => {
@@ -55,14 +53,13 @@ describe('GeoblockLoader', () => {
       <GeoblockLoader
         widget={<div id="inner-widget">Inner Widget</div>}
         serviceUnavailableView={<div id="unavailable-view">Service Unavailable</div>}
-        loadingView={<div id="loading-view">Loading</div>}
         checkout={checkout}
       />,
     );
 
     cy.get('#unavailable-view').should('exist');
     cy.get('#inner-widget').should('not.exist');
-    cy.get('#loading-view').should('not.exist');
+    cy.get('span').contains('Loading').should('not.exist');
   });
 
   it('should show service unavailable view if error thrown', () => {
@@ -74,13 +71,12 @@ describe('GeoblockLoader', () => {
       <GeoblockLoader
         widget={<div id="inner-widget">Inner Widget</div>}
         serviceUnavailableView={<div id="unavailable-view">Service Unavailable</div>}
-        loadingView={<div id="loading-view">Loading</div>}
         checkout={checkout}
       />,
     );
 
     cy.get('#unavailable-view').should('exist');
     cy.get('#inner-widget').should('not.exist');
-    cy.get('#loading-view').should('not.exist');
+    cy.get('span').contains('Loading').should('not.exist');
   });
 });

--- a/packages/checkout/widgets-lib/src/widgets/swap/GeoblockLoader.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/GeoblockLoader.tsx
@@ -3,30 +3,34 @@ import {
   useEffect,
   useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHandover } from '../../lib/hooks/useHandover';
 
 type GeoblockLoaderParams = {
   widget: React.ReactNode;
   serviceUnavailableView: React.ReactNode;
-  loadingView: React.ReactNode;
   checkout: Checkout,
 };
 
 export function GeoblockLoader({
   widget,
   serviceUnavailableView,
-  loadingView,
   checkout,
 }: GeoblockLoaderParams) {
-  const [loading, setLoading] = useState(true);
+  const { t } = useTranslation();
+  const { showLoader, hideLoader, isLoading } = useHandover();
+  const [requested, setRequested] = useState(false);
   const [available, setAvailable] = useState(false);
 
   useEffect(() => {
     (async () => {
       try {
+        showLoader({ text: t('views.LOADING_VIEW.text') });
+        setRequested(true);
         setAvailable(await checkout.isSwapAvailable());
-        setLoading(false);
+        hideLoader();
       } catch {
-        setLoading(false);
+        hideLoader();
         setAvailable(false);
       }
     })();
@@ -36,11 +40,9 @@ export function GeoblockLoader({
     // eslint-disable-next-line react/jsx-no-useless-fragment
     <>
       {
-        // eslint-disable-next-line no-nested-ternary
-        loading ? loadingView
-          : available
-            ? widget
-            : serviceUnavailableView
+        requested && !isLoading && (available
+          ? widget
+          : serviceUnavailableView)
       }
     </>
   );

--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidgetRoot.tsx
@@ -118,7 +118,6 @@ export class Swap extends Base<WidgetType.SWAP> {
             <HandoverProvider>
               <GeoblockLoader
                 checkout={this.checkout}
-                loadingView={<LoadingView loadingText={t('views.LOADING_VIEW.text')} />}
                 widget={
                 (
                   <ConnectLoader


### PR DESCRIPTION
# Summary
Implementation of loader for the Checkout widgets handover component.
[CM-676](https://immutable.atlassian.net/browse/CM-676)

# Detail and impact of the change
## Added 
New loader functions to `useHandover` hook, showLoader, hideLoader
Support for handover loader by the swap widget geoblock loader.

[CM-676]: https://immutable.atlassian.net/browse/CM-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ