### PR TITLE
breaking-change: improve webhook package

### DIFF
--- a/packages/minting-backend/sdk/src/index.ts
+++ b/packages/minting-backend/sdk/src/index.ts
@@ -1,6 +1,6 @@
 import { ImmutableConfiguration, ModuleConfiguration } from '@imtbl/config';
 import { BlockchainData } from '@imtbl/blockchain-data';
-import { init } from '@imtbl/webhook';
+import { handle } from '@imtbl/webhook';
 import { setEnvironment, setPublishableApiKey } from '@imtbl/metrics';
 import { trackUncaughtException } from 'analytics';
 import { mintingPersistence as mintingPersistencePg } from './persistence/pg/postgres';
@@ -71,7 +71,7 @@ export class MintingBackendModule {
   }
 
   async processMint(body: string | Record<string, unknown>, otherHandlers = noopHandlers) {
-    await init(body, this.baseConfig.environment, {
+    await handle(body, this.baseConfig.environment, {
       zkevmMintRequestUpdated: async (event: MintRequestEvent) => {
         await processMint(this.persistence, event, this.logger);
         otherHandlers.zkevmMintRequestUpdated(event);

--- a/packages/minting-backend/sdk/src/index.ts
+++ b/packages/minting-backend/sdk/src/index.ts
@@ -28,7 +28,7 @@ const noopHandlers = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   zkevmMintRequestUpdated: async (event: MintRequestEvent) => { },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  others: async (..._args: any) => { }
+  all: async (..._args: any) => { }
 };
 
 export class MintingBackendModule {
@@ -76,7 +76,7 @@ export class MintingBackendModule {
         await processMint(this.persistence, event, this.logger);
         otherHandlers.zkevmMintRequestUpdated(event);
       },
-      others: otherHandlers.others
+      all: otherHandlers.all
     });
   }
 }

--- a/packages/webhook/sdk/src/index.ts
+++ b/packages/webhook/sdk/src/index.ts
@@ -1,5 +1,5 @@
-import { init } from './init';
+import { handle } from './init';
 
 export {
-  init,
+  handle,
 };

--- a/packages/webhook/sdk/src/init.ts
+++ b/packages/webhook/sdk/src/init.ts
@@ -12,7 +12,7 @@ const allowedTopicArnPrefix = {
  * handle will validate webhook message origin and verify signature of the message and calls corresponding handlers passed in.
  * @param body The request body to a webhook endpoint in json string or js object form.
  * @param env The Immutable environment the webhook is set up for.
- * @param handlers The optional handlers object for different events. The `others` handler is a fallback handler for any other event that is not handled by the specific handlers.
+ * @param handlers The optional handlers object for different events. The `all` handler will be triggered for all event types.
  * @returns The event object from the webhook message after validation and verification.
  */
 export const handle = async (
@@ -20,8 +20,7 @@ export const handle = async (
   env: Environment,
   handlers?: {
     zkevmMintRequestUpdated?: (event: any) => Promise<void>;
-    // there will be more handlers added
-    others?: (event: any) => Promise<void>;
+    all?: (event: any) => Promise<void>;
   }
 ) => {
   const msg: any = await new Promise((resolve, reject) => {
@@ -55,10 +54,10 @@ export const handle = async (
         }
         break;
       default:
-        if (handlers?.others) {
-          await handlers?.others(event);
-        }
         break;
+    }
+    if (handlers?.all) {
+      await handlers?.all(event);
     }
   }
 


### PR DESCRIPTION
# Summary
This change is to improve the devex for webhook interface

# Detail and impact of the change
## Changed
`init` function is renamed to `handle` in the `webhook` package. `handlers` arg has been made optional. `other` handler has been renamed to `all` and changed semantics to "all events will trigger the `all` handler" so that when new named handlers are added, there won't be breaking changes on the `all` handler.
