### PR TITLE
[feat] [sale widget] Enable manual tx execution for sale widget

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -55,12 +55,15 @@ type SaleContextValues = SaleContextProps & {
     tokenAddress?: string,
     callback?: (response: SignResponse | undefined) => void
   ) => Promise<SignResponse | undefined>;
-  execute: (
+  executeAll: (
     signResponse: SignResponse | undefined,
     onTxnSuccess: (txn: ExecutedTransaction) => void,
-    onTxnError: (error: any, txns: ExecutedTransaction[]) => void,
-    isManualExecution: boolean
+    onTxnError: (error: any, txns: ExecutedTransaction[]) => void
   ) => Promise<ExecutedTransaction[]>;
+  executeNextTransaction: (
+    onTxnSuccess: (txn: ExecutedTransaction) => void,
+    onTxnError: (error: any, txns: ExecutedTransaction[]) => void
+  ) => Promise<boolean>;
   recipientAddress: string;
   recipientEmail: string;
   signResponse: SignResponse | undefined;
@@ -97,7 +100,8 @@ const SaleContext = createContext<SaleContextValues>({
   recipientAddress: '',
   recipientEmail: '',
   sign: () => Promise.resolve(undefined),
-  execute: () => Promise.resolve([]),
+  executeAll: () => Promise.resolve([]),
+  executeNextTransaction: () => Promise.resolve(false),
   signResponse: undefined,
   signError: undefined,
   executeResponse: undefined,
@@ -224,7 +228,8 @@ export function SaleContextProvider(props: {
 
   const {
     sign: signOrder,
-    execute,
+    executeAll,
+    executeNextTransaction,
     signResponse,
     signError,
     executeResponse,
@@ -339,7 +344,8 @@ export function SaleContextProvider(props: {
       sign,
       signResponse,
       signError,
-      execute,
+      executeAll,
+      executeNextTransaction,
       executeResponse,
       environmentId,
       collectionName,

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -58,7 +58,8 @@ type SaleContextValues = SaleContextProps & {
   execute: (
     signResponse: SignResponse | undefined,
     onTxnSuccess: (txn: ExecutedTransaction) => void,
-    onTxnError: (error: any, txns: ExecutedTransaction[]) => void
+    onTxnError: (error: any, txns: ExecutedTransaction[]) => void,
+    isManualExecution: boolean
   ) => Promise<ExecutedTransaction[]>;
   recipientAddress: string;
   recipientEmail: string;

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
@@ -441,6 +441,5 @@ export const useSignOrder = (input: SignOrderInput) => {
     executeResponse,
     tokenIds,
     executeNextTransaction,
-    currentTransactionIndex,
   };
 };

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
@@ -170,7 +170,7 @@ export const useSignOrder = (input: SignOrderInput) => {
     transactions: [],
   });
   const [tokenIds, setTokenIds] = useState<string[]>([]);
-  const [currentTransactionNumber, setCurrentTransactionNumber] = useState<number>(0);
+  const [currentTransactionIndex, setCurrentTransactionIndex] = useState<number>(0);
 
   const setExecuteTransactions = (transaction: ExecutedTransaction) => {
     setExecuteResponse((prev) => ({
@@ -396,7 +396,7 @@ export const useSignOrder = (input: SignOrderInput) => {
       }
       (successful ? setExecuteDone : setExecuteFailed)();
     } else {
-      setCurrentTransactionNumber(0);
+      setCurrentTransactionIndex(0);
     }
 
     return executeResponse.transactions;
@@ -408,10 +408,10 @@ export const useSignOrder = (input: SignOrderInput) => {
   ): Promise<boolean> => {
     if (
       !signResponse
-      || currentTransactionNumber >= signResponse.transactions.length
+      || currentTransactionIndex >= signResponse.transactions.length
     ) return false;
 
-    const transaction = signResponse.transactions[currentTransactionNumber];
+    const transaction = signResponse.transactions[currentTransactionIndex];
     const success = await executeTransaction(
       transaction,
       onTxnSuccess,
@@ -419,7 +419,7 @@ export const useSignOrder = (input: SignOrderInput) => {
     );
 
     if (success) {
-      setCurrentTransactionNumber((prev) => prev + 1);
+      setCurrentTransactionIndex((prev) => prev + 1);
     }
 
     return success;
@@ -433,6 +433,6 @@ export const useSignOrder = (input: SignOrderInput) => {
     executeResponse,
     tokenIds,
     executeNextTransaction,
-    currentTransactionNumber,
+    currentTransactionIndex,
   };
 };

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSignOrder.ts
@@ -11,6 +11,7 @@ import {
   ExecutedTransaction,
   SaleErrorTypes,
   SignPaymentTypes,
+  SignedTransaction,
 } from '../types';
 import { PRIMARY_SALES_API_BASE_URL } from '../utils/config';
 import { hexToText } from '../functions/utils';
@@ -152,7 +153,11 @@ const toSignResponse = (
 
 export const useSignOrder = (input: SignOrderInput) => {
   const {
-    provider, items, environment, environmentId, waitFulfillmentSettlements,
+    provider,
+    items,
+    environment,
+    environmentId,
+    waitFulfillmentSettlements,
   } = input;
   const [signError, setSignError] = useState<SignOrderError | undefined>(
     undefined,
@@ -165,6 +170,7 @@ export const useSignOrder = (input: SignOrderInput) => {
     transactions: [],
   });
   const [tokenIds, setTokenIds] = useState<string[]>([]);
+  const [currentTransactionNumber, setCurrentTransactionNumber] = useState<number>(0);
 
   const setExecuteTransactions = (transaction: ExecutedTransaction) => {
     setExecuteResponse((prev) => ({
@@ -255,7 +261,7 @@ export const useSignOrder = (input: SignOrderInput) => {
     ): Promise<SignResponse | undefined> => {
       try {
         const signer = provider?.getSigner();
-        const address = await signer?.getAddress() || '';
+        const address = (await signer?.getAddress()) || '';
 
         const data: SignApiRequest = {
           recipient_address: address,
@@ -323,10 +329,42 @@ export const useSignOrder = (input: SignOrderInput) => {
     [items, environmentId, environment, provider],
   );
 
+  const executeTransaction = async (
+    transaction: SignedTransaction,
+    onTxnSuccess: (txn: ExecutedTransaction) => void,
+    onTxnError: (error: any, txns: ExecutedTransaction[]) => void,
+  ) => {
+    const {
+      tokenAddress: to,
+      rawData: data,
+      methodCall: method,
+      gasEstimate,
+    } = transaction;
+
+    const [hash, txnError] = await sendTransaction(
+      to,
+      data,
+      gasEstimate,
+      method,
+    );
+
+    if (txnError || !hash) {
+      onTxnError(txnError, executeResponse.transactions);
+      return false;
+    }
+
+    const execTransaction = { method, hash };
+    setExecuteTransactions(execTransaction);
+    onTxnSuccess(execTransaction);
+
+    return true;
+  };
+
   const execute = async (
     signData: SignResponse | undefined,
     onTxnSuccess: (txn: ExecutedTransaction) => void,
     onTxnError: (error: any, txns: ExecutedTransaction[]) => void,
+    isManualExecution = false,
   ): Promise<ExecutedTransaction[]> => {
     if (!signData || !provider) {
       setSignError({
@@ -337,42 +375,54 @@ export const useSignOrder = (input: SignOrderInput) => {
       return [];
     }
 
-    let successful = true;
-    const execTransactions: ExecutedTransaction[] = [];
-
     const transactions = await filterAllowedTransactions(
       signData.transactions,
       provider,
     );
 
-    for (const transaction of transactions) {
-      const {
-        tokenAddress: to,
-        rawData: data,
-        methodCall: method,
-        gasEstimate,
-      } = transaction;
-      // eslint-disable-next-line no-await-in-loop
-      const [hash, txnError] = await sendTransaction(
-        to,
-        data,
-        gasEstimate,
-        method,
-      );
-
-      if (txnError || !hash) {
-        successful = false;
-        onTxnError(txnError, execTransactions);
-        break;
+    if (!isManualExecution) {
+      let successful = true;
+      for (const transaction of transactions) {
+        // eslint-disable-next-line no-await-in-loop
+        const success = await executeTransaction(
+          transaction,
+          onTxnSuccess,
+          onTxnError,
+        );
+        if (!success) {
+          successful = false;
+          break;
+        }
       }
-
-      execTransactions.push({ method, hash });
-      onTxnSuccess({ method, hash });
+      (successful ? setExecuteDone : setExecuteFailed)();
+    } else {
+      setCurrentTransactionNumber(0);
     }
 
-    (successful ? setExecuteDone : setExecuteFailed)();
+    return executeResponse.transactions;
+  };
 
-    return execTransactions;
+  const executeNextTransaction = async (
+    onTxnSuccess: (txn: ExecutedTransaction) => void,
+    onTxnError: (error: any, txns: ExecutedTransaction[]) => void,
+  ): Promise<boolean> => {
+    if (
+      !signResponse
+      || currentTransactionNumber >= signResponse.transactions.length
+    ) return false;
+
+    const transaction = signResponse.transactions[currentTransactionNumber];
+    const success = await executeTransaction(
+      transaction,
+      onTxnSuccess,
+      onTxnError,
+    );
+
+    if (success) {
+      setCurrentTransactionNumber((prev) => prev + 1);
+    }
+
+    return success;
   };
 
   return {
@@ -382,5 +432,7 @@ export const useSignOrder = (input: SignOrderInput) => {
     execute,
     executeResponse,
     tokenIds,
+    executeNextTransaction,
+    currentTransactionNumber,
   };
 };

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
@@ -44,6 +44,7 @@ export function PayWithCoins() {
         const details = { transactionId: signResponse?.transactionId };
         sendFailedEvent(error.toString(), error, txns, undefined, details); // checkoutPrimarySalePaymentMethods_FailEventFailed
       },
+      false,
     );
   };
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
@@ -16,7 +16,7 @@ export function PayWithCoins() {
     sendSuccessEvent,
   } = useSaleEvent();
   const {
-    execute, signResponse, executeResponse, signTokenIds,
+    executeAll, signResponse, executeResponse, signTokenIds,
   } = useSaleContext();
   const executedTxns = executeResponse?.transactions.length || 0;
 
@@ -35,7 +35,7 @@ export function PayWithCoins() {
   }
 
   const sendTransaction = async () => {
-    execute(
+    executeAll(
       signResponse,
       (txn) => {
         sendTransactionSuccessEvent(txn); // not an analytics event
@@ -44,7 +44,6 @@ export function PayWithCoins() {
         const details = { transactionId: signResponse?.transactionId };
         sendFailedEvent(error.toString(), error, txns, undefined, details); // checkoutPrimarySalePaymentMethods_FailEventFailed
       },
-      false,
     );
   };
 


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Enable manual transactions execution for sale widget to solve pop-up blocking for Passport.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->
Exposes `executeNextTransaction` which allows the FE to hook into a button to initiate transaction execution manually.
