### PR TITLE
fix: safe guard process on

### DIFF
--- a/packages/minting-backend/sdk/src/index.ts
+++ b/packages/minting-backend/sdk/src/index.ts
@@ -81,4 +81,10 @@ export class MintingBackendModule {
   }
 }
 
-process.on('uncaughtExceptionMonitor', trackUncaughtException);
+if (typeof process !== 'undefined' && process.on) {
+  try {
+    process.on('uncaughtExceptionMonitor', trackUncaughtException);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
# Summary
Safe guard the usage of `process.on`. Checkout widgets ended up importing minting backend code. This is to be defensive in calling `process.on`. A further investigation is needed to understand why Widgets will end up importing this module.

