### PR TITLE
fix: export webhook types

### DIFF
--- a/packages/webhook/sdk/src/index.ts
+++ b/packages/webhook/sdk/src/index.ts
@@ -1,8 +1,27 @@
-import { handle, WebhookHandlers } from './handler';
+import { handle } from './handler';
 
-export * from './event-types';
+export type {
+  BlockChainMetadata,
+  Chain,
+  ZkevmActivityBurn,
+  ZkevmActivityDeposit,
+  ZkevmActivityMint,
+  ZkevmActivitySale,
+  ZkevmActivityTransfer,
+  ZkevmActivityWithdrawal,
+  ZkevmCollectionUpdated,
+  ZkevmMetadataUpdated,
+  ZkevmMintRequestUpdated,
+  ZkevmNftUpdated,
+  ZkevmOrderUpdated,
+  ZkevmTokenUpdated,
+  ZkevmTradeCreated
+} from './event-types';
 
 export {
-  handle,
-  WebhookHandlers
+  handle
 };
+
+export type {
+  WebhookHandlers
+} from './handler';


### PR DESCRIPTION
# Summary
Export webhook types so that the caller can use them

# Detail and impact of the change
## Added 
Adding types export from webhook package.
