### PR TITLE
fix: [DX-2910] Webhook Package exports types in index.d.ts rather than webhook.d.ts

### DIFF
--- a/packages/webhook/sdk/package.json
+++ b/packages/webhook/sdk/package.json
@@ -39,6 +39,9 @@
     "test:e2e": "jest --runInBand --testMatch \"**/?(*.)+(e2e).[jt]s?(x)\"",
     "typecheck": "tsc --noEmit --jsx preserve"
   },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "types": "dist/index.d.ts"
 }

--- a/packages/webhook/sdk/src/index.ts
+++ b/packages/webhook/sdk/src/index.ts
@@ -1,4 +1,4 @@
-import { handle } from './handler';
+import { handle, WebhookHandlers } from './handler';
 
 export type {
   BlockChainMetadata,
@@ -19,9 +19,6 @@ export type {
 } from './event-types';
 
 export {
-  handle
-};
-
-export type {
+  handle,
   WebhookHandlers
-} from './handler';
+};


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
The types for the webhook package were added to the built index.d.ts file for the SDK, rather than the webhook.d.ts file. This adds the types back to the webhook.d.ts