### PR TITLE
fix(utils-crypto): use esm file extension

### DIFF
--- a/packages/x-client/src/utils/crypto/crypto.ts
+++ b/packages/x-client/src/utils/crypto/crypto.ts
@@ -4,7 +4,8 @@ import BN from 'bn.js';
 import elliptic from 'elliptic';
 import * as encUtils from 'enc-utils';
 import { Signer } from '@ethersproject/abstract-signer';
-import { solidityKeccak256 } from 'ethers/lib/utils';
+// eslint-disable-next-line import/extensions
+import { solidityKeccak256 } from 'ethers/lib/utils.js';
 import { StarkSigner } from '../../types';
 import { starkEcOrder } from '../stark/starkCurve';
 


### PR DESCRIPTION
# Summary
ESM imports require explicitly declaring the file extension on browser environments, per nodejs docs:
https://nodejs.org/api/esm.html#esm_mandatory_file_extensions

By not declaring the file extension as part of the import, typescript will throw an error while transpiling the code.

# Detail and impact of the change

## Changed
Replacing `ethers/lib/utils` imports to `ethers/lib/utils.js`.

# Anything else worth calling out?
Reproducible project:
https://github.com/pedropapa/immutable-sdk-esm-module-error

```
git clone https://github.com/pedropapa/immutable-sdk-esm-module-error.git
cd immutable-sdk-esm-module-error.git
yarn && yarn build
```

The following error should be thrown during the build:
```
   Collecting page data  ..Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/node_modules/ethers/lib/utils' imported from /node_modules/@imtbl/sdk/dist/index.js
Did you mean to import "ethers/lib/utils.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1157:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:383:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:352:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:227:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:87:39)
    at link (node:internal/modules/esm/module_job:86:36) {
  code: 'ERR_MODULE_NOT_FOUND',
```

Note: My PR is intended to be a hotfix, not a definitive solution, given it requires disabling the eslint check.
