### PR TITLE
fix: ID-1903 Fixed inconsistent errors

### DIFF
--- a/packages/passport/sdk-sample-app/src/components/Message.tsx
+++ b/packages/passport/sdk-sample-app/src/components/Message.tsx
@@ -37,9 +37,6 @@ function Message() {
           icon="Close"
           circularFrame
           sx={{
-            position: 'absolute',
-            top: '0.5rem',
-            right: '0.5rem',
             cursor: 'pointer',
           }}
           onClick={clearMessages}

--- a/packages/passport/sdk-sample-app/src/components/Message.tsx
+++ b/packages/passport/sdk-sample-app/src/components/Message.tsx
@@ -1,4 +1,4 @@
-import { ButtCon, Sticker } from '@biom3/react';
+import { Sticker } from '@biom3/react';
 import { Form } from 'react-bootstrap';
 import React, { useEffect } from 'react';
 import { useStatusProvider } from '@/context/StatusProvider';

--- a/packages/passport/sdk-sample-app/src/components/Message.tsx
+++ b/packages/passport/sdk-sample-app/src/components/Message.tsx
@@ -1,10 +1,11 @@
+import { ButtCon, Sticker } from '@biom3/react';
 import { Form } from 'react-bootstrap';
 import React, { useEffect } from 'react';
 import { useStatusProvider } from '@/context/StatusProvider';
 import CardStack from '@/components/CardStack';
 
 function Message() {
-  const { messages } = useStatusProvider();
+  const { messages, clearMessages } = useStatusProvider();
 
   useEffect(() => {
     const textarea = document.querySelector('textarea');
@@ -15,19 +16,35 @@ function Message() {
 
   return (
     <CardStack title="Message">
-      <Form style={{ width: '100%' }}>
-        <Form.Group>
-          <Form.Control
-            as="textarea"
-            rows={6}
-            value={`\n\n\n\n\n${messages.join('\n')}`}
-            readOnly
-            style={{
-              fontSize: '0.8rem',
-            }}
-          />
-        </Form.Group>
-      </Form>
+      <Sticker
+        style={{ width: '100%' }}
+        position={{ x: 'right', y: 'top' }}
+      >
+        <Form>
+          <Form.Group>
+            <Form.Control
+              as="textarea"
+              rows={6}
+              value={`\n\n\n\n\n${messages.join('\n')}`}
+              readOnly
+              style={{
+                fontSize: '0.8rem',
+              }}
+            />
+          </Form.Group>
+        </Form>
+        <Sticker.FramedIcon
+          icon="Close"
+          circularFrame
+          sx={{
+            position: 'absolute',
+            top: '0.5rem',
+            right: '0.5rem',
+            cursor: 'pointer',
+          }}
+          onClick={clearMessages}
+        />
+      </Sticker>
     </CardStack>
   );
 }

--- a/packages/passport/sdk-sample-app/src/context/StatusProvider.tsx
+++ b/packages/passport/sdk-sample-app/src/context/StatusProvider.tsx
@@ -6,12 +6,14 @@ import { PassportError } from '@imtbl/passport';
 const MessageContext = createContext<{
   messages: string[],
   addMessage:(operation: string, ...messages: any[]) => void,
+  clearMessages: () => void,
   isLoading: boolean,
   setIsLoading: (isLoading: boolean) => void,
 }>({
       messages: [],
       isLoading: false,
       addMessage: () => null,
+      clearMessages: () => null,
       setIsLoading: () => null,
     });
 
@@ -38,12 +40,17 @@ export function StatusProvider({
     setMessages((prevMessages) => [...prevMessages, messageString]);
   }, []);
 
+  const clearMessages = useCallback(() => {
+    setMessages([]);
+  }, [setMessages]);
+
   const providerValues = useMemo(() => ({
     messages,
     addMessage,
+    clearMessages,
     isLoading,
     setIsLoading,
-  }), [messages, addMessage, isLoading, setIsLoading]);
+  }), [messages, addMessage, clearMessages, isLoading, setIsLoading]);
 
   return (
     <MessageContext.Provider value={providerValues}>
@@ -56,12 +63,14 @@ export function useStatusProvider() {
   const {
     messages,
     addMessage,
+    clearMessages,
     isLoading,
     setIsLoading,
   } = useContext(MessageContext);
   return {
     messages,
     addMessage,
+    clearMessages,
     isLoading,
     setIsLoading,
   };

--- a/packages/passport/sdk/src/confirmation/confirmation.test.ts
+++ b/packages/passport/sdk/src/confirmation/confirmation.test.ts
@@ -116,6 +116,30 @@ describe('confirmation', () => {
         'https://passport.sandbox.immutable.com',
       );
     });
+
+    describe('when the transaction is rejected', () => {
+      it('should resolve with confirmed: false', async () => {
+        const transactionId = 'transactionId123';
+        addEventListenerMock
+          .mockImplementationOnce((event, callback) => {
+            callback({
+              origin: testConfig.passportDomain,
+              data: {
+                eventType: PASSPORT_EVENT_TYPE,
+                messageType: ReceiveMessage.TRANSACTION_REJECTED,
+              },
+            });
+          });
+
+        const res = await confirmationScreen.requestConfirmation(
+          transactionId,
+          mockEtherAddress,
+          TransactionApprovalRequestChainTypeEnum.Starkex,
+        );
+
+        expect(res.confirmed).toEqual(false);
+      });
+    });
   });
 
   describe('requestMessageConfirmation', () => {
@@ -157,6 +181,29 @@ describe('confirmation', () => {
         },
         'https://passport.sandbox.immutable.com',
       );
+    });
+
+    describe('when the message is rejected', () => {
+      it('should resolve with confirmed: false', async () => {
+        const transactionId = 'transactionId123';
+        addEventListenerMock
+          .mockImplementationOnce((event, callback) => {
+            callback({
+              origin: testConfig.passportDomain,
+              data: {
+                eventType: PASSPORT_EVENT_TYPE,
+                messageType: ReceiveMessage.MESSAGE_REJECTED,
+              },
+            });
+          });
+
+        const res = await confirmationScreen.requestMessageConfirmation(
+          transactionId,
+          mockEtherAddress,
+        );
+
+        expect(res.confirmed).toEqual(false);
+      });
     });
   });
 });

--- a/packages/passport/sdk/src/confirmation/confirmation.ts
+++ b/packages/passport/sdk/src/confirmation/confirmation.ts
@@ -81,14 +81,14 @@ export default class ConfirmationScreen {
             resolve({ confirmed: true });
             break;
           }
+          case ReceiveMessage.TRANSACTION_REJECTED: {
+            this.closeWindow();
+            resolve({ confirmed: false });
+            break;
+          }
           case ReceiveMessage.TRANSACTION_ERROR: {
             this.closeWindow();
             reject(new Error('Error during transaction confirmation'));
-            break;
-          }
-          case ReceiveMessage.TRANSACTION_REJECTED: {
-            this.closeWindow();
-            reject(new Error('User rejected transaction'));
             break;
           }
           default:
@@ -132,14 +132,14 @@ export default class ConfirmationScreen {
             resolve({ confirmed: true });
             break;
           }
+          case ReceiveMessage.MESSAGE_REJECTED: {
+            this.closeWindow();
+            resolve({ confirmed: false });
+            break;
+          }
           case ReceiveMessage.MESSAGE_ERROR: {
             this.closeWindow();
             reject(new Error('Error during message confirmation'));
-            break;
-          }
-          case ReceiveMessage.MESSAGE_REJECTED: {
-            this.closeWindow();
-            reject(new Error('User rejected message'));
             break;
           }
           default:


### PR DESCRIPTION
# Summary
This PR fixes an inconsistency with the errors that are thrown when the user rejects a transaction or message. Previously, rejecting a transaction with the "Cancel" button in the transaction confirmation app would throw a "User rejected transaction" error, but closing the window using the popup overlay or the OS' close button would result in a "Transaction rejected by user" error.

This PR removes the "User rejected transaction" error in favour of the "Transaction rejected by user" error.

https://github.com/immutable/ts-immutable-sdk/assets/9940216/9168807e-443e-4daa-8321-69c7d6ee5d86

## Fixed
- Passport: Fixed issue with inconsistent errors when the user rejects a transaction or message confirmation.

# Anything else worth calling out?
- Added a clear button to the messages output of the Passport sample application
