### PR TITLE
:feat move webhook minting backend out of alpha

### DIFF
--- a/sdk/module-release.json
+++ b/sdk/module-release.json
@@ -13,8 +13,8 @@
     "orderbook": "prod",
     "checkout": "prod",
     "x": "prod",
-    "webhook": "alpha",
-    "minting_backend": "alpha"
+    "webhook": "prod",
+    "minting_backend": "prod"
   },
   "excludeForBrowser": ["webhook", "minting_backend"],
   "fileCopy": [


### PR DESCRIPTION
# Summary
Move minting backend and webhook package out of alpha.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
Webhook package and minting backend is not in production builds other than the browser bundle.
