### PR TITLE
fix: CM-664 - Checks value is not null before parse to BigNumber

### DIFF
--- a/packages/checkout/sdk/src/balances/balances.ts
+++ b/packages/checkout/sdk/src/balances/balances.ts
@@ -190,6 +190,7 @@ export const getIndexerBalance = async (
 
     const tokenData = item.token || {};
 
+    if (item.value == null) return;
     const balance = BigNumber.from(item.value);
 
     let decimals = parseInt(tokenData.decimals, 10);


### PR DESCRIPTION
# Summary
Tokentrove reported this issue a couple of weeks ago, the issue happens when it's a newly created wallet but has ERC721 tokens (NO ERC20 and NO IMX), the blockscout api returns a payload like below, and the `coin_balance` field being `null` breaks when passed to the `BigNumber.from` function.

```
{
    "block_number_balance_updated_at": null,
    "coin_balance": null,
    "creation_tx_hash": null,
    "creator_address_hash": null,
    "ens_domain_name": null,
    "exchange_rate": null,
    "has_beacon_chain_withdrawals": false,
    "has_decompiled_code": false,
    "has_logs": false,
    "has_token_transfers": true,
    "has_tokens": false,
    "has_validated_blocks": false,
    "hash": "0x9509A79c32AAdE7cbfC0175890a6d0F33c089084",
    "implementation_address": null,
    "implementation_name": null,
    "implementations": [],
    "is_contract": false,
    "is_verified": null,
    "metadata": null,
    "name": null,
    "private_tags": [],
    "public_tags": [],
    "token": null,
    "watchlist_address_id": null,
    "watchlist_names": []
}
```
# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
