### PR TITLE
Add traders as codeowners to orderbook package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 /packages/internal/dex @immutable/tokens
 /packages/internal/bridge @immutable/rollups
 /packages/internal/guardian @immutable/passport
+/packages/orderbook @immutable/traders
 /packages/passport @immutable/passport
 /packages/x-provider @immutable/commerce
 /packages/checkout @immutable/commerce


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Correct team as codeowners of packages/orderbook
