### PR TITLE
Bridge approval is confirmed move to in progress view

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/bridge/views/ApproveTransaction.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/views/ApproveTransaction.tsx
@@ -242,10 +242,18 @@ export function ApproveTransaction({ bridgeTransaction }: ApproveTransactionProp
         provider: from.web3Provider,
         transaction: transaction.unsignedTx,
       });
+      viewDispatch({
+        payload: {
+          type: ViewActions.UPDATE_VIEW,
+          view: {
+            type: BridgeWidgetViews.IN_PROGRESS,
+            transactionHash: sendResult.transactionResponse.hash,
+            isTransfer: false,
+          },
+        },
+      });
 
-      setLoading(true);
       const receipt = await sendResult.transactionResponse.wait();
-
       if (receipt.status === 0) {
         viewDispatch({
           payload: {
@@ -256,19 +264,7 @@ export function ApproveTransaction({ bridgeTransaction }: ApproveTransactionProp
             },
           },
         });
-        return;
       }
-
-      viewDispatch({
-        payload: {
-          type: ViewActions.UPDATE_VIEW,
-          view: {
-            type: BridgeWidgetViews.IN_PROGRESS,
-            transactionHash: receipt.transactionHash,
-            isTransfer: false,
-          },
-        },
-      });
     } catch (error: any) {
       if (error.type === CheckoutErrorType.USER_REJECTED_REQUEST_ERROR) {
         setRejectedBridge(true);


### PR DESCRIPTION
# Summary
- Once approval is confirmed move to in progress view and skip L1 transaction confirmation.
- If error is returned, still displays bridge failure view.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
