### PR TITLE
fix: no russian nesting doll

### DIFF
--- a/packages/internal/dex/sdk/package.json
+++ b/packages/internal/dex/sdk/package.json
@@ -5,6 +5,7 @@
   "author": "Immutable",
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",
   "dependencies": {
+    "@imtbl/config": "^0.0.0",
     "@uniswap/router-sdk": "^1.4.0",
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/v3-sdk": "^3.9.0",

--- a/packages/internal/dex/sdk/package.json
+++ b/packages/internal/dex/sdk/package.json
@@ -5,7 +5,7 @@
   "author": "Immutable",
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",
   "dependencies": {
-    "@imtbl/config": "^0.0.0",
+    "@imtbl/config": "0.0.0",
     "@uniswap/router-sdk": "^1.4.0",
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/v3-sdk": "^3.9.0",

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -36,52 +36,46 @@ const getFilesToBuild = () => {
   return [...files, ...returnModules];
 };
 
-const getFileBuild = (inputFilename) => [
-  {
-    input: `./src/${inputFilename}.ts`,
-    output: {
-      dir: 'dist',
-      format: 'es',
-    },
-    plugins: [
-      nodeResolve({
-        resolveOnly: getPackages(),
-      }),
-      json(),
-      commonJs(),
-      typescript({
-        declaration: true,
-        declarationDir: './dist/types',
-      }),
-      replace({
-        exclude: 'node_modules/**',
-        preventAssignment: true,
-        __SDK_VERSION__: pkg.version,
-      }),
-    ],
-  },
-  {
-    input: `./dist/types/${inputFilename}.d.ts`,
-    output: {
-      file: `./dist/${inputFilename}.d.ts`,
-      format: 'es',
-    },
-    plugins: [
-      dts({
-        respectExternal: true,
-      }),
-    ],
-    external: ['pg'] 
-  },
-];
-
 const buildBundles = () => {
-  const modules = [];
   const filesToBuild = getFilesToBuild();
-  for (const file of filesToBuild) {
-    modules.push(...getFileBuild(file));
-  }
-  return modules;
+  // generate a single object that contains all the files under input
+  const [inputs, types] = filesToBuild.reduce((acc, f) => {
+    return [
+      {...acc[0], [f] : `./src/${f}.ts`},
+      {...acc[1], [f] : `./dist/types/${f}.d.ts`},
+    ];
+  }, [{}, {}])
+
+  return [
+    {
+      input: inputs,
+      output: {
+        dir: 'dist',
+        format: 'es',
+      },
+      plugins: [
+        nodeResolve({
+          resolveOnly: getPackages(),
+        }),
+        json(),
+        commonJs(),
+        typescript({
+          declaration: true,
+          declarationDir: './dist/types',
+        }),
+        replace({
+          exclude: 'node_modules/**',
+          preventAssignment: true,
+          __SDK_VERSION__: pkg.version,
+        }),
+        dts({
+          respectExternal: true,
+        }),
+      ],
+      external: ['pg'] 
+    },
+  ]
+
 };
 
 export default [

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -68,7 +68,8 @@ const buildBundles = () => {
           exclude: 'node_modules/**',
           preventAssignment: true,
           __SDK_VERSION__: pkg.version,
-        })
+        }),
+        terser(),
       ],
       external: ['pg'] 
     },

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -68,10 +68,7 @@ const buildBundles = () => {
           exclude: 'node_modules/**',
           preventAssignment: true,
           __SDK_VERSION__: pkg.version,
-        }),
-        dts({
-          respectExternal: true,
-        }),
+        })
       ],
       external: ['pg'] 
     },

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -36,6 +36,7 @@ const getFilesToBuild = () => {
   return [...files, ...returnModules];
 };
 
+
 const buildBundles = () => {
   const filesToBuild = getFilesToBuild();
   // generate a single object that contains all the files under input
@@ -68,6 +69,19 @@ const buildBundles = () => {
           preventAssignment: true,
           __SDK_VERSION__: pkg.version,
         }),
+        dts({
+          respectExternal: true,
+        }),
+      ],
+      external: ['pg'] 
+    },
+    {
+      input: types,
+      output: {
+        dir: 'dist',
+        format: 'es',
+      },
+      plugins: [
         dts({
           respectExternal: true,
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,7 +3542,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@imtbl/config@0.0.0, @imtbl/config@^0.0.0, @imtbl/config@workspace:packages/config":
+"@imtbl/config@0.0.0, @imtbl/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@imtbl/config@workspace:packages/config"
   dependencies:
@@ -3594,7 +3594,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@imtbl/dex-sdk@workspace:packages/internal/dex/sdk"
   dependencies:
-    "@imtbl/config": ^0.0.0
+    "@imtbl/config": 0.0.0
     "@rollup/plugin-json": ^6.0.0
     "@swc/core": ^1.3.36
     "@swc/jest": ^0.2.24

--- a/yarn.lock
+++ b/yarn.lock
@@ -3546,6 +3546,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@imtbl/config@workspace:packages/config"
   dependencies:
+    "@imtbl/metrics": 0.0.0
     "@rollup/plugin-typescript": ^11.0.0
     "@swc/core": ^1.3.36
     "@swc/jest": ^0.2.24

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,11 +3542,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@imtbl/config@0.0.0, @imtbl/config@workspace:packages/config":
+"@imtbl/config@0.0.0, @imtbl/config@^0.0.0, @imtbl/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@imtbl/config@workspace:packages/config"
   dependencies:
-    "@imtbl/metrics": 0.0.0
     "@rollup/plugin-typescript": ^11.0.0
     "@swc/core": ^1.3.36
     "@swc/jest": ^0.2.24
@@ -3594,6 +3593,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@imtbl/dex-sdk@workspace:packages/internal/dex/sdk"
   dependencies:
+    "@imtbl/config": ^0.0.0
     "@rollup/plugin-json": ^6.0.0
     "@swc/core": ^1.3.36
     "@swc/jest": ^0.2.24


### PR DESCRIPTION
# Summary
Make esm module not replicating each other as much as possible.
The size of this approach is ~31 MB vs 37.8MB on npm

# Detail and impact of the change

## Changed
Group esm package inputs into a rollup config so that roll up can reason about their relationship.

