### PR TITLE
TD-1515: chore: add examples for signing ERC1155 listings in Passport sample app.

### DIFF
--- a/packages/passport/sdk-sample-app/src/components/zkevm/EthSignTypedDataV4Examples/SeaportCreateERC1155ListingDefault.tsx
+++ b/packages/passport/sdk-sample-app/src/components/zkevm/EthSignTypedDataV4Examples/SeaportCreateERC1155ListingDefault.tsx
@@ -8,9 +8,9 @@ import WorkflowButton from '@/components/WorkflowButton';
 import { RequestExampleProps } from '@/types';
 import { useImmutableProvider } from '@/context/ImmutableProvider';
 import { usePassportProvider } from '@/context/PassportProvider';
-import { getCreateListingPayload } from './SeaportCreateListingExample';
+import { getCreateERC1155ListingPayload } from './SeaportCreateListingExample';
 
-function SeaportCreateListingDefault({ disabled, handleExampleSubmitted }: RequestExampleProps) {
+function SeaportCreateERC1155ListingDefault({ disabled, handleExampleSubmitted }: RequestExampleProps) {
   const { orderbookClient } = useImmutableProvider();
   const { zkEvmProvider } = usePassportProvider();
 
@@ -31,7 +31,7 @@ function SeaportCreateListingDefault({ disabled, handleExampleSubmitted }: Reque
         });
         const chainIdHex = await zkEvmProvider.request({ method: 'eth_chainId' });
         const chainId = parseInt(chainIdHex, 16);
-        const data = getCreateListingPayload({ seaportContractAddress, walletAddress: address, chainId });
+        const data = getCreateERC1155ListingPayload({ seaportContractAddress, walletAddress: address, chainId });
         setParams([address, data]);
       }
     };
@@ -49,8 +49,8 @@ function SeaportCreateListingDefault({ disabled, handleExampleSubmitted }: Reque
   }, [handleExampleSubmitted, params]);
 
   return (
-    <Accordion.Item eventKey="4">
-      <Accordion.Header>Seaport Create Listing (Hardcoded example)</Accordion.Header>
+    <Accordion.Item eventKey="5">
+      <Accordion.Header>Seaport Create Listing - ERC1155 order (Hardcoded example)</Accordion.Header>
       <Accordion.Body>
         <Alert variant="warning">
           Note: This method only returns a signed message, it does not submit an order to the orderbook.
@@ -82,4 +82,4 @@ function SeaportCreateListingDefault({ disabled, handleExampleSubmitted }: Reque
   );
 }
 
-export default SeaportCreateListingDefault;
+export default SeaportCreateERC1155ListingDefault;

--- a/packages/passport/sdk-sample-app/src/components/zkevm/EthSignTypedDataV4Examples/SeaportCreateERC721ListingDefault.tsx
+++ b/packages/passport/sdk-sample-app/src/components/zkevm/EthSignTypedDataV4Examples/SeaportCreateERC721ListingDefault.tsx
@@ -1,0 +1,85 @@
+import React, {
+  useCallback, useEffect, useMemo, useState,
+} from 'react';
+import {
+  Accordion, Alert, Form, Stack,
+} from 'react-bootstrap';
+import WorkflowButton from '@/components/WorkflowButton';
+import { RequestExampleProps } from '@/types';
+import { useImmutableProvider } from '@/context/ImmutableProvider';
+import { usePassportProvider } from '@/context/PassportProvider';
+import { getCreateERC721ListingPayload } from './SeaportCreateListingExample';
+
+function SeaportCreateERC721ListingDefault({ disabled, handleExampleSubmitted }: RequestExampleProps) {
+  const { orderbookClient } = useImmutableProvider();
+  const { zkEvmProvider } = usePassportProvider();
+
+  const [params, setParams] = useState<any>();
+
+  const seaportContractAddress = useMemo(
+    () => (
+      orderbookClient.config().seaportContractAddress
+    ),
+    [orderbookClient],
+  );
+
+  useEffect(() => {
+    const getAddress = async () => {
+      if (zkEvmProvider) {
+        const [address] = await zkEvmProvider.request({
+          method: 'eth_requestAccounts',
+        });
+        const chainIdHex = await zkEvmProvider.request({ method: 'eth_chainId' });
+        const chainId = parseInt(chainIdHex, 16);
+        const data = getCreateERC721ListingPayload({ seaportContractAddress, walletAddress: address, chainId });
+        setParams([address, data]);
+      }
+    };
+    getAddress().catch(console.log);
+  }, [zkEvmProvider, seaportContractAddress]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    return handleExampleSubmitted({
+      method: 'eth_signTypedData_v4',
+      params,
+    });
+  }, [handleExampleSubmitted, params]);
+
+  return (
+    <Accordion.Item eventKey="4">
+      <Accordion.Header>Seaport Create Listing - ERC721 order (Hardcoded example)</Accordion.Header>
+      <Accordion.Body>
+        <Alert variant="warning">
+          Note: This method only returns a signed message, it does not submit an order to the orderbook.
+        </Alert>
+        <Form onSubmit={handleSubmit} className="mb-4">
+          <Form.Group className="mb-3">
+            <Form.Label>
+              Preview
+            </Form.Label>
+            <Form.Control
+              required
+              disabled
+              as="textarea"
+              rows={7}
+              value={JSON.stringify(params, null, '\t')}
+            />
+          </Form.Group>
+          <Stack direction="horizontal" gap={3}>
+            <WorkflowButton
+              disabled={disabled}
+              type="submit"
+            >
+              Submit
+            </WorkflowButton>
+          </Stack>
+        </Form>
+      </Accordion.Body>
+    </Accordion.Item>
+  );
+}
+
+export default SeaportCreateERC721ListingDefault;

--- a/packages/passport/sdk-sample-app/src/components/zkevm/EthSignTypedDataV4Examples/SeaportCreateListingExample.ts
+++ b/packages/passport/sdk-sample-app/src/components/zkevm/EthSignTypedDataV4Examples/SeaportCreateListingExample.ts
@@ -1,4 +1,4 @@
-export const getCreateListingPayload = ({ seaportContractAddress, walletAddress, chainId }:
+export const getCreateERC721ListingPayload = ({ seaportContractAddress, walletAddress, chainId }:
 { seaportContractAddress: string, walletAddress: string, chainId: number }) => (
   {
     domain: {
@@ -35,7 +35,7 @@ export const getCreateListingPayload = ({ seaportContractAddress, walletAddress,
           identifierOrCriteria: '842809524',
           itemType: '2',
           startAmount: '1',
-          token: '0x114c1f0702547751a546661bc375d95fb2d281a8',
+          token: '0xd46546c8d7ebe9c1b2afe299080eef374618eca2',
         },
       ],
       offerer: walletAddress,
@@ -43,6 +43,171 @@ export const getCreateListingPayload = ({ seaportContractAddress, walletAddress,
       salt: '14819419685848783759',
       startTime: '1709004852',
       zone: '0x8831867e347ab87fa30199c5b695f0a31604bb52',
+      zoneHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    },
+    primaryType: 'OrderComponents',
+    types: {
+      ConsiderationItem: [
+        {
+          name: 'itemType',
+          type: 'uint8',
+        },
+        {
+          name: 'token',
+          type: 'address',
+        },
+        {
+          name: 'identifierOrCriteria',
+          type: 'uint256',
+        },
+        {
+          name: 'startAmount',
+          type: 'uint256',
+        },
+        {
+          name: 'endAmount',
+          type: 'uint256',
+        },
+        {
+          name: 'recipient',
+          type: 'address',
+        },
+      ],
+      EIP712Domain: [
+        {
+          name: 'name',
+          type: 'string',
+        },
+        {
+          name: 'version',
+          type: 'string',
+        },
+        {
+          name: 'chainId',
+          type: 'uint256',
+        },
+        {
+          name: 'verifyingContract',
+          type: 'address',
+        },
+      ],
+      OfferItem: [
+        {
+          name: 'itemType',
+          type: 'uint8',
+        },
+        {
+          name: 'token',
+          type: 'address',
+        },
+        {
+          name: 'identifierOrCriteria',
+          type: 'uint256',
+        },
+        {
+          name: 'startAmount',
+          type: 'uint256',
+        },
+        {
+          name: 'endAmount',
+          type: 'uint256',
+        },
+      ],
+      OrderComponents: [
+        {
+          name: 'offerer',
+          type: 'address',
+        },
+        {
+          name: 'zone',
+          type: 'address',
+        },
+        {
+          name: 'offer',
+          type: 'OfferItem[]',
+        },
+        {
+          name: 'consideration',
+          type: 'ConsiderationItem[]',
+        },
+        {
+          name: 'orderType',
+          type: 'uint8',
+        },
+        {
+          name: 'startTime',
+          type: 'uint256',
+        },
+        {
+          name: 'endTime',
+          type: 'uint256',
+        },
+        {
+          name: 'zoneHash',
+          type: 'bytes32',
+        },
+        {
+          name: 'salt',
+          type: 'uint256',
+        },
+        {
+          name: 'conduitKey',
+          type: 'bytes32',
+        },
+        {
+          name: 'counter',
+          type: 'uint256',
+        },
+      ],
+    },
+  }
+);
+
+export const getCreateERC1155ListingPayload = ({ seaportContractAddress, walletAddress, chainId }:
+{ seaportContractAddress: string, walletAddress: string, chainId: number }) => (
+  {
+    domain: {
+      chainId,
+      name: 'ImmutableSeaport',
+      verifyingContract: seaportContractAddress,
+      version: '1.5',
+    },
+    message: {
+      conduitKey: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      consideration: [
+        {
+          endAmount: '10000000000000000000',
+          identifierOrCriteria: '0',
+          itemType: '0',
+          recipient: walletAddress,
+          startAmount: '10000000000000000000',
+          token: '0x0000000000000000000000000000000000000000',
+        },
+        {
+          endAmount: '100000000000000000',
+          identifierOrCriteria: '0',
+          itemType: '0',
+          recipient: walletAddress,
+          startAmount: '100000000000000000',
+          token: '0x0000000000000000000000000000000000000000',
+        },
+      ],
+      counter: '0',
+      endTime: '1772076852',
+      offer: [
+        {
+          endAmount: '10',
+          identifierOrCriteria: '3',
+          itemType: '3',
+          startAmount: '10',
+          token: '0xd6ebeec5b52c4a237a4c64c6d3171e78b57a40f7',
+        },
+      ],
+      offerer: walletAddress,
+      orderType: '3',
+      salt: '14819419685848783759',
+      startTime: '1709004852',
+      zone: '0x1004f9615e79462c711ff05a386bdba91a7628c3',
       zoneHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
     },
     primaryType: 'OrderComponents',

--- a/packages/passport/sdk-sample-app/src/components/zkevm/EthSignTypedDataV4Examples/index.ts
+++ b/packages/passport/sdk-sample-app/src/components/zkevm/EthSignTypedDataV4Examples/index.ts
@@ -1,6 +1,7 @@
 import ValidateTypedDataSignature from '@/components/zkevm/EthSignTypedDataV4Examples/ValidateTypedDataSignature';
 import SeaportCreateListing from './SeaportCreateListing';
-import SeaportCreateListingDefault from './SeaportCreateListingDefault';
+import SeaportCreateERC721ListingDefault from './SeaportCreateERC721ListingDefault';
+import SeaportCreateERC1155ListingDefault from './SeaportCreateERC1155ListingDefault';
 import SignEtherMail from './SignEtherMail';
 import ValidateEtherMail from './ValidateEtherMail';
 
@@ -9,7 +10,8 @@ const EthSignTypedDataV4Examples = [
   SignEtherMail,
   ValidateEtherMail,
   SeaportCreateListing,
-  SeaportCreateListingDefault,
+  SeaportCreateERC721ListingDefault,
+  SeaportCreateERC1155ListingDefault,
 ];
 
 export default EthSignTypedDataV4Examples;


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [X] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Add examples for signing ERC1155 listings in Passport sample app.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->
* New hardcoded example to generate signable message for ERC1155 listings creation
 
![Screenshot 2024-06-25 at 15 18 31](https://github.com/immutable/ts-immutable-sdk/assets/116692862/4501af52-a285-4c9e-bb08-057ab6310d4f)

## Changed
<!-- Section for changes in existing functionality. -->
* Updated the generic `CreateListing` example to support ERC1155 token type. 

![Screenshot 2024-06-25 at 15 18 05](https://github.com/immutable/ts-immutable-sdk/assets/116692862/f8e9742b-70a9-4a32-8c36-77d5b4435da2)