### PR TITLE
refactor: use cached node_modules across workflows

### DIFF
--- a/.github/workflows/build-lint-typecheck-test.yaml
+++ b/.github/workflows/build-lint-typecheck-test.yaml
@@ -25,14 +25,23 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: "yarn"
 
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Cache node_modules
+      - name: Restore cached node_modules
+        id: restore-cache-node_modules
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
+        run: yarn install --immutable
+
+      - name: Cache node_modules
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Check Single Package Version Policy
         run: yarn syncpack:check
@@ -67,8 +76,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node-modules-
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Restore cached build artifacts
         uses: actions/cache@v4
@@ -77,7 +85,6 @@ jobs:
             ./sdk
             ./packages
           key: ${{ runner.os }}-build-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-build-
 
       - name: Build passport sample app
         run: yarn workspace @imtbl/passport-sdk-sample-app build
@@ -101,8 +108,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node-modules-
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Restore cached build artifacts
         uses: actions/cache@v4
@@ -111,7 +117,6 @@ jobs:
             ./sdk
             ./packages
           key: ${{ runner.os }}-build-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-build-
 
       - name: Typecheck
         run: yarn typecheck
@@ -137,8 +142,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node-modules-
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Restore cached build artifacts
         uses: actions/cache@v4
@@ -147,7 +151,6 @@ jobs:
             ./sdk
             ./packages
           key: ${{ runner.os }}-build-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-build-
 
       - name: Test
         run: yarn test
@@ -188,8 +191,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node-modules-
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Get reviewing teams
         id: reviewer-teams
@@ -203,7 +205,6 @@ jobs:
             ./sdk
             ./packages
           key: ${{ runner.os }}-build-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-build-
 
       - name: Checkout-widgets cypress tests
         if: ${{ contains(steps.reviewer-teams.outputs.teams, 'Wallets') && !contains(github.event.pull_request.title, 'SKIP-CY') }}
@@ -243,8 +244,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node-modules-
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/build-lint-typecheck-test.yaml
+++ b/.github/workflows/build-lint-typecheck-test.yaml
@@ -25,6 +25,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: "yarn"
 
+      # this step will also try to cache the node_modules at the end of the workflow run
       - name: Restore cached node_modules
         id: restore-cache-node_modules
         uses: actions/cache@v4
@@ -35,13 +36,6 @@ jobs:
       - name: Install dependencies
         if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
         run: yarn install --immutable
-
-      - name: Cache node_modules
-        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Check Single Package Version Policy
         run: yarn syncpack:check

--- a/.github/workflows/build-sdk.yaml
+++ b/.github/workflows/build-sdk.yaml
@@ -29,13 +29,13 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
-      - name: Build
-        run: yarn build
+      # - name: Build
+      #   run: yarn build
 
-      - name: Cache build artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            ./sdk
-            ./packages
-          key: ${{ runner.os }}-build-cache-${{ github.sha }}
+      # - name: Cache build artifacts
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: |
+      #       ./sdk
+      #       ./packages
+      #     key: ${{ runner.os }}-build-cache-${{ github.sha }}

--- a/.github/workflows/build-sdk.yaml
+++ b/.github/workflows/build-sdk.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Cache build artifacts
+      - name: Cache node_modules
         uses: actions/cache@v4
         with:
           path: node_modules

--- a/.github/workflows/detect-node-version-change.yaml
+++ b/.github/workflows/detect-node-version-change.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Node engine version from package.json
         id: get_package_json_node_engine_version

--- a/.github/workflows/functional-tests-imx.yml
+++ b/.github/workflows/functional-tests-imx.yml
@@ -10,13 +10,25 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version-file: ".nvmrc"
+          cache: 'yarn'
+
+      - name: Restore cached node_modules
+        id: restore-cache-node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Install root dependencies
-        run: npm install -g yarn && yarn install --immutable
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
+        run: yarn install --immutable
 
       - name: Build SDK
         run: yarn build

--- a/.github/workflows/functional-tests-zkevm.yml
+++ b/.github/workflows/functional-tests-zkevm.yml
@@ -10,13 +10,25 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'yarn'
+
+      - name: Restore cached node_modules
+        id: restore-cache-node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Install root dependencies
-        run: npm install -g yarn && yarn install --immutable
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
+        run: yarn install --immutable
 
       - name: Build SDK
         run: yarn build

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,13 +12,25 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.40.0-jammy
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+  
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
           node-version-file: samples/apps/ts-immutable-sample/.nvmrc
+          cache: 'yarn'
 
+      - name: Restore cached node_modules
+        id: restore-cache-node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
+  
       - name: Install root dependencies
-        run: npm install -g yarn && yarn install --immutable
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
+        run: yarn install --immutable
 
       - name: Build SDK
         run: yarn build

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -16,12 +16,12 @@ jobs:
       GITHUB_USER: ${{ github.actor }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Checkout Docs Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: immutable/docs
           token: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: "yarn"
@@ -55,7 +55,15 @@ jobs:
           jq '.version = "${{ env.VERSION }}"' ./package.json > "$tmp" && mv "$tmp" ./package.json
         shell: bash
 
+      - name: Restore cached node_modules
+        id: restore-cache-node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
+
       - name: Install dependencies
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
         run: yarn install --immutable
 
       - name: Build

--- a/.github/workflows/publish-major-version.yaml
+++ b/.github/workflows/publish-major-version.yaml
@@ -70,7 +70,7 @@ jobs:
         run: failure("Public releases should be only done from main branch, current branch ${{ github.ref }}")
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
         run: git fetch --tags
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: "yarn"
@@ -100,7 +100,15 @@ jobs:
           ./.github/scripts/version-up.sh --${{ github.event.inputs.release_type }} --$upgrade_type --apply $revision_upgrade
         shell: bash
 
+      - name: Restore cached node_modules
+        id: restore-cache-node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
+
       - name: Install dependencies
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
         run: yarn install --immutable
 
       - name: Lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,7 @@ jobs:
         run: failure("Public releases should be only done from main branch, current branch ${{ github.ref }}")
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
@@ -67,7 +67,7 @@ jobs:
         run: git fetch --tags
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: "yarn"
@@ -87,7 +87,15 @@ jobs:
           ./.github/scripts/version-up.sh --${{ env.RELEASE_TYPE }} $upgrade_type --apply $revision_upgrade
         shell: bash
 
+      - name: Restore cached node_modules
+        id: restore-cache-node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
+
       - name: Install dependencies
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
         run: yarn install --immutable
 
       - name: Lint

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -5,7 +5,7 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2.3.4

--- a/.github/workflows/smokes-tests.yaml
+++ b/.github/workflows/smokes-tests.yaml
@@ -16,16 +16,24 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=14366
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org/
           cache: "yarn"
 
+      - name: Restore cached node_modules
+        id: restore-cache-node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
+
       - name: Install root dependencies
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
         run: yarn install --immutable
 
       - name: Build


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Refactor workflows to use the cached `node_modules` between workflows. This cache should be similar between workflow runs as it should only change when adding or removing dependencies from the root level `package.json`.

`build-lint-typecheck` and `build-sdk` workflows should update the cache if the `yarn.lock` changes.

# Detail and impact of the change

## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
- When dependencies haven't changed in `package.json` this appears to reduce run time of all affected workflows by around 2 minutes. 
