### PR TITLE
[DX-2954] feat: always return an error if 'success' is false

### DIFF
--- a/packages/game-bridge/src/index.ts
+++ b/packages/game-bridge/src/index.ts
@@ -224,10 +224,10 @@ window.callFunction = async (jsonData: string) => {
           responseFor: fxName,
           requestId,
           success: true,
-          code: response?.code,
-          deviceCode: response?.deviceCode,
-          url: response?.url,
-          interval: response?.interval,
+          code: response.code,
+          deviceCode: response.deviceCode,
+          url: response.url,
+          interval: response.interval,
         });
         break;
       }
@@ -247,6 +247,7 @@ window.callFunction = async (jsonData: string) => {
           responseFor: fxName,
           requestId,
           success: userInfo !== null,
+          error: userInfo === null ? 'Failed to re-login' : undefined,
         });
         break;
       }
@@ -268,6 +269,7 @@ window.callFunction = async (jsonData: string) => {
           responseFor: fxName,
           requestId,
           success: providerSet,
+          error: !providerSet ? 'Failed to reconnect' : undefined,
         });
         break;
       }
@@ -320,6 +322,7 @@ window.callFunction = async (jsonData: string) => {
           responseFor: fxName,
           requestId,
           success: providerSet,
+          error: !providerSet ? 'Failed to connect via PKCE' : undefined,
         });
         break;
       }
@@ -366,6 +369,7 @@ window.callFunction = async (jsonData: string) => {
           responseFor: fxName,
           requestId,
           success: providerSet,
+          error: !providerSet ? 'Failed to connect' : undefined,
         });
         break;
       }
@@ -543,6 +547,7 @@ window.callFunction = async (jsonData: string) => {
           responseFor: fxName,
           requestId,
           success: providerSet,
+          error: !providerSet ? 'Failed to connect to EVM' : undefined,
         });
         break;
       }


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Updated the game bridge so that if `status` is `false`, an `error` object is always returned.