### PR TITLE
[Fix] add close handovers

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -324,6 +324,11 @@ export function SaleContextProvider(props: {
   );
 
   useEffect(() => {
+    if (!signError) return;
+    goToErrorView(signError.type, signError.data);
+  }, [signError]);
+
+  useEffect(() => {
     if (!orderQuoteError) return;
     goToErrorView(orderQuoteError.type, orderQuoteError.data);
   }, [orderQuoteError]);

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -106,6 +106,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       return;
     }
 
+    closeHandover();
     viewDispatch({
       payload: {
         type: ViewActions.UPDATE_VIEW,

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -63,7 +63,6 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
   const signAndProceed = (tokenAddress?: string) => {
     sign(SignPaymentTypes.CRYPTO, tokenAddress);
 
-    closeHandover();
     viewDispatch({
       payload: {
         type: ViewActions.UPDATE_VIEW,
@@ -107,7 +106,6 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       return;
     }
 
-    closeHandover();
     viewDispatch({
       payload: {
         type: ViewActions.UPDATE_VIEW,

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -70,6 +70,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
         },
       },
     });
+    closeHandover();
   };
 
   const onFundingRouteExecuted = () => {
@@ -91,6 +92,9 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       ),
     });
 
+    // eslint-disable-next-line no-debugger
+    debugger;
+
     const { type, fundingItem } = fundingBalance;
 
     sendProceedToPay(
@@ -104,7 +108,6 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       signAndProceed(fundingItem.token.address);
       return;
     }
-
     viewDispatch({
       payload: {
         type: ViewActions.UPDATE_VIEW,
@@ -118,6 +121,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
         },
       },
     });
+    closeHandover();
   };
 
   const {

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -92,9 +92,6 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       ),
     });
 
-    // eslint-disable-next-line no-debugger
-    debugger;
-
     const { type, fundingItem } = fundingBalance;
 
     sendProceedToPay(

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -61,6 +61,19 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
   const onPayWithCard = (paymentType: SalePaymentTypes) => goBackToPaymentMethods(paymentType);
 
   const signAndProceed = (tokenAddress?: string) => {
+    addHandover({
+      animationUrl: getRemoteRive(
+        environment,
+        getRiveAnimationName(TransactionMethod.APPROVE),
+      ),
+      inputValue:
+        transactionRiveAnimations[TransactionMethod.APPROVE].inputValues.start,
+      children: (
+        <Heading sx={{ px: 'base.spacing.x6' }}>
+          {t('views.PAYMENT_METHODS.handover.initial')}
+        </Heading>
+      ),
+    });
     sign(SignPaymentTypes.CRYPTO, tokenAddress);
 
     viewDispatch({
@@ -78,20 +91,6 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
   };
 
   const onProceedToBuy = (fundingBalance: FundingBalance) => {
-    addHandover({
-      animationUrl: getRemoteRive(
-        environment,
-        getRiveAnimationName(TransactionMethod.APPROVE),
-      ),
-      inputValue:
-        transactionRiveAnimations[TransactionMethod.APPROVE].inputValues.start,
-      children: (
-        <Heading sx={{ px: 'base.spacing.x6' }}>
-          {t('views.PAYMENT_METHODS.handover.initial')}
-        </Heading>
-      ),
-    });
-
     const { type, fundingItem } = fundingBalance;
 
     sendProceedToPay(

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -62,6 +62,8 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
 
   const signAndProceed = (tokenAddress?: string) => {
     sign(SignPaymentTypes.CRYPTO, tokenAddress);
+
+    closeHandover();
     viewDispatch({
       payload: {
         type: ViewActions.UPDATE_VIEW,
@@ -70,7 +72,6 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
         },
       },
     });
-    closeHandover();
   };
 
   const onFundingRouteExecuted = () => {
@@ -105,6 +106,8 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       signAndProceed(fundingItem.token.address);
       return;
     }
+
+    closeHandover();
     viewDispatch({
       payload: {
         type: ViewActions.UPDATE_VIEW,
@@ -118,7 +121,6 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
         },
       },
     });
-    closeHandover();
   };
 
   const {
@@ -165,6 +167,8 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
         smartCheckoutResult.transactionRequirements,
       );
       setPaymentMethod(undefined);
+
+      closeHandover();
       viewDispatch({
         payload: {
           type: ViewActions.UPDATE_VIEW,


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

## Fixed
<!-- Section for any bug fixes. -->
On unhappy paths, it should close handovers before proceeding to top up view.
Add back `useEffect` to listen to errors from sale context.


