### PR TITLE
[ID-1769] fix: Passport zkEVM Provider denotes ethAddress from user session

### DIFF
--- a/packages/passport/sdk/src/Passport.int.test.ts
+++ b/packages/passport/sdk/src/Passport.int.test.ts
@@ -216,7 +216,7 @@ describe('Passport', () => {
           });
 
           expect(accounts).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
-          expect(mockGetUser).toHaveBeenCalledTimes(1);
+          expect(mockGetUser).toHaveBeenCalledTimes(2);
         });
 
         describe('when the registration request fails', () => {
@@ -284,7 +284,7 @@ describe('Passport', () => {
         });
 
         expect(result).toEqual(transactionHash);
-        expect(mockGetUser).toHaveBeenCalledTimes(4);
+        expect(mockGetUser).toHaveBeenCalledTimes(5);
       });
     });
 

--- a/packages/passport/sdk/src/Passport.int.test.ts
+++ b/packages/passport/sdk/src/Passport.int.test.ts
@@ -76,7 +76,6 @@ describe('Passport', () => {
   const mockSigninPopup = jest.fn();
   const mockSigninSilent = jest.fn();
   const mockGetUser = jest.fn();
-  // const mockGetSigner = jest.fn();
   const mockLoginWithOidc = jest.fn();
   const mockMagicRequest = jest.fn();
 
@@ -97,9 +96,6 @@ describe('Passport', () => {
       rpcProvider: { request: mockMagicRequest },
       preload: jest.fn(),
     }));
-    // (Web3Provider as unknown as jest.Mock).mockImplementation(() => ({
-    //   getSigner: mockGetSigner,
-    // }));
   });
 
   afterEach(() => {
@@ -187,11 +183,10 @@ describe('Passport', () => {
           expect(mockGetUser).toHaveBeenCalledTimes(2);
         });
 
-        it('ethSigner is initialised even if user exists', async () => {
+        it('ethSigner is initialised if user logs in after connectEvm', async () => {
           mockGetUser.mockResolvedValueOnce(Promise.resolve(null));
           mockSigninPopup.mockResolvedValue(mockOidcUserZkevm);
           mockSigninSilent.mockResolvedValueOnce(mockOidcUserZkevm);
-          // mockGetSigner.mockImplementation(() => { });
 
           const passport = new Passport({
             baseConfig: new ImmutableConfiguration({
@@ -204,14 +199,12 @@ describe('Passport', () => {
             scope: 'openid offline_access profile email transact',
           });
 
-          // user doesn't exist, so wont set signer when provider is instantiated
+          // user isn't logged in, so wont set signer when provider is instantiated
           const zkEvmProvider = passport.connectEvm();
 
-          // logs user in
+          // user logs in, ethSigner is initialised
           await passport.login();
 
-          // user already exists, so return zkevm address
-          mockGetUser.mockResolvedValue(Promise.resolve(mockOidcUserZkevm));
           const accounts = await zkEvmProvider.request({
             method: 'eth_requestAccounts',
           });

--- a/packages/passport/sdk/src/Passport.int.test.ts
+++ b/packages/passport/sdk/src/Passport.int.test.ts
@@ -180,7 +180,7 @@ describe('Passport', () => {
           });
 
           expect(accounts).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
-          expect(mockGetUser).toHaveBeenCalledTimes(1);
+          expect(mockGetUser).toHaveBeenCalledTimes(2);
         });
       });
 
@@ -216,7 +216,7 @@ describe('Passport', () => {
           });
 
           expect(accounts).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
-          expect(mockGetUser).toHaveBeenCalledTimes(2);
+          expect(mockGetUser).toHaveBeenCalledTimes(3);
         });
 
         describe('when the registration request fails', () => {
@@ -284,7 +284,7 @@ describe('Passport', () => {
         });
 
         expect(result).toEqual(transactionHash);
-        expect(mockGetUser).toHaveBeenCalledTimes(5);
+        expect(mockGetUser).toHaveBeenCalledTimes(6);
       });
     });
 

--- a/packages/passport/sdk/src/Passport.int.test.ts
+++ b/packages/passport/sdk/src/Passport.int.test.ts
@@ -20,7 +20,6 @@ import GuardianClient from './guardian';
 import { chainIdHex, mockUserZkEvm } from './test/mocks';
 
 jest.mock('./guardian');
-
 jest.mock('magic-sdk');
 jest.mock('oidc-client-ts');
 jest.mock('@imtbl/x-client');
@@ -182,35 +181,6 @@ describe('Passport', () => {
           expect(accounts).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
           expect(mockGetUser).toHaveBeenCalledTimes(2);
         });
-
-        it('ethSigner is initialised if user logs in after connectEvm', async () => {
-          mockGetUser.mockResolvedValueOnce(Promise.resolve(null));
-          mockSigninPopup.mockResolvedValue(mockOidcUserZkevm);
-          mockSigninSilent.mockResolvedValueOnce(mockOidcUserZkevm);
-
-          const passport = new Passport({
-            baseConfig: new ImmutableConfiguration({
-              environment: Environment.SANDBOX,
-            }),
-            audience: 'platform_api',
-            clientId,
-            redirectUri,
-            logoutRedirectUri,
-            scope: 'openid offline_access profile email transact',
-          });
-
-          // user isn't logged in, so wont set signer when provider is instantiated
-          const zkEvmProvider = passport.connectEvm();
-
-          // user logs in, ethSigner is initialised
-          await passport.login();
-
-          const accounts = await zkEvmProvider.request({
-            method: 'eth_requestAccounts',
-          });
-
-          expect(accounts).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
-        });
       });
 
       describe('when the user is logging in for the first time', () => {
@@ -314,6 +284,72 @@ describe('Passport', () => {
 
         expect(result).toEqual(transactionHash);
         expect(mockGetUser).toHaveBeenCalledTimes(6);
+      });
+
+      it('ethSigner is initialised if user logs in after connectEvm', async () => {
+        const transferToAddress = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC';
+
+        useMswHandlers([
+          mswHandlers.counterfactualAddress.success,
+          mswHandlers.rpcProvider.success,
+          mswHandlers.relayer.success,
+          mswHandlers.guardian.evaluateTransaction.success,
+        ]);
+        mockMagicRequest.mockImplementation(({ method }: RequestArguments) => {
+          switch (method) {
+            case 'eth_chainId': {
+              return Promise.resolve(chainIdHex);
+            }
+            case 'eth_accounts': {
+              return Promise.resolve([magicWalletAddress]);
+            }
+            case 'personal_sign': {
+              return Promise.resolve('0x6b168cf5d90189eaa51d02ff3fa8ffc8956b1ea20fdd34280f521b1acca092305b9ace24e643fe64a30c528323065f5b77e1fb4045bd330aad01e7b9a07591f91b');
+            }
+            default: {
+              throw new Error(`Unexpected method: ${method}`);
+            }
+          }
+        });
+        mockGetUser.mockResolvedValueOnce(Promise.resolve(null));
+        mockSigninPopup.mockResolvedValue(mockOidcUserZkevm);
+        mockSigninSilent.mockResolvedValueOnce(mockOidcUserZkevm);
+
+        const passport = new Passport({
+          baseConfig: new ImmutableConfiguration({
+            environment: Environment.SANDBOX,
+          }),
+          audience: 'platform_api',
+          clientId,
+          redirectUri,
+          logoutRedirectUri,
+          scope: 'openid offline_access profile email transact',
+        });
+
+        // user isn't logged in, so wont set signer when provider is instantiated
+        const zkEvmProvider = passport.connectEvm();
+
+        // user logs in, ethSigner is initialised
+        await passport.login();
+
+        mockGetUser.mockResolvedValue(Promise.resolve(mockOidcUserZkevm));
+        const accounts = await zkEvmProvider.request({
+          method: 'eth_requestAccounts',
+        });
+
+        expect(accounts).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
+
+        const transaction: TransactionRequest = {
+          to: transferToAddress,
+          value: '5000000000000000',
+          data: '0x00',
+        };
+        const result = await zkEvmProvider.request({
+          method: 'eth_sendTransaction',
+          params: [transaction],
+        });
+
+        expect(result).toEqual(transactionHash);
       });
     });
 

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -192,6 +192,7 @@ export class Passport {
       identify({
         passportId: user.profile.sub,
       });
+      this.passportEventEmitter.emit(PassportEvents.LOGGED_IN, user);
     }
 
     return user ? user.profile : null;
@@ -217,6 +218,7 @@ export class Passport {
       interval,
       timeoutMs,
     );
+    this.passportEventEmitter.emit(PassportEvents.LOGGED_IN, user);
     return user.profile;
   }
 
@@ -232,6 +234,7 @@ export class Passport {
       authorizationCode,
       state,
     );
+    this.passportEventEmitter.emit(PassportEvents.LOGGED_IN, user);
     return user.profile;
   }
 

--- a/packages/passport/sdk/src/types.ts
+++ b/packages/passport/sdk/src/types.ts
@@ -5,6 +5,7 @@ import { Flow } from '@imtbl/metrics';
 
 export enum PassportEvents {
   LOGGED_OUT = 'loggedOut',
+  LOGGED_IN = 'loggedIn',
   ACCOUNTS_REQUESTED = 'accountsRequested',
 }
 
@@ -18,6 +19,7 @@ export type AccountsRequestedEvent = {
 
 export interface PassportEventMap extends Record<string, any> {
   [PassportEvents.LOGGED_OUT]: [];
+  [PassportEvents.LOGGED_IN]: [User];
   [PassportEvents.ACCOUNTS_REQUESTED]: [AccountsRequestedEvent];
 }
 

--- a/packages/passport/sdk/src/zkEvm/sendTransaction.test.ts
+++ b/packages/passport/sdk/src/zkEvm/sendTransaction.test.ts
@@ -86,7 +86,7 @@ describe('sendTransaction', () => {
         ethSigner,
         rpcProvider: rpcProvider as unknown as StaticJsonRpcProvider,
         relayerClient: relayerClient as unknown as RelayerClient,
-        zkevmAddress: mockUserZkEvm.zkEvm.ethAddress,
+        zkEvmAddress: mockUserZkEvm.zkEvm.ethAddress,
         guardianClient: guardianClient as unknown as GuardianClient,
         flow: flow as unknown as Flow,
       });
@@ -103,7 +103,7 @@ describe('sendTransaction', () => {
         ethSigner,
         rpcProvider: rpcProvider as unknown as StaticJsonRpcProvider,
         relayerClient: relayerClient as unknown as RelayerClient,
-        zkevmAddress: mockUserZkEvm.zkEvm.ethAddress,
+        zkEvmAddress: mockUserZkEvm.zkEvm.ethAddress,
         guardianClient: guardianClient as unknown as GuardianClient,
         flow: flow as unknown as Flow,
       });
@@ -131,7 +131,7 @@ describe('sendTransaction', () => {
         ethSigner,
         rpcProvider: rpcProvider as unknown as StaticJsonRpcProvider,
         relayerClient: relayerClient as unknown as RelayerClient,
-        zkevmAddress: mockUserZkEvm.zkEvm.ethAddress,
+        zkEvmAddress: mockUserZkEvm.zkEvm.ethAddress,
         guardianClient: guardianClient as unknown as GuardianClient,
         flow: flow as unknown as Flow,
       });
@@ -167,7 +167,7 @@ describe('sendTransaction', () => {
         ethSigner,
         rpcProvider: rpcProvider as unknown as StaticJsonRpcProvider,
         relayerClient: relayerClient as unknown as RelayerClient,
-        zkevmAddress: mockUserZkEvm.zkEvm.ethAddress,
+        zkEvmAddress: mockUserZkEvm.zkEvm.ethAddress,
         guardianClient: guardianClient as unknown as GuardianClient,
         flow: flow as unknown as Flow,
       });
@@ -217,7 +217,7 @@ describe('sendTransaction', () => {
           ethSigner,
           rpcProvider: rpcProvider as unknown as StaticJsonRpcProvider,
           relayerClient: relayerClient as unknown as RelayerClient,
-          zkevmAddress: mockUserZkEvm.zkEvm.ethAddress,
+          zkEvmAddress: mockUserZkEvm.zkEvm.ethAddress,
           guardianClient: guardianClient as unknown as GuardianClient,
           flow: flow as unknown as Flow,
         }),
@@ -245,7 +245,7 @@ describe('sendTransaction', () => {
           ethSigner,
           rpcProvider: rpcProvider as unknown as StaticJsonRpcProvider,
           relayerClient: relayerClient as unknown as RelayerClient,
-          zkevmAddress: mockUserZkEvm.zkEvm.ethAddress,
+          zkEvmAddress: mockUserZkEvm.zkEvm.ethAddress,
           guardianClient: guardianClient as unknown as GuardianClient,
           flow: flow as unknown as Flow,
         }),

--- a/packages/passport/sdk/src/zkEvm/sendTransaction.ts
+++ b/packages/passport/sdk/src/zkEvm/sendTransaction.ts
@@ -18,7 +18,7 @@ import GuardianClient, { convertBigNumberishToString } from '../guardian';
 const MAX_TRANSACTION_HASH_RETRIEVAL_RETRIES = 30;
 const TRANSACTION_HASH_RETRIEVAL_WAIT = 1000;
 
-export type EthSendTransactionParams = {
+type EthSendTransactionParams = {
   ethSigner: Signer;
   rpcProvider: StaticJsonRpcProvider;
   guardianClient: GuardianClient;

--- a/packages/passport/sdk/src/zkEvm/sendTransaction.ts
+++ b/packages/passport/sdk/src/zkEvm/sendTransaction.ts
@@ -23,7 +23,7 @@ export type EthSendTransactionParams = {
   rpcProvider: StaticJsonRpcProvider;
   guardianClient: GuardianClient;
   relayerClient: RelayerClient;
-  zkevmAddress: string,
+  zkEvmAddress: string,
   params: Array<any>;
   flow: Flow;
 };
@@ -99,7 +99,7 @@ export const sendTransaction = async ({
   rpcProvider,
   relayerClient,
   guardianClient,
-  zkevmAddress,
+  zkEvmAddress,
   flow,
 }: EthSendTransactionParams): Promise<string> => {
   const { chainId } = await rpcProvider.detectNetwork();
@@ -111,7 +111,7 @@ export const sendTransaction = async ({
     params[0],
     rpcProvider,
     relayerClient,
-    zkevmAddress,
+    zkEvmAddress,
   );
   flow.addEvent('endBuildMetaTransactions');
 
@@ -134,7 +134,7 @@ export const sendTransaction = async ({
     metaTransactions,
     nonce,
     chainIdBigNumber,
-    zkevmAddress,
+    zkEvmAddress,
     ethSigner,
   );
   getSignedMetaTransactionsPromise.then(() => flow.addEvent('endGetSignedMetaTransactions'));
@@ -144,7 +144,7 @@ export const sendTransaction = async ({
     getSignedMetaTransactionsPromise,
   ]);
 
-  const relayerId = await relayerClient.ethSendTransaction(zkevmAddress, signedTransactions);
+  const relayerId = await relayerClient.ethSendTransaction(zkEvmAddress, signedTransactions);
   flow.addEvent('endRelayerSendTransaction');
 
   const retrieveRelayerTransaction = async () => {

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
@@ -27,6 +27,7 @@ describe('ZkEvmProvider', () => {
   const ethSigner = {};
   const authManager = {
     getUserOrLogin: jest.fn().mockResolvedValue(mockUserZkEvm),
+    getUser: jest.fn().mockResolvedValue(mockUserZkEvm),
   };
   const magicAdapter = {
     login: jest.fn(),
@@ -63,7 +64,7 @@ describe('ZkEvmProvider', () => {
 
   describe('eth_requestAccounts', () => {
     it('should return the ethAddress if already logged in', async () => {
-      authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(mockUserZkEvm);
       const provider = getProvider();
 
       const resultOne = await provider.request({ method: 'eth_requestAccounts', params: [] });
@@ -71,8 +72,8 @@ describe('ZkEvmProvider', () => {
 
       expect(resultOne).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
       expect(resultTwo).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
-      expect(authManager.getUserOrLogin).toBeCalledTimes(1);
-      expect(identify).toHaveBeenCalledTimes(1);
+      expect(authManager.getUser).toBeCalledTimes(2);
+      expect(identify).toHaveBeenCalledTimes(0);
     });
 
     it('should emit accountsChanged event and identify user when user logs in', async () => {
@@ -93,6 +94,7 @@ describe('ZkEvmProvider', () => {
 
     it('should throw an error if the signer initialisation fails', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(mockUserZkEvm);
       (Web3Provider as unknown as jest.Mock).mockImplementation(() => ({
         getSigner: () => {
           throw new Error('Something went wrong');
@@ -128,6 +130,7 @@ describe('ZkEvmProvider', () => {
 
     it('should open a confirmation screen', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(mockUserZkEvm);
       const provider = getProvider();
       await provider.request({ method: 'eth_requestAccounts' });
       await provider.request({ method: 'eth_sendTransaction', params: [transaction] });
@@ -138,6 +141,7 @@ describe('ZkEvmProvider', () => {
     it('should call sendTransaction with the correct params', async () => {
       const transactionHash = '0x789';
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(mockUserZkEvm);
       (sendTransaction as jest.Mock).mockResolvedValue(transactionHash);
 
       const provider = getProvider();
@@ -177,6 +181,7 @@ describe('ZkEvmProvider', () => {
     it('should call eth_signTypedData_v4 with the correct params', async () => {
       const signature = '0x123';
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(mockUserZkEvm);
       (signTypedDataV4 as jest.Mock).mockResolvedValue(signature);
 
       const provider = getProvider();
@@ -200,6 +205,7 @@ describe('ZkEvmProvider', () => {
 
     it('should open a confirmation screen', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(mockUserZkEvm);
       const provider = getProvider();
       await provider.request({ method: 'eth_requestAccounts' });
       await provider.request({ method: 'eth_signTypedData_v4', params: [address, typedDataPayload] });

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
@@ -73,7 +73,6 @@ describe('ZkEvmProvider', () => {
       expect(resultOne).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
       expect(resultTwo).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
       expect(authManager.getUser).toBeCalledTimes(2);
-      expect(identify).toHaveBeenCalledTimes(0);
     });
 
     it('should emit accountsChanged event and identify user when user logs in', async () => {
@@ -95,6 +94,7 @@ describe('ZkEvmProvider', () => {
     it('should throw an error if the signer initialisation fails', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
       authManager.getUser.mockReturnValue(mockUserZkEvm);
+
       (Web3Provider as unknown as jest.Mock).mockImplementation(() => ({
         getSigner: () => {
           throw new Error('Something went wrong');
@@ -103,9 +103,7 @@ describe('ZkEvmProvider', () => {
       const provider = getProvider();
       await provider.request({ method: 'eth_requestAccounts' });
 
-      await expect(async () => (
-        provider.request({ method: 'eth_sendTransaction' })
-      )).rejects.toThrow(
+      await expect(provider.request({ method: 'eth_sendTransaction' })).rejects.toThrow(
         new JsonRpcError(RpcErrorCode.INTERNAL_ERROR, 'Something went wrong'),
       );
     });

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
@@ -161,7 +161,7 @@ describe('ZkEvmProvider', () => {
         ethSigner,
         rpcProvider: expect.any(Object),
         relayerClient: expect.any(RelayerClient),
-        zkevmAddress: mockUserZkEvm.zkEvm.ethAddress,
+        zkEvmAddress: mockUserZkEvm.zkEvm.ethAddress,
         flow: expect.any(Object),
       });
     });

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
@@ -63,6 +63,12 @@ describe('ZkEvmProvider', () => {
   };
 
   describe('eth_requestAccounts', () => {
+    it('constructor tries to automatically connect existing user session when provider is instantiated', async () => {
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+      getProvider();
+      expect(authManager.getUser).toHaveBeenCalledTimes(1);
+    });
+
     it('should return the ethAddress if already logged in', async () => {
       authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
       const provider = getProvider();

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.test.ts
@@ -64,7 +64,7 @@ describe('ZkEvmProvider', () => {
 
   describe('eth_requestAccounts', () => {
     it('should return the ethAddress if already logged in', async () => {
-      authManager.getUser.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
       const provider = getProvider();
 
       const resultOne = await provider.request({ method: 'eth_requestAccounts', params: [] });
@@ -72,10 +72,12 @@ describe('ZkEvmProvider', () => {
 
       expect(resultOne).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
       expect(resultTwo).toEqual([mockUserZkEvm.zkEvm.ethAddress]);
-      expect(authManager.getUser).toBeCalledTimes(2);
+      expect(authManager.getUser).toBeCalledTimes(3);
     });
 
     it('should emit accountsChanged event and identify user when user logs in', async () => {
+      authManager.getUser.mockReturnValue(Promise.resolve(null));
+
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
       const provider = getProvider();
       const onAccountsChanged = jest.fn();
@@ -93,7 +95,7 @@ describe('ZkEvmProvider', () => {
 
     it('should throw an error if the signer initialisation fails', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
-      authManager.getUser.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
 
       (Web3Provider as unknown as jest.Mock).mockImplementation(() => ({
         getSigner: () => {
@@ -117,6 +119,8 @@ describe('ZkEvmProvider', () => {
     };
 
     it('should throw an error if the user is not logged in', async () => {
+      authManager.getUser.mockReturnValue(Promise.resolve(null));
+
       const provider = getProvider();
 
       await expect(async () => (
@@ -128,7 +132,8 @@ describe('ZkEvmProvider', () => {
 
     it('should open a confirmation screen', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
-      authManager.getUser.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
       const provider = getProvider();
       await provider.request({ method: 'eth_requestAccounts' });
       await provider.request({ method: 'eth_sendTransaction', params: [transaction] });
@@ -139,7 +144,7 @@ describe('ZkEvmProvider', () => {
     it('should call sendTransaction with the correct params', async () => {
       const transactionHash = '0x789';
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
-      authManager.getUser.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
       (sendTransaction as jest.Mock).mockResolvedValue(transactionHash);
 
       const provider = getProvider();
@@ -167,6 +172,8 @@ describe('ZkEvmProvider', () => {
     const typedDataPayload = '{}';
 
     it('should throw an error if the user is not logged in', async () => {
+      authManager.getUser.mockReturnValue(Promise.resolve(null));
+
       const provider = getProvider();
 
       await expect(async () => (
@@ -179,7 +186,7 @@ describe('ZkEvmProvider', () => {
     it('should call eth_signTypedData_v4 with the correct params', async () => {
       const signature = '0x123';
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
-      authManager.getUser.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
       (signTypedDataV4 as jest.Mock).mockResolvedValue(signature);
 
       const provider = getProvider();
@@ -203,7 +210,7 @@ describe('ZkEvmProvider', () => {
 
     it('should open a confirmation screen', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
-      authManager.getUser.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
       const provider = getProvider();
       await provider.request({ method: 'eth_requestAccounts' });
       await provider.request({ method: 'eth_signTypedData_v4', params: [address, typedDataPayload] });
@@ -214,6 +221,8 @@ describe('ZkEvmProvider', () => {
 
   describe('isPassport', () => {
     it('should be set to true', () => {
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
       const provider = getProvider();
 
       expect(provider.isPassport).toBe(true);
@@ -226,6 +235,7 @@ describe('ZkEvmProvider', () => {
 
     describe('and eth_sendTransaction is called', () => {
       it('throws an unauthorized error', async () => {
+        authManager.getUser.mockReturnValue(Promise.resolve(null));
         authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
 
         const provider = getProvider();
@@ -241,6 +251,7 @@ describe('ZkEvmProvider', () => {
     describe('and eth_signTypedDataV4 is called', () => {
       it('throws an unauthorized error', async () => {
         authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+        authManager.getUser.mockReturnValue(Promise.resolve(null));
 
         const provider = getProvider();
         await provider.request({ method: 'eth_requestAccounts' });
@@ -255,6 +266,7 @@ describe('ZkEvmProvider', () => {
     describe('and eth_accounts is called', () => {
       it('returns an empty array', async () => {
         authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+        authManager.getUser.mockReturnValue(Promise.resolve(null));
 
         const provider = getProvider();
         await provider.request({ method: 'eth_requestAccounts' });
@@ -267,6 +279,8 @@ describe('ZkEvmProvider', () => {
 
     it('should emit accountsChanged', async () => {
       authManager.getUserOrLogin.mockReturnValue(mockUserZkEvm);
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
       const provider = getProvider();
       await provider.request({ method: 'eth_requestAccounts' });
 
@@ -293,6 +307,8 @@ describe('ZkEvmProvider', () => {
     });
 
     it('should call detectNetwork', async () => {
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
       detectNetworkMock.mockResolvedValueOnce({ chainId });
 
       const provider = getProvider();
@@ -454,6 +470,8 @@ describe('ZkEvmProvider', () => {
     });
 
     it.each(passthroughMethods)('should passthrough %s to the rpcProvider', async ({ requestArgument, returnValue }) => {
+      authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
       sendMock.mockResolvedValueOnce(returnValue);
 
       const provider = getProvider();
@@ -470,6 +488,8 @@ describe('ZkEvmProvider', () => {
 
     describe('eth_getBalance', () => {
       it('defaults the `blockNumber` argument to `latest` if not provided', async () => {
+        authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
         const provider = getProvider();
         await provider.request({ method: 'eth_getBalance', params: ['0x1'] });
 
@@ -479,6 +499,8 @@ describe('ZkEvmProvider', () => {
 
     describe('eth_getCode', () => {
       it('defaults the `blockNumber` argument to `latest` if not provided', async () => {
+        authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
         const provider = getProvider();
         await provider.request({ method: 'eth_getCode', params: ['0x1'] });
 
@@ -488,6 +510,8 @@ describe('ZkEvmProvider', () => {
 
     describe('eth_getTransactionCount', () => {
       it('defaults the `blockNumber` argument to `latest` if not provided', async () => {
+        authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
         const provider = getProvider();
         await provider.request({ method: 'eth_getTransactionCount', params: ['0x1'] });
 
@@ -497,6 +521,8 @@ describe('ZkEvmProvider', () => {
 
     describe('eth_getStorageAt', () => {
       it('defaults the `blockNumber` argument to `latest` if not provided', async () => {
+        authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
         const provider = getProvider();
         await provider.request({ method: 'eth_getStorageAt', params: ['0x1', '0x2'] });
 
@@ -506,6 +532,8 @@ describe('ZkEvmProvider', () => {
 
     describe('eth_call', () => {
       it('defaults the `blockNumber` argument to `latest` if not provided', async () => {
+        authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
         const provider = getProvider();
         await provider.request({ method: 'eth_call', params: [{ to: '0x1' }] });
 
@@ -515,6 +543,8 @@ describe('ZkEvmProvider', () => {
 
     describe('eth_estimateGas', () => {
       it('defaults the `blockNumber` argument to `latest` if not provided', async () => {
+        authManager.getUser.mockReturnValue(Promise.resolve(mockUserZkEvm));
+
         const provider = getProvider();
         await provider.request({ method: 'eth_estimateGas', params: [{ to: '0x1' }] });
 

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
@@ -137,23 +137,24 @@ export class ZkEvmProvider implements Provider {
    *
    */
   #initialiseEthSigner(user: User) {
+    const generateSigner = async (): Promise<Signer> => {
+      const magicRpcProvider = await this.#magicAdapter.login(user.idToken!);
+      const web3Provider = new Web3Provider(magicRpcProvider);
+
+      return web3Provider.getSigner();
+    };
+
     this.#signerInitialisationError = undefined;
     // eslint-disable-next-line no-async-promise-executor
     this.#ethSigner = new Promise(async (resolve) => {
       try {
-        resolve(await this.#getSignerFromUser(user));
+        resolve(await generateSigner());
       } catch (err) {
         // Capture and store the initialization error
         this.#signerInitialisationError = err;
         resolve(undefined);
       }
     });
-  }
-
-  async #getSignerFromUser(user: User): Promise<Signer> {
-    const magicRpcProvider = await this.#magicAdapter.login(user.idToken!);
-    const web3Provider = new Web3Provider(magicRpcProvider);
-    return web3Provider.getSigner();
   }
 
   async #getSigner(): Promise<Signer> {

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
@@ -121,6 +121,7 @@ export class ZkEvmProvider implements Provider {
       // User does not exist, don't initialise an eth signer
     });
 
+    passportEventEmitter.on(PassportEvents.LOGGED_IN, this.#initialiseEthSignerOnLogin);
     passportEventEmitter.on(PassportEvents.LOGGED_OUT, this.#handleLogout);
     passportEventEmitter.on(
       PassportEvents.ACCOUNTS_REQUESTED,
@@ -131,6 +132,10 @@ export class ZkEvmProvider implements Provider {
   #handleLogout = () => {
     this.#ethSigner = undefined;
     this.#providerEventEmitter.emit(ProviderEvent.ACCOUNTS_CHANGED, []);
+  };
+
+  #initialiseEthSignerOnLogin = (user: User) => {
+    if (isZkEvmUser(user)) this.#initialiseEthSigner(user);
   };
 
   /**

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
@@ -195,7 +195,7 @@ export class ZkEvmProvider implements Provider {
     try {
       const user = await this.#authManager.getUser();
       if (user && isZkEvmUser(user)) {
-        this.#ethSigner = this.#getSignerFromUser(user);
+        this.#initialiseEthSigner(user);
         return user.zkEvm.ethAddress;
       }
       return undefined;

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
@@ -188,7 +188,7 @@ export class ZkEvmProvider implements Provider {
         guardianClient: this.#guardianClient,
         rpcProvider: this.#rpcProvider,
         relayerClient: this.#relayerClient,
-        zkevmAddress: zkEvmAddress,
+        zkEvmAddress,
         flow,
       });
     };
@@ -299,7 +299,7 @@ export class ZkEvmProvider implements Provider {
               guardianClient: this.#guardianClient,
               rpcProvider: this.#rpcProvider,
               relayerClient: this.#relayerClient,
-              zkevmAddress: zkEvmAddress,
+              zkEvmAddress,
               flow,
             });
           });

--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
@@ -121,7 +121,7 @@ export class ZkEvmProvider implements Provider {
       // User does not exist, don't initialise an eth signer
     });
 
-    passportEventEmitter.on(PassportEvents.LOGGED_IN, this.#initialiseEthSignerOnLogin);
+    passportEventEmitter.on(PassportEvents.LOGGED_IN, (user: User) => this.#initialiseEthSigner(user));
     passportEventEmitter.on(PassportEvents.LOGGED_OUT, this.#handleLogout);
     passportEventEmitter.on(
       PassportEvents.ACCOUNTS_REQUESTED,
@@ -132,10 +132,6 @@ export class ZkEvmProvider implements Provider {
   #handleLogout = () => {
     this.#ethSigner = undefined;
     this.#providerEventEmitter.emit(ProviderEvent.ACCOUNTS_CHANGED, []);
-  };
-
-  #initialiseEthSignerOnLogin = (user: User) => {
-    if (isZkEvmUser(user)) this.#initialiseEthSigner(user);
   };
 
   /**


### PR DESCRIPTION
# Summary
This PR:
- [Passport zkEVM provider automatically connects to dApp if a valid user session exists](https://immutable.atlassian.net/browse/ID-1770); and
- [Manages state around token expiration better by checking user session and if not exists, forcing a login.](https://immutable.atlassian.net/browse/ID-1769)

# Detail and impact of the change
Main changes:
- We're _always_ emitting the accountsChanged event when the Logout button is pressed; decoupling it from the class attribute
- For every request, we are preemptively trying to get their zkEvm address from their User session. If the User doesn't exist, then they will be prompted to login for `eth_requestAccounts` requests and for all other requests, throw an error for the dApp to nudge them to `eth_requestAccounts` first. This handles cases where a Users session is expired, or refresh token is expired, which will prompt them to login.
- When a User logs in, we are emitting an event and consuming by the zkEvmProvider to initialise the ethSigner for that user, to handle backwards compatibility.

## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
