### PR TITLE
fix: allow use of localstorage to be optional in metrics

### DIFF
--- a/packages/game-bridge/src/index.ts
+++ b/packages/game-bridge/src/index.ts
@@ -2,7 +2,7 @@
 import * as passport from '@imtbl/passport';
 import * as config from '@imtbl/config';
 import * as provider from '@imtbl/x-provider';
-import { track, identify } from '@imtbl/metrics';
+import { track, identify, utils as metricsUtils } from '@imtbl/metrics';
 import { providers } from 'ethers';
 
 /* eslint-disable no-undef */
@@ -16,6 +16,8 @@ const keyData = 'data';
 
 const trackFunction = 'track';
 const moduleName = 'gameBridge';
+
+metricsUtils.useLocalStorage(false);
 
 // version check placeholders
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/internal/metrics/src/index.ts
+++ b/packages/internal/metrics/src/index.ts
@@ -1,5 +1,6 @@
 // Exporting utils
 import * as localStorage from './utils/localStorage';
+import { useLocalStorage } from './utils/state';
 
 export { track } from './track';
 export { trackDuration } from './performance';
@@ -15,4 +16,5 @@ export {
 } from './details';
 export const utils = {
   localStorage,
+  useLocalStorage,
 };

--- a/packages/internal/metrics/src/initialise.ts
+++ b/packages/internal/metrics/src/initialise.ts
@@ -101,7 +101,9 @@ export const initialise = async () => {
 
     // Get runtimeId and store it
     const { runtimeId, sTime } = response;
-    storeDetail(Detail.RUNTIME_ID, runtimeId);
+    if (!existingRuntimeId) {
+      storeDetail(Detail.RUNTIME_ID, runtimeId);
+    }
     setClockSkew(sTime);
   } catch (error) {
     initialised = false;

--- a/packages/internal/metrics/src/utils/globalise.ts
+++ b/packages/internal/metrics/src/utils/globalise.ts
@@ -2,7 +2,7 @@ import { memorise } from 'lru-memorise';
 import { getGlobalisedValue as globalise } from 'global-const';
 
 const GLOBALISE_KEY = 'imtbl__metrics';
-const MEMORISE_TIMEFRAME = 5000;
+const MEMORISE_TIMEFRAME = 1000;
 const MEMORISE_MAX = 1000;
 
 export const getGlobalisedValue = <T>(key: string, value: T): T => globalise<T>(GLOBALISE_KEY, key, value);

--- a/packages/internal/metrics/src/utils/globalise.ts
+++ b/packages/internal/metrics/src/utils/globalise.ts
@@ -13,7 +13,7 @@ export const getGlobalisedCachedFunction = <T extends (...args: any[]) => any>(
 ): T => {
   // Some applications (esp backend, or frontends using the split bundles) can sometimes
   // initialise the same request multiple times. This will prevent multiple of the
-  // same event,value from being reported in a 1 second period.
+  // same event,values from being reported in a 1 second period.
   const memorisedFn = memorise(fn, {
     lruOptions: { ttl: MEMORISE_TIMEFRAME, max: MEMORISE_MAX },
   }) as unknown as T;


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Allows the use of localstorage to be optional, some environments (e.g. game bridge) doesn't have robust local storage implementations, so disable it for those environments.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
