### PR TITLE
feat: Sale widget - advanced topup options link to Squid

### DIFF
--- a/packages/checkout/widgets-lib/src/views/top-up/TopUpView.tsx
+++ b/packages/checkout/widgets-lib/src/views/top-up/TopUpView.tsx
@@ -272,7 +272,7 @@ export function TopUpView({
 
     localTrack('AdvancedOptions', { ...data, widgetEvent });
 
-    window.open(`${toolkitBaseUrl}/faster-bridge/`, '_blank');
+    window.open(`${toolkitBaseUrl}/squid-bridge/`, '_blank');
   };
 
   const renderFees = (txt: string): ReactNode => (


### PR DESCRIPTION
# Summary
In the Checkout widgets, when a user has insufficient funds, we present a list of options to the user to choose how to fund their wallet.

Currently, we link to the Layerswap Bridge in Toolkit. This PR changes the link to go to the Squid Bridge in Toolkit.

https://immutable.atlassian.net/browse/CM-771
