### PR TITLE
[DX-3013] feat: passport indexed db storage for unity sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "scripts": {
     "build": "yarn workspace @imtbl/sdk updateDependencies && NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk,@imtbl/checkout-widgets && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
     "build:onlysdk": "NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk && yarn syncpack:format",
+    "dev": "./dev.sh",
     "docs:build": "typedoc",
     "docs:serve": "http-server ./docs --cors -p 8080 -c-1",
     "lint": "wsrun --exclude-missing -e lint --no-error-on-unmatched-pattern",
@@ -64,8 +65,7 @@
     "test:checkout:sdk:coverage": "wsrun -p @imtbl/checkout-sdk --exclude-missing -e test:coverage",
     "test:examples": "cd examples/ts-immutable-sample && yarn test && yarn test:e2e",
     "test:vpn": "RUN_VPN_TESTS=1 wsrun --exclude-missing -e test",
-    "typecheck": "wsrun --exclude-missing typecheck",
-    "dev": "./dev.sh"
+    "typecheck": "wsrun --exclude-missing typecheck"
   },
   "workspaces": {
     "packages": [

--- a/packages/passport/sdk/package.json
+++ b/packages/passport/sdk/package.json
@@ -21,6 +21,7 @@
     "ethers": "^5.7.2",
     "events": "^3.3.0",
     "jwt-decode": "^3.1.2",
+    "localforage": "^1.10.0",
     "magic-sdk": "^21.2.0",
     "oidc-client-ts": "2.4.0",
     "uuid": "^8.3.2"

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -11,6 +11,7 @@ import axios from 'axios';
 import * as crypto from 'crypto';
 import jwt_decode from 'jwt-decode';
 import { getDetail, Detail } from '@imtbl/metrics';
+import localForage from 'localforage';
 import DeviceCredentialsManager from './storage/device_credentials_manager';
 import logger from './utils/logger';
 import { isTokenExpired } from './utils/token';
@@ -31,6 +32,7 @@ import {
 } from './types';
 import { PassportConfiguration } from './config';
 import Overlay from './overlay';
+import { LocalForageAsyncStorage } from './storage/LocalForageAsyncStorage';
 
 const formUrlEncodedHeader = {
   headers: {
@@ -44,7 +46,14 @@ const authorizeEndpoint = '/authorize';
 const getAuthConfiguration = (config: PassportConfiguration): UserManagerSettings => {
   const { authenticationDomain, oidcConfiguration } = config;
 
-  const store = typeof window !== 'undefined' ? window.localStorage : new InMemoryWebStorage();
+  let store;
+  if (config.crossSdkBridgeEnabled) {
+    store = new LocalForageAsyncStorage('ImmutableSDKPassport', localForage.INDEXEDDB);
+  } else if (typeof window !== 'undefined') {
+    store = window.localStorage;
+  } else {
+    store = new InMemoryWebStorage();
+  }
   const userStore = new WebStorageStateStore({ store });
 
   const endSessionEndpoint = new URL(logoutEndpoint, authenticationDomain.replace(/^(?:https?:\/\/)?(.*)/, 'https://$1'));

--- a/packages/passport/sdk/src/storage/LocalForageAsyncStorage.ts
+++ b/packages/passport/sdk/src/storage/LocalForageAsyncStorage.ts
@@ -1,0 +1,34 @@
+import { AsyncStorage } from 'oidc-client-ts';
+import localForage from 'localforage';
+
+export class LocalForageAsyncStorage implements AsyncStorage {
+  private storage: LocalForage;
+
+  constructor(name: string, driver: string | string[]) {
+    this.storage = localForage.createInstance({ name, driver });
+  }
+
+  get length(): Promise<number> {
+    return this.storage.length();
+  }
+
+  clear(): Promise<void> {
+    return this.storage.clear();
+  }
+
+  getItem(key: string): Promise<string | null> {
+    return this.storage.getItem<string>(key);
+  }
+
+  key(index: number): Promise<string | null> {
+    return this.storage.key(index);
+  }
+
+  async removeItem(key: string): Promise<void> {
+    await this.storage.removeItem(key);
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    await this.storage.setItem(key, value);
+  }
+}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -44,6 +44,7 @@
     "i18next": "^23.7.6",
     "i18next-browser-languagedetector": "^7.2.0",
     "jwt-decode": "^3.1.2",
+    "localforage": "^1.10.0",
     "lru-memorise": "0.3.0",
     "magic-sdk": "^21.2.0",
     "merkletreejs": "^0.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2250,7 +2250,6 @@ __metadata:
     "@biom3/design-tokens": ~0.4.0
     buffer: ^6.0.3
     csstype: ^3.1.2
-    localforage: ^1.10.0
     lodash.debounce: ^4.0.8
     lodash.get: ^4.4.2
     lodash.isequal: ^4.5.0
@@ -3833,6 +3832,7 @@ __metadata:
     jest-environment-jsdom: ^29.4.3
     jwt-decode: ^3.1.2
     jwt-encode: ^1.0.1
+    localforage: ^1.10.0
     magic-sdk: ^21.2.0
     msw: ^1.2.2
     oidc-client-ts: 2.4.0
@@ -3923,6 +3923,7 @@ __metadata:
     i18next: ^23.7.6
     i18next-browser-languagedetector: ^7.2.0
     jwt-decode: ^3.1.2
+    localforage: ^1.10.0
     lru-memorise: 0.3.0
     magic-sdk: ^21.2.0
     merkletreejs: ^0.3.11


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
The device code authentication works well on Android, iOS, and Mac, but the Unity SDK encounters issues on Windows. After logging in, the user's OIDC data stored in localStorage often disappears when reopening the game. This happens because Windows initially stores localStorage items in memory, unlike IndexedDB, which writes directly to disk. Upon looking at the Chromium source code for version 122.0.6261.130, local storage items only get committed after every [5 seconds](https://source.chromium.org/chromium/chromium/src/+/refs/tags/122.0.6261.130:components/services/storage/dom_storage/local_storage_impl.cc;drc=81b3c99740a33d3ed7cf86781031637417c3aa38;l=154). Additionally, this [line](https://source.chromium.org/chromium/chromium/src/+/main:components/services/storage/dom_storage/local_storage_impl.cc;l=194;drc=fa1e0cf5238e2600039f60af6909aefbd4cf003c) is also the other cause of the issue because the metrics package was using local storage a lot.

To ensure better compatibility with game engines, this PR updates game SDKs to use IndexedDB instead of local storage for storing OIDC data.
