### PR TITLE
feat: Add settlementType to Segment events

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/events/sale.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/events/sale.ts
@@ -1,3 +1,4 @@
+import { FundingBalance } from '@imtbl/checkout-widgets/src/widgets/sale/types';
 import { TokenInfo } from '../../../types';
 
 /**
@@ -88,6 +89,7 @@ export type SalePaymentMethod = {
  */
 export type SalePaymentToken = {
   /** Chosen payment token */
+  settlementType: FundingBalance['type'];
   type: string;
   token: TokenInfo;
   amount: string;

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/OrderReview.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/OrderReview.tsx
@@ -85,10 +85,9 @@ export function OrderReview({
   const onSelect = (selectedIndex: number) => {
     setSelectedCurrencyIndex(selectedIndex);
 
-    const { fundingItem } = fundingBalances[selectedIndex];
     sendSelectedPaymentToken(
       OrderSummarySubViews.REVIEW_ORDER,
-      fundingItem,
+      fundingBalances[selectedIndex],
       conversions,
     );
     // checkoutPrimarySalePaymentTokenSelected
@@ -134,7 +133,7 @@ export function OrderReview({
   // Trigger page loaded event
   useMount(
     () => {
-      const tokens = fundingBalances.map(({ fundingItem }) => getPaymentTokenDetails(fundingItem, conversions));
+      const tokens = fundingBalances.map((fb) => getPaymentTokenDetails(fb, conversions));
       sendPageView(SaleWidgetViews.ORDER_SUMMARY, {
         subView: OrderSummarySubViews.REVIEW_ORDER,
         tokens,

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { StandardAnalyticsActions } from '@imtbl/react-analytics';
-import { FundingItem, SalePaymentTypes } from '@imtbl/checkout-sdk';
+import { SalePaymentTypes } from '@imtbl/checkout-sdk';
 import {
   UserJourney,
   useAnalytics,
@@ -16,7 +16,7 @@ import {
   sendSalePaymentTokenEvent,
 } from '../SaleWidgetEvents';
 import { SaleWidgetViews } from '../../../context/view-context/SaleViewContextTypes';
-import { ExecutedTransaction } from '../types';
+import { ExecutedTransaction, FundingBalance } from '../types';
 import { useSaleContext } from '../context/SaleContextProvider';
 import { toPascalCase, toStringifyTransactions } from '../functions/utils';
 import { getPaymentTokenDetails } from '../utils/analytics';
@@ -148,10 +148,10 @@ export const useSaleEvent = () => {
 
   const sendSelectedPaymentToken = (
     screen: string,
-    fundingItem: FundingItem,
+    fundingBalance: FundingBalance,
     conversions: Map<string, number>,
   ) => {
-    const details = getPaymentTokenDetails(fundingItem, conversions);
+    const details = getPaymentTokenDetails(fundingBalance, conversions);
     track({
       ...commonProps,
       screen: toPascalCase(screen),
@@ -190,7 +190,7 @@ export const useSaleEvent = () => {
 
   const sendProceedToPay = (
     screen: string,
-    fundingItem: FundingItem,
+    fundingBalance: FundingBalance,
     conversions: Map<string, number>,
     controlType: AnalyticsControlTypes = 'Button',
     action: StandardAnalyticsActions = 'Pressed',
@@ -203,7 +203,7 @@ export const useSaleEvent = () => {
       action,
       extras: {
         ...userProps,
-        ...getPaymentTokenDetails(fundingItem, conversions),
+        ...getPaymentTokenDetails(fundingBalance, conversions),
       },
     });
   };

--- a/packages/checkout/widgets-lib/src/widgets/sale/utils/analytics.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/utils/analytics.ts
@@ -1,25 +1,30 @@
-import { FundingItem, SalePaymentToken } from '@imtbl/checkout-sdk';
+import { SalePaymentToken } from '@imtbl/checkout-sdk';
 import { calculateCryptoToFiat } from '../../../lib/utils';
+import { FundingBalance } from '../types';
 
 export const getPaymentTokenDetails = (
-  fundingItem: FundingItem,
+  fundingBalance: FundingBalance,
   conversions: Map<string, number>,
-): SalePaymentToken => ({
-  type: fundingItem.type,
-  token: fundingItem.token,
-  amount: fundingItem.fundsRequired.formattedAmount,
-  balance: fundingItem.userBalance.formattedBalance,
-  fiat: {
-    symbol: 'USD',
-    balance: calculateCryptoToFiat(
-      fundingItem.userBalance.formattedBalance,
-      fundingItem.token.symbol,
-      conversions,
-    ),
-    amount: calculateCryptoToFiat(
-      fundingItem.fundsRequired.formattedAmount,
-      fundingItem.token.symbol,
-      conversions,
-    ),
-  },
-});
+): SalePaymentToken => {
+  const { fundingItem } = fundingBalance;
+  return ({
+    settlementType: fundingBalance.type,
+    type: fundingItem.type,
+    token: fundingItem.token,
+    amount: fundingItem.fundsRequired.formattedAmount,
+    balance: fundingItem.userBalance.formattedBalance,
+    fiat: {
+      symbol: 'USD',
+      balance: calculateCryptoToFiat(
+        fundingItem.userBalance.formattedBalance,
+        fundingItem.token.symbol,
+        conversions,
+      ),
+      amount: calculateCryptoToFiat(
+        fundingItem.fundsRequired.formattedAmount,
+        fundingItem.token.symbol,
+        conversions,
+      ),
+    },
+  });
+};

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -95,7 +95,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
 
     sendProceedToPay(
       SaleWidgetViews.ORDER_SUMMARY,
-      fundingItem,
+      fundingBalance,
       cryptoFiatState.conversions,
     );
     // checkoutPrimarySaleProceedToPay


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Add the settlementType of SUFFICIENT or SWAP into the Segment events for ProceedToPay in the Checkout Sales Widget

https://immutable.atlassian.net/browse/CM-775
