### PR TITLE
fix: DX-3055 deal with browser bundle

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -109,6 +109,9 @@ jobs:
       - name: Test
         run: yarn test
 
+      - name: copy browser bundle
+        run: yarn copyBrowserBundles
+
       - name: Push tags
         # Boolean inputs are not actually booleans, see https://github.com/actions/runner/issues/1483
         if: (env.DRY_RUN) == 'false'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -92,25 +92,23 @@ jobs:
         run: |
           echo "NEXT_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
 
-      - name: Update package.json version for build
-        run: |
-          tmp=$(mktemp)
-          jq '.version = "${{steps.version.outputs.NEXT_VERSION}}"' ./sdk/package.json > "$tmp" && mv "$tmp" ./sdk/package.json
-
-      - name: Build
-        run: |
-          export NODE_OPTIONS=--max-old-space-size=6144 && RELEASE_TYPE=${{ env.RELEASE_TYPE }} yarn build
-          ls -l ./sdk/dist/browser/checkout || echo 1
-          [ -d "./sdk/dist/browser/checkout" ] || { echo "Error: Directory does not exist." && exit 1; }
-
       - name: Typecheck
         run: yarn typecheck
 
       - name: Test
         run: yarn test
 
-      - name: copy browser bundle
-        run: yarn copyBrowserBundles
+      - name: Update package.json version for build
+        run: |
+          tmp=$(mktemp)
+          jq '.version = "${{steps.version.outputs.NEXT_VERSION}}"' ./sdk/package.json > "$tmp" && mv "$tmp" ./sdk/package.json
+
+      # WARNING: build step should be after typecheck and test steps. This is to make sure build artifacts are overwritten by the lint and tests steps.
+      - name: Build
+        run: |
+          export NODE_OPTIONS=--max-old-space-size=6144 && RELEASE_TYPE=${{ env.RELEASE_TYPE }} yarn build
+          ls -l ./sdk/dist/browser/checkout || echo 1
+          [ -d "./sdk/dist/browser/checkout" ] || { echo "Error: Directory does not exist." && exit 1; }
 
       - name: Push tags
         # Boolean inputs are not actually booleans, see https://github.com/actions/runner/issues/1483

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "responselike": "^2.0.0"
   },
   "scripts": {
-    "build": "yarn workspace @imtbl/sdk updateDependencies && NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk --skip-nx-cache && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
+    "build": "yarn workspace @imtbl/sdk updateDependencies && NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
+    "copyBrowserBundles": "yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
     "build:examples": "yarn workspaces foreach -Apt --include='@examples/**' run build",
     "build:onlysdk": "NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk && yarn syncpack:format",
     "dev": "./dev.sh",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "scripts": {
     "build": "yarn workspace @imtbl/sdk updateDependencies && NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
-    "copyBrowserBundles": "yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
     "build:examples": "yarn workspaces foreach -Apt --include='@examples/**' run build",
     "build:onlysdk": "NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk && yarn syncpack:format",
     "dev": "./dev.sh",


### PR DESCRIPTION
# Summary
Put in a temp fix for browser bundling copying logic so that when running test and typecheck during publish, the copied bundle will not be deleted.

A proper fix is coming to include the bundling logic inside nx target.
