### PR TITLE
fix: make copyBrowserBundle part of nx target

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "responselike": "^2.0.0"
   },
   "scripts": {
-    "build": "yarn workspace @imtbl/sdk updateDependencies && NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk && yarn syncpack:format && yarn wsrun -p @imtbl/sdk -a -m copyBrowserBundles",
+    "build": "nx run @imtbl/sdk:build",
     "build:examples": "yarn workspaces foreach -Apt --include='@examples/**' run build",
     "build:onlysdk": "NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk && yarn syncpack:format",
     "dev": "./dev.sh",

--- a/packages/game-bridge/package.json
+++ b/packages/game-bridge/package.json
@@ -14,8 +14,8 @@
     "parcel": "^2.8.3"
   },
   "scripts": {
-    "d": "swc src -d dist --strip-leading-paths --ignore '**/*.test.*'",
     "build": "parcel build --no-cache --no-scope-hoist && yarn updateSdkVersion",
+    "d": "swc src -d dist --strip-leading-paths --ignore '**/*.test.*'",
     "lint": "eslint ./src --ext .ts,.jsx,.tsx --max-warnings=0",
     "start": "parcel",
     "updateSdkVersion": "./scripts/updateSdkVersion.sh"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -155,7 +155,7 @@
     "@openzeppelin/contracts": "3.4.2-solc-0.7"
   },
   "scripts": {
-    "build": "yarn updateDependencies && yarn regenModules && rm -rf dist && NODE_ENV=production node --max-old-space-size=14366 ../node_modules/rollup/dist/bin/rollup --config rollup.config.js && rm -rf dist/types && yarn syncpack:format && yarn copyBrowserBundles",
+    "build": "yarn updateDependencies && yarn regenModules && rm -rf dist && NODE_ENV=production node --max-old-space-size=14366 ../node_modules/rollup/dist/bin/rollup --config rollup.config.js && rm -rf dist/types && yarn copyBrowserBundles",
     "build:only": "rm -rf dist && NODE_ENV=production node --max-old-space-size=8192 ../node_modules/rollup/dist/bin/rollup --config rollup.config.js && rm -rf dist/types",
     "copyBrowserBundles": "node scripts/copyBrowserBundles.js",
     "generateIndex": "node scripts/generateIndex.js",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -155,7 +155,7 @@
     "@openzeppelin/contracts": "3.4.2-solc-0.7"
   },
   "scripts": {
-    "build": "yarn updateDependencies && yarn regenModules && rm -rf dist && NODE_ENV=production node --max-old-space-size=8192 ../node_modules/rollup/dist/bin/rollup --config rollup.config.js && rm -rf dist/types",
+    "build": "yarn updateDependencies && yarn regenModules && rm -rf dist && NODE_ENV=production node --max-old-space-size=14366 ../node_modules/rollup/dist/bin/rollup --config rollup.config.js && rm -rf dist/types && yarn syncpack:format && yarn copyBrowserBundles",
     "build:only": "rm -rf dist && NODE_ENV=production node --max-old-space-size=8192 ../node_modules/rollup/dist/bin/rollup --config rollup.config.js && rm -rf dist/types",
     "copyBrowserBundles": "node scripts/copyBrowserBundles.js",
     "generateIndex": "node scripts/generateIndex.js",


### PR DESCRIPTION
# Summary
Make copyBrowserBundle part of sdk's nx build target. So all contains under sdk/dist folder will be part of nx cache.

# Detail and impact of the change

## Changed
Move all scripts under root build script to sdk's build script
