### PR TITLE
fix: Publish SDK reference docs workflow 

### DIFF
--- a/.github/scripts/update-docs-link.sh
+++ b/.github/scripts/update-docs-link.sh
@@ -40,8 +40,8 @@ fi
   echo "major: $major minor: $minor patch: $patch"
   # Update versions in the browserBundle docs (https://docs.immutable.com/docs/x/sdks/typescript/#browser-bundle)
   FILES=(
-    docs/main/zkEVM/sdks/typescript/_zkevmtypescript.mdx
-    docs/main/sdks/typescript/_starkextypescript.mdx
+    docs/main/sdks/zkEVM/typescript/_zkevmtypescript.mdx
+    docs/main/x/sdks/typescript/_starkextypescript.mdx
   )
   for FILE in "${FILES[@]}"
   do


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Fix links to the SDK docs in the update links script.

# Detail and impact of the change
New versions of the SDK should have the TS SDK reference docs published correctly.


## Fixed
- Publish SDK reference docs workflow 


# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
