### PR TITLE
fix: add missing dep to passport sample app

### DIFF
--- a/packages/passport/sdk-sample-app/package.json
+++ b/packages/passport/sdk-sample-app/package.json
@@ -5,6 +5,7 @@
     "@biom3/design-tokens": "^0.4.2",
     "@biom3/react": "^0.25.0",
     "@imtbl/config": "0.0.0",
+    "@imtbl/orderbook": "0.0.0",
     "@imtbl/passport": "0.0.0",
     "@imtbl/x-client": "0.0.0",
     "@imtbl/x-provider": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4640,6 +4640,7 @@ __metadata:
     "@biom3/design-tokens": ^0.4.2
     "@biom3/react": ^0.25.0
     "@imtbl/config": 0.0.0
+    "@imtbl/orderbook": 0.0.0
     "@imtbl/passport": 0.0.0
     "@imtbl/x-client": 0.0.0
     "@imtbl/x-provider": 0.0.0


### PR DESCRIPTION
# Summary
Passport sample app imports @imtbl/orderbook but it's not in the package.json
