### PR TITLE
fix: add missing dep to passport sample app

### DIFF
--- a/packages/passport/sdk-sample-app/package.json
+++ b/packages/passport/sdk-sample-app/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@biom3/design-tokens": "^0.4.2",
     "@biom3/react": "^0.25.0",
+    "@imtbl/blockchain-data": "0.0.0",
     "@imtbl/config": "0.0.0",
     "@imtbl/orderbook": "0.0.0",
     "@imtbl/passport": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4639,6 +4639,7 @@ __metadata:
   dependencies:
     "@biom3/design-tokens": ^0.4.2
     "@biom3/react": ^0.25.0
+    "@imtbl/blockchain-data": 0.0.0
     "@imtbl/config": 0.0.0
     "@imtbl/orderbook": 0.0.0
     "@imtbl/passport": 0.0.0


### PR DESCRIPTION
# Summary
Adding missing dependencies
