### PR TITLE
fix: SDK reference docs workflow

### DIFF
--- a/.github/scripts/check-docs-deployed.sh
+++ b/.github/scripts/check-docs-deployed.sh
@@ -11,7 +11,7 @@ fi
 
 # this command will send a GET request to the docs site, the -s option silences the output,
 # the -o option redirects the output to /dev/null, and the -w option formats the output to only return the HTTP status code
-HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://docs.immutable.com/sdk-references/ts-immutable-sdk/$VERSION/modules/_imtbl_sdk.html)
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://docs.immutable.com/sdk-references/ts-immutable-sdk/$VERSION/)
 
 if [ "$HTTP_STATUS" -ne 200 ]; then
   echo "SDK reference docs for v$VERSION are not deployed. Check Netlify for the build status. https://app.netlify.com/sites/imx-docs-prod/deploys"

--- a/.github/scripts/check-docs-version.sh
+++ b/.github/scripts/check-docs-version.sh
@@ -20,9 +20,3 @@ if [ -d "$CLONE_DIR/api-docs/sdk-references/ts-immutable-sdk/$VERSION" ]; then
   echo "There is already a docs folder for v$VERSION. Please create a separate PR to update the SDK reference docs for v$VERSION."
   exit 1
 fi
-
-# check the version contains `alpha` string
-if echo "$VERSION" | grep -q "alpha"; then
-  echo "Skipping docs generation for alpha version"
-  exit 1
-fi

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -7,9 +7,34 @@ on:
       - completed
 
 jobs:
+  AlphaCheck:
+    name: Check if SDK version is alpha
+    runs-on: ubuntu-latest
+    outputs:
+      is_alpha: ${{ steps.alpha_check.outputs.is_alpha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check alpha version
+        id: alpha_check
+        run: |
+          if $(git describe --tags --abbrev=0) | grep -q "alpha"; then
+            echo "Skipping docs generation for alpha version"
+            echo "is_alpha=true" >> $GITHUB_ENV
+            exit 0
+          else
+            echo "is_alpha=false" >> $GITHUB_ENV
+          fi
+        shell: bash
+
   PublishDocs:
     name: Publish SDK Reference Docs
     runs-on: ubuntu-latest
+    needs: AlphaCheck
+    if: ${{ needs.AlphaCheck.outputs.is_alpha != 'true' }}
     env:
       SDK_PUBLISH_SLACK_WEBHOOK: ${{ secrets.SDK_PUBLISH_SLACK_WEBHOOK }}
       NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

The workflow was incorrectly exiting with a failure status when the SDK reference docs had actually built and deployed correctly.

This fixes the script to check the correct deployed docs URL, and prevents the workflow from returning a failed status when attempting to build and deploy docs for `alpha` versions. 

# Detail and impact of the change
No impact for customers.  

## Fixed
- SDK reference docs workflow incorrectly reporting failed status

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
