### PR TITLE
fix: SDK reference docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -21,7 +21,8 @@ jobs:
       - name: Check alpha version
         id: alpha_check
         run: |
-          if $(git describe --tags --abbrev=0) | grep -q "alpha"; then
+          VERSION=$(git describe --tags --abbrev=0)
+          if echo "$VERSION" | grep -q "alpha"; then
             echo "Skipping docs generation for alpha version"
             echo "is_alpha=true" >> $GITHUB_ENV
             exit 0


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Fix syntax error in SDK reference docs workflow check to run on alpha builds.
