### PR TITLE
fix: check alpha version on publish job

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -38,7 +38,7 @@ jobs:
     name: Publish SDK Reference Docs
     runs-on: ubuntu-latest
     needs: AlphaCheck
-    # if: ${{ needs.AlphaCheck.outputs.is_alpha == 'false' }}
+    if: ${{ needs.AlphaCheck.outputs.is_alpha == 'false' }}
     env:
       SDK_PUBLISH_SLACK_WEBHOOK: ${{ secrets.SDK_PUBLISH_SLACK_WEBHOOK }}
       NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
@@ -47,7 +47,6 @@ jobs:
     steps:
       - name: Is Alpha Version
         run: |
-          echo "Is Alpha Version: ${{ needs.AlphaCheck.outputs.is_alpha }}"
           echo "Is Alpha Version: ${{ env.IS_ALPHA }}"
 
       - name: Check Public Release Branch


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
Only run the build and publish docs job for non-alpha builds.
