### PR TITLE
feat: game bridge build check version string

### DIFF
--- a/.github/workflows/build-game-bridge.yaml
+++ b/.github/workflows/build-game-bridge.yaml
@@ -70,25 +70,35 @@ jobs:
       - name: Update Version Strings
         run: cd packages/game-bridge && ./scripts/updateSdkVersion.sh
 
-      # - name: Check Unity Version String Updated
-      #   if: ${{ github.event.inputs.game_engine == 'Unity' || github.event.inputs.game_engine == 'Both' }}
-      #   run: |
-      #     UNITY_ARTIFACT_PATH="./packages/game-bridge/dist/unity/index.html"
-      #     UNITY_VERSION_STRING_COUNT=$(cat $UNITY_ARTIFACT_PATH | grep -c -o "ts-immutable-sdk-${{ env.TS_SDK_TAG }}")
-      #     if [ "$UNITY_VERSION_STRING_COUNT" -eq 0 ]; then
-      #         echo "Error: Updated version string not found in $UNITY_ARTIFACT_PATH"
-      #         exit 1
-      #     fi
+      - name: Check Unity Version String Updated
+        if: ${{ github.event.inputs.game_engine == 'Unity' || github.event.inputs.game_engine == 'Both' }}
+        run: |
+          UNITY_ARTIFACT_PATH="./packages/game-bridge/dist/unity/index.html"
+          if [ ! -f "$UNITY_ARTIFACT_PATH" ]; then
+            echo "Error: Unity artifact file not found at $UNITY_ARTIFACT_PATH"
+            exit 1
+          fi
+          UNITY_VERSION_STRING_COUNT=$(grep -c -o "ts-immutable-sdk-${{ env.TS_SDK_TAG }}" "$UNITY_ARTIFACT_PATH" || true)
+          if [ "$UNITY_VERSION_STRING_COUNT" -eq 0 ]; then
+            echo "Error: Updated version string not found in $UNITY_ARTIFACT_PATH"
+            exit 1
+          fi
+          echo "Unity version string updated successfully"
 
-      # - name: Check Unreal Version String Updated
-      #   if: ${{ github.event.inputs.game_engine == 'Unreal' || github.event.inputs.game_engine == 'Both' }}
-      #   run: |
-      #     UNREAL_ARTIFACT_PATH="./packages/game-bridge/dist/unreal/index.js"
-      #     UNREAL_VERSION_STRING_COUNT=$(cat $UNREAL_ARTIFACT_PATH | grep -c -o "ts-immutable-sdk-${{ env.TS_SDK_TAG }}")
-      #     if [ "$UNREAL_VERSION_STRING_COUNT" -eq 0 ]; then
-      #         echo "Error: Updated version string not found in $UNREAL_ARTIFACT_PATH"
-      #         exit 1
-      #     fi
+      - name: Check Unreal Version String Updated
+        if: ${{ github.event.inputs.game_engine == 'Unreal' || github.event.inputs.game_engine == 'Both' }}
+        run: |
+          UNREAL_ARTIFACT_PATH="./packages/game-bridge/dist/unreal/index.js"
+          if [ ! -f "$UNREAL_ARTIFACT_PATH" ]; then
+            echo "Error: Unreal artifact file not found at $UNREAL_ARTIFACT_PATH"
+            exit 1
+          fi
+          UNREAL_VERSION_STRING_COUNT=$(grep -c -o "ts-immutable-sdk-${{ env.TS_SDK_TAG }}" "$UNREAL_ARTIFACT_PATH" || true)
+          if [ "$UNREAL_VERSION_STRING_COUNT" -eq 0 ]; then
+            echo "Error: Updated version string not found in $UNREAL_ARTIFACT_PATH"
+            exit 1
+          fi
+          echo "Unreal version string updated successfully"
 
       - name: Cache build artifacts
         uses: actions/cache@v4

--- a/packages/game-bridge/scripts/updateSdkVersion.sh
+++ b/packages/game-bridge/scripts/updateSdkVersion.sh
@@ -6,10 +6,13 @@
 # - TS_SDK_HASH: The git hash of the tag
 
 set -e
-set -x
+# Enable debug mode (set -x) only in CI environment
+if [ -n "$CI" ]; then
+  set -x
+fi
 
 # The files to update
-FILE_PATHS=("./dist/unity/index.html" "./dist/unreal/index.js" "./dist/unreal/index.js.map")
+FILE_PATHS=("./dist/unity/index.html" "./dist/unreal/index.js")
 
 # check files exist
 for FILE_PATH in "${FILE_PATHS[@]}"
@@ -41,15 +44,15 @@ if [ -z "$CI" ]; then
 else
   echo "Update SDK version in CI / non-locally" 
   # Get the current branch name
-  current_branch=$(git rev-parse --abbrev-ref HEAD)
+  current_branch=${GITHUB_REF#refs/heads/}
 
-  # # Check if the current branch is "main"
-  # if [ "$current_branch" == "main" ]; then
-  #     echo "You are on the main branch. Continuing..."
-  # else
-  #     echo "You are not on the main branch. Exiting..."
-  #     exit 1
-  # fi
+  # Check if the current branch is "main"
+  if [ "$current_branch" == "main" ]; then
+      echo "You are on the main branch. Continuing..."
+  else
+      echo "You are not on the main branch. Exiting..."
+      exit 1
+  fi
 
   # Check if TS_SDK_TAG environment variable is set
   if [ -z "$TS_SDK_TAG" ]; then

--- a/packages/game-bridge/scripts/updateSdkVersion.sh
+++ b/packages/game-bridge/scripts/updateSdkVersion.sh
@@ -46,6 +46,11 @@ else
   # Get the current branch name
   current_branch=${GITHUB_REF#refs/heads/}
 
+  # If current_branch is empty, fall back to git command
+  if [ -z "$current_branch" ]; then
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+  fi
+
   # Check if the current branch is "main"
   if [ "$current_branch" == "main" ]; then
       echo "You are on the main branch. Continuing..."


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Check the version string is set in the game bridge build artefacts.

# Detail and impact of the change
Should prevent SDKs being released with the incorrect version string. This can cause issues for Passport if the string is not set correctly.

## Added
- Workflow steps to check the version string in game bridge is set correctly

