### PR TITLE
fix: [DX-3092] Use rollup build instead of swc d for watch mode

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "**sample-app**/",
     "**playground**/",
     "*.cjs",
+    "*.js",
     "tests/func-tests/"
   ],
   "parser": "@typescript-eslint/parser",

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,12 +9,11 @@
     "**sample-app**/",
     "**playground**/",
     "*.cjs",
-    "*.js",
     "tests/func-tests/"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./tsconfig.json",
+    "project": "./tsconfig.base.json",
     "tsconfigRootDir": "."
   },
   "rules": {

--- a/build-dependents.js
+++ b/build-dependents.js
@@ -23,7 +23,7 @@ try {
 
   if (isDependent || changedProject === currentProject) {
     // Rebuild the current project
-    const command = `nx run-many --target=d --projects=${currentProject} --parallel=5`;
+    const command = `nx run-many --target=build --projects=${currentProject} --parallel=5`;
 
     console.log(`Running command: ${command}`);
     execSync(command, { stdio: 'inherit' });

--- a/dev.sh
+++ b/dev.sh
@@ -28,5 +28,5 @@ fi
 
 # Run nx commands with the selected or provided package name
 echo "Running commands for package: $PACKAGE_NAME"
-nx run $PACKAGE_NAME:d --parallel=5
+nx run $PACKAGE_NAME:build --parallel=5
 nx watch --all -- node ./build-dependents.js \$NX_PROJECT_NAME $(echo $PACKAGE_NAME)

--- a/examples/passport/identity-with-nextjs/.eslintrc.json
+++ b/examples/passport/identity-with-nextjs/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/examples/passport/next-connect-kit/.eslintrc.json
+++ b/examples/passport/next-connect-kit/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/examples/passport/next-rainbow-kit/.eslintrc.json
+++ b/examples/passport/next-rainbow-kit/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/examples/passport/next-wagmi/.eslintrc.json
+++ b/examples/passport/next-wagmi/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/examples/passport/next-web3-modal/.eslintrc.json
+++ b/examples/passport/next-web3-modal/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/examples/passport/wallets-connect-with-nextjs/.eslintrc.json
+++ b/examples/passport/wallets-connect-with-nextjs/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": ["next/core-web-vitals", "next"]
 }

--- a/examples/passport/wallets-signing-with-nextjs/.eslintrc.json
+++ b/examples/passport/wallets-signing-with-nextjs/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": ["next/core-web-vitals", "next"]
 }

--- a/examples/passport/wallets-transactions-with-nextjs/.eslintrc.json
+++ b/examples/passport/wallets-transactions-with-nextjs/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }


### PR DESCRIPTION
The swc d command nx watch mode is using for our yarn dev command doesn’t generate the declaration files. Revert back to using the rollup build command for the watch mode.