### PR TITLE
chore: TD-1596: optimize use of banker funds in E2E tests.

### DIFF
--- a/tests/func-tests/zkevm/features/order.feature
+++ b/tests/func-tests/zkevm/features/order.feature
@@ -12,6 +12,7 @@ Feature: orderbook
         Then the listing should be of status filled
         And 1 ERC721 token should be transferred to the fulfiller
         And 1 trade should be available
+        And any remaining funds are returned to the banker
 
     Scenario: bulk creating and fulfilling ERC721 listings
         Given I have a funded offerer account
@@ -23,6 +24,7 @@ Feature: orderbook
         Then the listing should be of status filled
         And 1 ERC721 token should be transferred to the fulfiller
         And 1 trade should be available
+        And any remaining funds are returned to the banker
 
     Scenario: create and completely fill a ERC1155 listing
         Given I have a funded offerer account
@@ -34,6 +36,7 @@ Feature: orderbook
         Then the listing should be of status filled
         And 100 ERC1155 tokens should be transferred to the fulfiller
         And 1 trade should be available
+        And any remaining funds are returned to the banker
 
     Scenario: create and partially fill a ERC1155 listing
         Given I have a funded offerer account
@@ -50,6 +53,7 @@ Feature: orderbook
         # Checks for the total amount of tokens transferred - 100 = 90 from first fulfilment + 10 from second fulfilment
         And 100 ERC1155 tokens should be transferred to the fulfiller
         And 2 trades should be available
+        And any remaining funds are returned to the banker
 
     Scenario: create and bulk fill multiple listings
         Given I have a funded offerer account
@@ -67,6 +71,7 @@ Feature: orderbook
         Then the listing should be of status active
         # Assert only the ERC1155 trade in this scenario
         And 1 trade should be available
+        And any remaining funds are returned to the banker
 
     Scenario: create and fully fill a ERC1155 listing without an explicit fulfill amount
         Given I have a funded offerer account
@@ -78,6 +83,7 @@ Feature: orderbook
         Then the listing should be of status filled
         And 100 ERC1155 tokens should be transferred to the fulfiller
         And 1 trade should be available
+        And any remaining funds are returned to the banker
 
     Scenario: create and partially fill a ERC1155 listing, second fill without explicit amount
         Given I have a funded offerer account
@@ -94,3 +100,4 @@ Feature: orderbook
         # Checks for the total amount of tokens transferred - 100 = 90 from first fulfilment + 10 from second fulfilment
         And 100 ERC1155 tokens should be transferred to the fulfiller
         And 2 trades should be available
+        And any remaining funds are returned to the banker

--- a/tests/func-tests/zkevm/step-definitions/order.steps.ts
+++ b/tests/func-tests/zkevm/step-definitions/order.steps.ts
@@ -14,7 +14,7 @@ import {
   whenICreateAListing, whenIFulfillTheListingToBuy, andERC1155TokensShouldBeTransferredToTheFulfiller,
   thenTheListingsShouldBeOfStatus,
   whenIFulfillBulkListings, whenIFulfillTheListingToBuyWithoutExplicitFulfillmentAmt,
-  whenICreateABulkListing,
+  whenICreateABulkListing, andAnyRemainingFundsAreReturnedToBanker,
 } from './shared';
 
 const feature = loadFeature('features/order.feature', { tagFilter: process.env.TAGS });
@@ -78,6 +78,8 @@ defineFeature(feature, (test) => {
     andERC721TokenShouldBeTransferredToTheFulfiller(and, bankerWallet, erc721ContractAddress, testTokenId, fulfiller);
 
     andTradeShouldBeAvailable(and, sdk, fulfiller, getListingId);
+
+    andAnyRemainingFundsAreReturnedToBanker(and, bankerWallet, offerer, fulfiller);
   }, 120_000);
 
   test('bulk creating and fulfilling ERC721 listings', async ({
@@ -117,6 +119,8 @@ defineFeature(feature, (test) => {
     andERC721TokenShouldBeTransferredToTheFulfiller(and, bankerWallet, erc721ContractAddress, testTokenId2, fulfiller);
 
     andTradeShouldBeAvailable(and, sdk, fulfiller, getListingId);
+
+    andAnyRemainingFundsAreReturnedToBanker(and, bankerWallet, offerer, fulfiller);
   }, 120_000);
 
   test('create and completely fill a ERC1155 listing', ({
@@ -156,6 +160,8 @@ defineFeature(feature, (test) => {
     andERC1155TokensShouldBeTransferredToTheFulfiller(and, bankerWallet, erc1155ContractAddress, testTokenId, fulfiller);
 
     andTradeShouldBeAvailable(and, sdk, fulfiller, getListingId);
+
+    andAnyRemainingFundsAreReturnedToBanker(and, bankerWallet, offerer, fulfiller);
   }, 120_000);
 
   test('create and partially fill a ERC1155 listing', ({
@@ -203,6 +209,8 @@ defineFeature(feature, (test) => {
     andERC1155TokensShouldBeTransferredToTheFulfiller(and, bankerWallet, erc1155ContractAddress, testTokenId, fulfiller);
 
     andTradeShouldBeAvailable(and, sdk, fulfiller, getListingId);
+
+    andAnyRemainingFundsAreReturnedToBanker(and, bankerWallet, offerer, fulfiller);
   }, 120_000);
 
   test('create and bulk fill multiple listings', ({
@@ -256,6 +264,8 @@ defineFeature(feature, (test) => {
     thenTheListingShouldBeOfStatus(then, sdk, getERC1155ListingId);
 
     andTradeShouldBeAvailable(and, sdk, fulfiller, getERC1155ListingId);
+
+    andAnyRemainingFundsAreReturnedToBanker(and, bankerWallet, offerer, fulfiller);
   }, 120_000);
 
   test('create and fully fill a ERC1155 listing without an explicit fulfill amount', ({
@@ -294,6 +304,8 @@ defineFeature(feature, (test) => {
     andERC1155TokensShouldBeTransferredToTheFulfiller(and, bankerWallet, erc1155ContractAddress, testTokenId, fulfiller);
 
     andTradeShouldBeAvailable(and, sdk, fulfiller, getListingId);
+
+    andAnyRemainingFundsAreReturnedToBanker(and, bankerWallet, offerer, fulfiller);
   }, 120_000);
 
   test('create and partially fill a ERC1155 listing, second fill without explicit amount', ({
@@ -341,5 +353,7 @@ defineFeature(feature, (test) => {
     andERC1155TokensShouldBeTransferredToTheFulfiller(and, bankerWallet, erc1155ContractAddress, testTokenId, fulfiller);
 
     andTradeShouldBeAvailable(and, sdk, fulfiller, getListingId);
+
+    andAnyRemainingFundsAreReturnedToBanker(and, bankerWallet, offerer, fulfiller);
   }, 120_000);
 });

--- a/tests/func-tests/zkevm/step-definitions/shared.ts
+++ b/tests/func-tests/zkevm/step-definitions/shared.ts
@@ -1,6 +1,6 @@
 import { orderbook } from '@imtbl/sdk';
 import { DefineStepFunction } from 'jest-cucumber';
-import { Wallet } from 'ethers';
+import { BigNumber, Wallet } from 'ethers';
 import {
   bulkFulfillListings,
   connectToTestERC1155Token,
@@ -14,6 +14,7 @@ import { actionAll } from '../utils/orderbook/actions';
 const imxForApproval = 0.03 * 1e18;
 const imxForFulfillment = 0.08 * 1e18;
 const listingPrice = 0.0001 * 1e18;
+const transferTxnFee = 0.0035 * 1e18;
 
 // Workaround to retry banker on-chain actions which can race with test runs on other PRs
 // eslint-disable-next-line consistent-return
@@ -330,5 +331,41 @@ export const andTradeShouldBeAvailable = (
     }
 
     expect(targetTrades?.length === count);
+  });
+};
+
+export const andAnyRemainingFundsAreReturnedToBanker = (
+    and: DefineStepFunction,
+    banker: Wallet,
+    offerer: Wallet,
+    fulfiller: Wallet,
+) => {
+  and(/^any remaining funds are returned to the banker$/, async () => {
+    await withBankerRetry(async () => {
+      const fulfillerBalance = await fulfiller.getBalance();
+      const offererBalance = await offerer.getBalance();
+
+      if (fulfillerBalance.gt(BigNumber.from(transferTxnFee))) {
+        // fulfiller returns funds
+        const fulfillerReturnTxn = await fulfiller.sendTransaction({
+          to: banker.address,
+          value: `${fulfillerBalance.sub(BigNumber.from(transferTxnFee)).toString()}`,
+          ...GAS_OVERRIDES,
+        });
+
+        await fulfillerReturnTxn.wait(1);
+      }
+
+      if (offererBalance.gt(BigNumber.from(transferTxnFee))) {
+        // offerer returns funds
+        const offererReturnTxn = await offerer.sendTransaction({
+          to: banker.address,
+          value: `${offererBalance.sub(BigNumber.from(transferTxnFee)).toString()}`,
+          ...GAS_OVERRIDES,
+        });
+
+        await offererReturnTxn.wait(1);
+      }
+    });
   });
 };


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [X] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Add additional step in E2E tests to return any remaining funds from funded accounts back to banker.