### PR TITLE
[DX-3122] fix: get transaction receipt success check

### DIFF
--- a/packages/game-bridge/src/index.ts
+++ b/packages/game-bridge/src/index.ts
@@ -716,7 +716,7 @@ window.callFunction = async (jsonData: string) => {
           method: 'eth_getTransactionReceipt',
           params: [request.txHash],
         });
-        const success = response !== null && response !== undefined;
+        const success = response !== undefined;
 
         if (!success) {
           throw new Error('Failed to get transaction receipt');


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
When checking whether the get transaction receipt failed or not, it should only check that the response is undefined, not null.