### PR TITLE
fix: [DX-3131] Fix slow dev rebuild for initial changed package

### DIFF
--- a/build-dependents.js
+++ b/build-dependents.js
@@ -23,7 +23,7 @@ try {
 
   if (isDependent || changedProject === currentProject) {
     // Rebuild the current project
-    const command = `nx run-many --target=d --projects=${currentProject} --parallel=5`;
+    const command = `nx run-many --target=d --projects=${currentProject} --parallel=5 --no-cloud`;
 
     console.log(`Running command: ${command}`);
     execSync(command, { stdio: 'inherit' });

--- a/dev.sh
+++ b/dev.sh
@@ -28,5 +28,5 @@ fi
 
 # Run nx commands with the selected or provided package name
 echo "Running commands for package: $PACKAGE_NAME"
-nx run $PACKAGE_NAME:d --parallel=5
+nx run $PACKAGE_NAME:d --parallel=5 --no-cloud
 nx watch --all -- node ./build-dependents.js \$NX_PROJECT_NAME $(echo $PACKAGE_NAME)


### PR DESCRIPTION
Fixes the delay in the initial rebuild caused by the nx cloud connection. This disables that to save us ~5-8 seconds in dev rebuild loop times, especially since the impact will be minimal with dev mode facing constant changes