### PR TITLE
[NO-CHANGELOG][Checkout Widgets] fix: Prevent passing provider as prop to framer motion children

### DIFF
--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/WalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/WalletDrawer.tsx
@@ -119,8 +119,8 @@ export function WalletDrawer({
             key={providerDetail.info.rdns}
             testId={testId}
             loading={walletItemLoading}
-            providerDetail={providerDetail}
-            onWalletItemClick={handleWalletItemClick}
+            providerInfo={providerDetail.info}
+            onWalletItemClick={() => handleWalletItemClick(providerDetail)}
             rc={(
               <motion.div variants={listItemVariants} custom={index} />
             )}

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/WalletItem.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/WalletItem.tsx
@@ -1,15 +1,15 @@
 import { MenuItem } from '@biom3/react';
 import { cloneElement, ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EIP6963ProviderDetail } from '@imtbl/checkout-sdk';
+import { EIP6963ProviderInfo } from '@imtbl/checkout-sdk';
 import { RawImage } from '../RawImage/RawImage';
 
 export interface WalletItemProps<RC extends ReactElement | undefined = undefined> {
   loading?: boolean;
   recommended?: boolean;
   testId: string;
-  providerDetail: EIP6963ProviderDetail;
-  onWalletItemClick: (providerDetail: EIP6963ProviderDetail) => Promise<void>;
+  providerInfo: EIP6963ProviderInfo;
+  onWalletItemClick: () => void;
   rc?: RC;
 }
 
@@ -20,7 +20,7 @@ export function WalletItem<
   testId,
   loading = false,
   recommended = false,
-  providerDetail,
+  providerInfo,
   onWalletItemClick,
 }: WalletItemProps<RC>) {
   const { t } = useTranslation();
@@ -34,27 +34,27 @@ export function WalletItem<
           setBusy(true);
           // let the parent handle errors
           try {
-            await onWalletItemClick(providerDetail);
+            await onWalletItemClick();
           } finally {
             setBusy(false);
           }
         },
       })}
-      testId={`${testId}-wallet-list-${providerDetail.info.rdns}`}
+      testId={`${testId}-wallet-list-${providerInfo.rdns}`}
       size="medium"
       emphasized
       sx={{ position: 'relative' }}
     >
       <RawImage
-        src={providerDetail.info.icon}
-        alt={providerDetail.info.name}
+        src={providerInfo.icon}
+        alt={providerInfo.name}
         sx={{
           position: 'absolute',
           left: 'base.spacing.x3',
         }}
       />
       <MenuItem.Label size="medium" sx={{ marginLeft: '65px' }}>
-        {providerDetail.info.name}
+        {providerInfo.name}
       </MenuItem.Label>
       {((recommended || busy) && (
         <MenuItem.Badge

--- a/packages/checkout/widgets-lib/src/widgets/connect/components/WalletItem.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/connect/components/WalletItem.tsx
@@ -1,7 +1,7 @@
 import { Badge, Box, MenuItem } from '@biom3/react';
 import { useTranslation } from 'react-i18next';
 import { cloneElement, ReactElement, useState } from 'react';
-import { EIP6963ProviderDetail, WalletProviderName } from '@imtbl/checkout-sdk';
+import { EIP6963ProviderInfo, WalletProviderName } from '@imtbl/checkout-sdk';
 import { RawImage } from '../../../components/RawImage/RawImage';
 import { getProviderSlugFromRdns } from '../../../lib/provider';
 import useIsSmallScreen from '../../../lib/hooks/useIsSmallScreen';
@@ -9,8 +9,8 @@ import useIsSmallScreen from '../../../lib/hooks/useIsSmallScreen';
 export interface WalletProps<RC extends ReactElement | undefined = undefined> {
   loading?: boolean;
   recommended?: boolean;
-  onWalletItemClick: (providerDetail: EIP6963ProviderDetail) => void;
-  providerDetail: EIP6963ProviderDetail;
+  onWalletItemClick: () => void;
+  providerInfo: EIP6963ProviderInfo;
   rc?: RC;
 }
 
@@ -20,13 +20,13 @@ export function WalletItem<
   rc = <span />,
   loading = false,
   recommended = false,
-  providerDetail,
+  providerInfo,
   onWalletItemClick,
 }: WalletProps<RC>) {
   const { t } = useTranslation();
   const { isSmallScreenMode } = useIsSmallScreen();
   const [busy, setBusy] = useState(false);
-  const providerSlug = getProviderSlugFromRdns(providerDetail.info.rdns);
+  const providerSlug = getProviderSlugFromRdns(providerInfo.rdns);
   const isPassport = providerSlug === WalletProviderName.PASSPORT;
   const isPassportOrMetamask = isPassport || providerSlug === WalletProviderName.METAMASK;
   const offsetStyles = { marginLeft: '65px' };
@@ -39,13 +39,13 @@ export function WalletItem<
           setBusy(true);
           // let the parent handle errors
           try {
-            await onWalletItemClick(providerDetail);
+            await onWalletItemClick();
           } finally {
             setBusy(false);
           }
         },
       })}
-      testId={`wallet-list-${providerDetail.info.rdns}`}
+      testId={`wallet-list-${providerInfo.rdns}`}
       size="medium"
       emphasized
       sx={{
@@ -54,8 +54,8 @@ export function WalletItem<
       }}
     >
       <RawImage
-        src={providerDetail.info.icon}
-        alt={providerDetail.info.name}
+        src={providerInfo.icon}
+        alt={providerInfo.name}
         sx={{
           position: 'absolute',
           left: 'base.spacing.x3',
@@ -80,7 +80,7 @@ export function WalletItem<
             }}
           />
         ))}
-        <Box>{providerDetail.info.name}</Box>
+        <Box>{providerInfo.name}</Box>
       </MenuItem.Label>
       {(!busy && <MenuItem.IntentIcon />)}
       <MenuItem.Caption sx={{ ...offsetStyles }}>

--- a/packages/checkout/widgets-lib/src/widgets/connect/components/WalletList.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/connect/components/WalletList.tsx
@@ -372,8 +372,8 @@ export function WalletList(props: WalletListProps) {
         <WalletItem
           recommended
           key={passportProviderDetail.info.rdns}
-          onWalletItemClick={handleWalletItemClick}
-          providerDetail={passportProviderDetail}
+          onWalletItemClick={() => handleWalletItemClick(passportProviderDetail)}
+          providerInfo={passportProviderDetail.info}
           rc={(
             <motion.div
               variants={listItemVariants}
@@ -386,8 +386,8 @@ export function WalletList(props: WalletListProps) {
       {filteredProviders.length === 1 && (
         <WalletItem
           key={filteredProviders[0].info.rdns}
-          onWalletItemClick={handleWalletItemClick}
-          providerDetail={filteredProviders[0]}
+          onWalletItemClick={() => handleWalletItemClick(filteredProviders[0])}
+          providerInfo={filteredProviders[0].info}
           rc={(
             <motion.div
               variants={listItemVariants}


### PR DESCRIPTION
# Summary
Prevent passing non serialisable objects as props to components that are wrapped with framer motion.
As this objects wont be serialised when the widgets are rendered within a cross domain iframe

# Detail and impact of the change
<img width="1078" alt="Screenshot 2024-08-20 at 3 49 44 PM" src="https://github.com/user-attachments/assets/d8538ec5-8388-4648-a378-2f2ab2dbeb0f">
