### PR TITLE
feat: Add autoProceed to SaleWidget

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/components/FundingRouteExecute/FundingRouteExecute.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/FundingRouteExecute/FundingRouteExecute.tsx
@@ -17,7 +17,6 @@ import {
   OnRampSuccess,
   OnRampFailed,
   ChainId,
-  SwapDirection,
 } from '@imtbl/checkout-sdk';
 import {
   useCallback,
@@ -158,7 +157,6 @@ export function FundingRouteExecute({
           fromTokenAddress: step.fundingItem.token.address,
           toTokenAddress: requiredTokenAddress,
           autoProceed: true,
-          direction: SwapDirection.FROM,
         });
         if (network.chainId === getL2ChainId(checkout!.config)) {
           setView(FundingRouteExecuteViews.EXECUTE_SWAP);

--- a/packages/checkout/widgets-lib/src/widgets/sale/components/FundingRouteExecute/FundingRouteExecute.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/FundingRouteExecute/FundingRouteExecute.tsx
@@ -17,6 +17,7 @@ import {
   OnRampSuccess,
   OnRampFailed,
   ChainId,
+  SwapDirection,
 } from '@imtbl/checkout-sdk';
 import {
   useCallback,
@@ -156,13 +157,14 @@ export function FundingRouteExecute({
           amount: step.fundingItem.fundsRequired.formattedAmount,
           fromTokenAddress: step.fundingItem.token.address,
           toTokenAddress: requiredTokenAddress,
+          autoProceed: true,
+          direction: SwapDirection.FROM,
         });
         if (network.chainId === getL2ChainId(checkout!.config)) {
           setView(FundingRouteExecuteViews.EXECUTE_SWAP);
           return;
         }
         nextView.current = FundingRouteExecuteViews.EXECUTE_SWAP;
-
         setView(FundingRouteExecuteViews.SWITCH_NETWORK_ZKEVM);
       }
 

--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
@@ -221,8 +221,8 @@ export default function SwapWidget({
           <SwapCoins
             theme={theme}
             cancelAutoProceed={cancelAutoProceed}
-            fromAmount={fromAmount}
-            toAmount={toAmount}
+            fromAmount={viewState.view.data?.fromAmount ?? fromAmount}
+            toAmount={viewState.view.data?.toAmount ?? toAmount}
             fromTokenAddress={viewState.view.data?.fromTokenAddress ?? fromTokenAddress}
             toTokenAddress={viewState.view.data?.toTokenAddress ?? toTokenAddress}
           />

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -673,7 +673,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
 
   const isFormValidForAutoProceed = useMemo(() => {
     if (!autoProceed) return false;
-    if (!loadedToAndFromTokens) return false;
+    if (loadedToAndFromTokens === false) return false;
 
     return !loading;
   }, [autoProceed, loading, loadedToAndFromTokens]);
@@ -761,8 +761,12 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     });
   };
 
-  // eslint-disable-next-line max-len
-  const shouldSendTransaction = useMemo(() => ((canAutoSwap === true && autoProceed === true) ? true : undefined), [canAutoSwap, autoProceed]);
+  const shouldSendTransaction = useMemo(() => {
+    if (canAutoSwap === true && autoProceed === true) {
+      return true;
+    }
+    return undefined;
+  }, [canAutoSwap, autoProceed]);
 
   useEffect(() => {
     if (shouldSendTransaction === undefined) return;

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -761,7 +761,8 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     });
   };
 
-  const shouldSendTransaction = useMemo(() => canAutoSwap === true && autoProceed === true, [canAutoSwap, autoProceed]);
+  // eslint-disable-next-line max-len
+  const shouldSendTransaction = useMemo(() => ((canAutoSwap === true && autoProceed === true) ? true : undefined), [canAutoSwap, autoProceed]);
 
   useEffect(() => {
     if (shouldSendTransaction === undefined) return;

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -761,11 +761,12 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     });
   };
 
+  const shouldSendTransaction = useMemo(() => canAutoSwap === true && autoProceed === true, [canAutoSwap, autoProceed]);
+
   useEffect(() => {
-    if (!autoProceed) return;
-    if (!canAutoSwap) return;
+    if (shouldSendTransaction === undefined) return;
     sendTransaction();
-  }, [canAutoSwap, autoProceed, sendTransaction]);
+  }, [shouldSendTransaction]);
 
   return (
     <>


### PR DESCRIPTION
# Summary
Modify `SaleWidget` to use `autoProceed` to `true` on the `SwapWidget`

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
