### PR TITLE
feat: Inform users about bridge withdrawal queue

### DIFF
--- a/packages/checkout/widgets-lib/src/components/WithdrawalQueueDrawer/WithdrawalQueueDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WithdrawalQueueDrawer/WithdrawalQueueDrawer.tsx
@@ -1,0 +1,153 @@
+import {
+  Body,
+  Box,
+  ButtCon,
+  Button,
+  CloudImage,
+  Drawer,
+  Heading,
+} from '@biom3/react';
+import { Checkout } from '@imtbl/checkout-sdk';
+import { Environment } from '@imtbl/config';
+import { useTranslation } from 'react-i18next';
+import { getRemoteImage } from '../../lib/utils';
+
+export enum WithdrawalQueueWarningType {
+  TYPE_THRESHOLD = 'exceedsThreshold',
+  TYPE_ACTIVE_QUEUE = 'queueActivated',
+}
+
+export interface WithdrawalQueueDrawerProps {
+  visible: boolean;
+  checkout: Checkout;
+  onCloseDrawer: () => void;
+  warningType?: WithdrawalQueueWarningType;
+  onProceed?: () => void;
+  onAdjustAmount?: () => void;
+  threshold?: number;
+}
+export function WithdrawalQueueDrawer({
+  visible,
+  checkout,
+  warningType,
+  onCloseDrawer,
+  onProceed,
+  onAdjustAmount,
+  threshold,
+}: WithdrawalQueueDrawerProps) {
+  const { t } = useTranslation();
+
+  const bridgeWarningUrl = getRemoteImage(
+    checkout.config.environment ?? Environment.PRODUCTION,
+    '/notenougheth.svg',
+  );
+
+  return (
+    warningType && (
+      <Drawer
+        size={warningType === WithdrawalQueueWarningType.TYPE_THRESHOLD ? 'full' : 'threeQuarter'}
+        visible={visible}
+        onCloseDrawer={onCloseDrawer}
+        showHeaderBar={false}
+      >
+        <Drawer.Content
+          testId="withdraway-queue-bottom-sheet"
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <CloudImage
+              sx={{ paddingTop: 'base.spacing.x4', paddingBottom: 'base.spacing.x9' }}
+              use={(
+                <img
+                  src={bridgeWarningUrl}
+                  alt={t(`drawers.withdrawalQueue.${warningType}.heading`, { threshold })}
+                />
+              )}
+            />
+            <ButtCon
+              icon="Close"
+              variant="tertiary"
+              sx={{
+                pos: 'absolute',
+                top: 'base.spacing.x5',
+                left: 'base.spacing.x5',
+                backdropFilter: 'blur(30px)',
+              }}
+              onClick={onCloseDrawer}
+            />
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 'base.spacing.x4',
+                paddingX: 'base.spacing.x6',
+              }}
+            >
+              <Heading
+                size="small"
+                weight="bold"
+                sx={{ textAlign: 'center', paddingX: 'base.spacing.x6' }}
+              >
+                {t(`drawers.withdrawalQueue.${warningType}.heading`, { threshold })}
+              </Heading>
+
+              <Body
+                size="medium"
+                weight="regular"
+                sx={{
+                  color: 'base.color.text.body.secondary',
+                  textAlign: 'center',
+                  paddingX: 'base.spacing.x6',
+                }}
+              >
+                {t(`drawers.withdrawalQueue.${warningType}.body`, { threshold })}
+              </Body>
+            </Box>
+          </Box>
+
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              paddingX: 'base.spacing.x6',
+              width: '100%',
+            }}
+          >
+            {warningType === WithdrawalQueueWarningType.TYPE_THRESHOLD && (
+              <Button
+                size="large"
+                variant="primary"
+                sx={{ width: '100%', marginBottom: 'base.spacing.x5' }}
+                onClick={onAdjustAmount}
+              >
+                {t('drawers.withdrawalQueue.exceedsThreshold.buttons.cancel')}
+              </Button>
+            )}
+
+            <Button
+              size="large"
+              variant="primary"
+              sx={{ width: '100%', marginBottom: 'base.spacing.x10' }}
+              onClick={onProceed}
+            >
+              {t(`drawers.withdrawalQueue.${warningType}.buttons.proceed`)}
+            </Button>
+          </Box>
+        </Drawer.Content>
+      </Drawer>
+    )
+  );
+}

--- a/packages/checkout/widgets-lib/src/components/WithdrawalQueueDrawer/WithdrawalQueueDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WithdrawalQueueDrawer/WithdrawalQueueDrawer.tsx
@@ -1,7 +1,6 @@
 import {
   Body,
   Box,
-  ButtCon,
   Button,
   CloudImage,
   Drawer,
@@ -22,7 +21,6 @@ export interface WithdrawalQueueDrawerProps {
   checkout: Checkout;
   onCloseDrawer: () => void;
   warningType?: WithdrawalQueueWarningType;
-  onProceed?: () => void;
   onAdjustAmount?: () => void;
   threshold?: number;
 }
@@ -31,7 +29,6 @@ export function WithdrawalQueueDrawer({
   checkout,
   warningType,
   onCloseDrawer,
-  onProceed,
   onAdjustAmount,
   threshold,
 }: WithdrawalQueueDrawerProps) {
@@ -75,17 +72,6 @@ export function WithdrawalQueueDrawer({
                   alt={t(`drawers.withdrawalQueue.${warningType}.heading`, { threshold })}
                 />
               )}
-            />
-            <ButtCon
-              icon="Close"
-              variant="tertiary"
-              sx={{
-                pos: 'absolute',
-                top: 'base.spacing.x5',
-                left: 'base.spacing.x5',
-                backdropFilter: 'blur(30px)',
-              }}
-              onClick={onCloseDrawer}
             />
             <Box
               sx={{
@@ -141,7 +127,7 @@ export function WithdrawalQueueDrawer({
               size="large"
               variant="primary"
               sx={{ width: '100%', marginBottom: 'base.spacing.x10' }}
-              onClick={onProceed}
+              onClick={onCloseDrawer}
             >
               {t(`drawers.withdrawalQueue.${warningType}.buttons.proceed`)}
             </Button>

--- a/packages/checkout/widgets-lib/src/locales/en.json
+++ b/packages/checkout/widgets-lib/src/locales/en.json
@@ -775,6 +775,23 @@
         "body": "Make sure pop ups are enabled and follow the prompts in your wallet to connect",
         "actionButtonText": "Try again"
       }
+    },
+    "withdrawalQueue": {
+      "exceedsThreshold": {
+        "heading": "This withdraw will trigger a 24h delay. Withdraw less than {{threshold}} to avoid this.",
+        "body": "This withdrawal is over a security threshold that will trigger a 24hr delay. Withdraw an amount lower than {{threshold}} to have it actioned in ~20 minutes. Alternatively you can proceed and receive funds in 24hrs. ",
+        "buttons": {
+          "cancel": "Lower amount",
+          "proceed": "I understand"
+        }
+      },
+      "queueActivated": {
+        "heading": "This withdrawal will take 24hrs.",
+        "body": "We’re experiencing higher than normal congestion and wanted to let you know before you proceed.",
+        "buttons": {
+          "proceed": "I understand"
+        }
+      }
     }
   }
 }

--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -13,7 +13,7 @@
         "body1": "資金をImmutable zkEVMにブリッジするには、<layerswapLink>Layerswap</layerswapLink>の使用をお勧めします。リファエルをオンにしてIMXを受け取ります。",
         "body2": "または、ガス無料のImmutable Passportで簡単に支払いとプレイができます。",
         "buttonText": "それでも進む"
-      }    
+      }
     },
     "CONNECT_SUCCESS": {
       "status": "接続が安全です",
@@ -761,6 +761,23 @@
         "heading": "考えを変えましたか？",
         "body": "ポップアップが有効になっていることを確認し、ウォレットのプロンプトに従って接続してください。",
         "actionButtonText": "もう一度試す"
+      }
+    },
+    "withdrawalQueue": {
+      "exceedsThreshold": {
+        "heading": "この引き出しには 24 時間の遅延が発生します。これを回避するには、{{threshold}} 未満の引き出しを行ってください。",
+        "body": "この出金はセキュリティしきい値を超えているため、24 時間の遅延が発生します。{{threshold}} 未満の金額を出金すると、約 20 分で処理されます。または、続行して 24 時間以内に資金を受け取ることもできます。",
+        "buttons": {
+          "cancel": "低い金額",
+          "proceed": "わかりました"
+        }
+      },
+      "queueActivated": {
+        "heading": "この引き出しには24時間かかります。",
+        "body": "通常よりも混雑がひどいため、続行する前にお知らせします。",
+        "buttons": {
+          "proceed": "わかりました"
+        }
       }
     }
   }

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -755,6 +755,23 @@
         "body": "팝업이 활성화되어 있는지 확인하고 지갑의 프롬프트를 따라 연결하세요.",
         "actionButtonText": "다시 시도"
       }
+    },
+    "withdrawalQueue": {
+      "exceedsThreshold": {
+        "heading": "이 인출은 24시간 지연을 유발합니다. 이를 피하려면 {{threshold}}보다 적게 인출하세요.",
+        "body": "이 출금은 보안 임계값을 초과하여 24시간 지연이 발생합니다. {{threshold}}보다 적은 금액을 출금하면 약 20분 내에 처리됩니다. 아니면 진행하여 24시간 내에 자금을 받을 수 있습니다.",
+        "buttons": {
+          "cancel": "낮은 금액",
+          "proceed": "이해합니다"
+        }
+      },
+      "queueActivated": {
+        "heading": "인출에는 24시간이 소요됩니다.",
+        "body": "평소보다 교통 체증이 심해 진행하기 전에 알려드리고자 합니다.",
+        "buttons": {
+          "proceed": "이해합니다"
+        }
+      }
     }
   }
 }

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -755,6 +755,23 @@
         "body": "确保弹出窗口已启用，并按照钱包中的提示进行连接。",
         "actionButtonText": "重试"
       }
+    },
+    "withdrawalQueue": {
+      "exceedsThreshold": {
+        "heading": "此次提款将触发 24 小时延迟。提款金额不得超过 {{threshold}}，以避免出现此情况。",
+        "body": "此次提款超过安全阈值，将导致 24 小时延迟。提款金额低于 {{threshold}} 可在约 20 分钟内完成。或者，您也可以继续操作并在 24 小时内收到资金。",
+        "buttons": {
+          "cancel": "较低金额",
+          "proceed": "我明白"
+        }
+      },
+      "queueActivated": {
+        "heading": "此次提款将耗时 24 小时。",
+        "body": "我们正面临比平常更严重的拥堵，因此我们想在您继续前通知您。",
+        "buttons": {
+          "proceed": "我明白"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Our bridge has a [withdrawal delay mechanism](https://github.com/immutable/zkevm-bridge-contracts/blob/main/docs/high-level-architecture.md#withdrawal-delay-mechanism) that can affect large transfers or delay any transfer when the queue is activated. Users performing a bridge operation have no information about it before the transfer, sometimes leading to funds being locked without the user knowing it'll happen.

Given we can predict when transactions will cause a queue and know when the queue is activated, we're adding a warning before transactions are sent, so users can make an informed decision.

Sample flows:


https://github.com/user-attachments/assets/64b27704-be41-4ad3-bc52-09dc42afa200


https://github.com/user-attachments/assets/e78c2bb8-ff09-4edf-8dfe-9243dc5b7fbc


