### PR TITLE
feat: Add analytic event to insufficient funds scenario

### DIFF
--- a/packages/checkout/widgets-lib/src/context/view-context/SwapViewContextTypes.ts
+++ b/packages/checkout/widgets-lib/src/context/view-context/SwapViewContextTypes.ts
@@ -62,6 +62,7 @@ export interface ApproveERC20SwapData {
   transaction: TransactionRequest;
   info: Quote;
   swapFormInfo: PrefilledSwapForm;
+  autoProceed: boolean;
 }
 export interface PrefilledSwapForm {
   fromAmount: string;

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
@@ -208,6 +208,25 @@ export const useSaleEvent = () => {
     });
   };
 
+  const sendInsufficientFunds = (
+    screen: string,
+    txRequirements: any,
+    controlType: AnalyticsControlTypes = 'Event',
+    action: StandardAnalyticsActions = 'Viewed',
+  ) => {
+    track({
+      ...commonProps,
+      screen: toPascalCase(screen),
+      control: 'InsufficientFunds',
+      controlType,
+      action,
+      extras: {
+        ...userProps,
+        ...txRequirements,
+      },
+    });
+  };
+
   const sendViewFeesEvent = (
     screen: string,
     controlType: AnalyticsControlTypes = 'Button',
@@ -238,5 +257,6 @@ export const useSaleEvent = () => {
     sendSelectedPaymentToken,
     sendProceedToPay,
     sendViewFeesEvent,
+    sendInsufficientFunds,
   };
 };

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -40,7 +40,7 @@ type OrderSummaryProps = {
 
 export function OrderSummary({ subView }: OrderSummaryProps) {
   const { t } = useTranslation();
-  const { sendProceedToPay } = useSaleEvent();
+  const { sendProceedToPay, sendInsufficientFunds } = useSaleEvent();
   const {
     fromTokenAddress,
     collectionName,
@@ -165,6 +165,12 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
         smartCheckoutResult.transactionRequirements,
       );
       setPaymentMethod(undefined);
+
+      // Send analytics event to track insufficient funds
+      sendInsufficientFunds(
+        SaleWidgetViews.ORDER_SUMMARY,
+        data,
+      );
 
       closeHandover();
       viewDispatch({

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -665,6 +665,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
         swapToAddress: toToken?.address,
         swapToAmount: toAmount,
         swapToTokenSymbol: toToken?.symbol,
+        autoProceed,
       },
     });
 
@@ -711,6 +712,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
         swapToTokenSymbol: data?.toTokenSymbol,
         isSwapFormValid: isValid,
         hasFundsForGas: !insufficientFundsForGas,
+        autoProceed,
       },
     });
     if (!isValid) return;
@@ -755,6 +757,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
             transaction: transaction.swap.transaction,
             info: transaction.quote,
             swapFormInfo: prefilledSwapData,
+            autoProceed,
           },
         },
       },

--- a/packages/checkout/widgets-lib/src/widgets/swap/views/ApproveERC20Onboarding.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/ApproveERC20Onboarding.tsx
@@ -151,6 +151,9 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
       screen: 'ApproveERC20',
       control: 'ApproveSpending',
       controlType: 'Button',
+      extras: {
+        autoProceed: data.autoProceed,
+      },
     });
     setLoading(true);
 
@@ -252,6 +255,9 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
       screen: 'ApproveERC20',
       control: 'ApproveSwap',
       controlType: 'Button',
+      extras: {
+        autoProceed: data.autoProceed,
+      },
     });
     setLoading(true);
 


### PR DESCRIPTION
# Summary
- Adding a new analytic event when the user has insufficient funds in the Sale Widget.
- Adding autoProceed property to analytics events in the Swap Widget

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
