### PR TITLE
[NO CHANGELOG][Checkout Widget] Remove provider updated event and handle errors in provider relay

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/checkout/context/CheckoutContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/checkout/context/CheckoutContextProvider.tsx
@@ -1,4 +1,4 @@
-import { PostMessageHandler, PostMessageHandlerEventType } from '@imtbl/checkout-sdk';
+import { PostMessageHandler } from '@imtbl/checkout-sdk';
 import {
   Dispatch, ReactNode, useContext, useEffect,
 } from 'react';
@@ -21,13 +21,7 @@ export function CheckoutContextProvider({
   children,
 }: CheckoutContextProviderProps) {
   const { checkoutState, checkoutDispatch } = values;
-  const {
-    checkout,
-    provider,
-    iframeContentWindow,
-    postMessageHandler,
-    iframeURL,
-  } = checkoutState;
+  const { checkout, iframeContentWindow, iframeURL } = checkoutState;
 
   useEffect(() => {
     if (!iframeContentWindow || !checkout || !iframeURL) return;
@@ -49,15 +43,6 @@ export function CheckoutContextProvider({
       },
     });
   }, [iframeContentWindow, checkout, iframeURL]);
-
-  useEffect(() => {
-    if (!provider || !postMessageHandler) return;
-
-    postMessageHandler.send(PostMessageHandlerEventType.PROVIDER_UPDATED, {
-      isMetamask: provider.provider.isMetaMask,
-      isPassport: (provider.provider as any)?.isPassport,
-    });
-  }, [provider, postMessageHandler]);
 
   return (
     <CheckoutContext.Provider value={values}>


### PR DESCRIPTION
# Summary
Removes update provider event, because if it gets sent while a connection is awaiting response from the wallet it will trigger an early transition to the connected state.

This is possible because the provider was already connected, so the await is technically not required. However the connect loader does not handle this condition.

Overall this event is not required in the iframe to set the provider, given that it will already been set via an EIP6963 event.
However, we may need to dispatch this event for when the provider was directly given into the widget via `factory.update({ provider });`