### PR TITLE
[NO CHANGELOG][Wallet Widget] remove unexpected props from img component

### DIFF
--- a/packages/checkout/widgets-lib/src/components/TokenImage/TokenImage.tsx
+++ b/packages/checkout/widgets-lib/src/components/TokenImage/TokenImage.tsx
@@ -32,12 +32,17 @@ export function TokenImage({
     [src, error],
   );
 
+  const { ...cleanedProps } = forwardedProps as Record<string, unknown>;
+  if (Object.prototype.hasOwnProperty.call(cleanedProps, 'responsiveSizes')) {
+    delete cleanedProps.responsiveSizes;
+  }
+
   return (
     <img
       src={url}
       alt={name}
       onError={() => setError(true)}
-      {...forwardedProps}
+      {...cleanedProps}
     />
   );
 }


### PR DESCRIPTION
# Summary
TokenImage its use by MenuItem a Biome design system component that will forward a `responsiveSizes` props that should not be forwarded to `img` tag.

ie:
```tsx
      <MenuItem.FramedImage
        circularFrame
        use={(
          <TokenImage src={icon} name={name} defaultImage={defaultTokenImage} />
        )}
      />
``` 
