### PR TITLE
fix: Use language agnostic Support link

### DIFF
--- a/packages/checkout/widgets-lib/src/locales/ja.json
+++ b/packages/checkout/widgets-lib/src/locales/ja.json
@@ -593,7 +593,7 @@
         "body1": "サポートが必要ですか？",
         "body2": " お問い合わせは ",
         "body3": "サポートへ",
-        "supportLink": "https://support.immutable.com/hc/en-us",
+        "supportLink": "https://support.immutable.com/hc",
         "passport": {
           "body1": "または、完了した取引をご覧になるには ",
           "body2": "パスポート"

--- a/packages/checkout/widgets-lib/src/locales/ko.json
+++ b/packages/checkout/widgets-lib/src/locales/ko.json
@@ -586,7 +586,7 @@
         "body1": "도움이 필요하신가요?",
         "body2": " 문의하기 ",
         "body3": "지원팀",
-        "supportLink": "https://support.immutable.com/hc/en-us",
+        "supportLink": "https://support.immutable.com/hc",
         "passport": {
           "body1": "또는 귀하의 ",
           "body2": "패스포트"

--- a/packages/checkout/widgets-lib/src/locales/zh.json
+++ b/packages/checkout/widgets-lib/src/locales/zh.json
@@ -586,7 +586,7 @@
         "body1": "需要帮助吗？",
         "body2": " 联系 ",
         "body3": "支持",
-        "supportLink": "https://support.immutable.com/hc/en-us",
+        "supportLink": "https://support.immutable.com/hc",
         "passport": {
           "body1": "或在您的 ",
           "body2": "护照"

--- a/packages/checkout/widgets-lib/src/views/error/ErrorView.tsx
+++ b/packages/checkout/widgets-lib/src/views/error/ErrorView.tsx
@@ -52,7 +52,7 @@ export function ErrorView({
         <Link
           size="small"
           rc={
-            <a href="https://support.immutable.com/hc/en-us" />
+            <a href="https://support.immutable.com/hc" />
           }
         >
           {t('views.ERROR_VIEW.body', { returnObjects: true })[1]}


### PR DESCRIPTION
# Summary
Change Support link in Checkout Widgets to one that auto-detects the user's language based on their browser settings.