### PR TITLE
feat: ID-2334 Removed preload call from Magic SDK

### DIFF
--- a/packages/passport/sdk/src/Passport.int.test.ts
+++ b/packages/passport/sdk/src/Passport.int.test.ts
@@ -93,7 +93,6 @@ describe('Passport', () => {
     (Magic as jest.Mock).mockImplementation(() => ({
       openid: { loginWithOIDC: mockLoginWithOidc },
       rpcProvider: { request: mockMagicRequest },
-      preload: jest.fn(),
     }));
   });
 

--- a/packages/passport/sdk/src/magicAdapter.test.ts
+++ b/packages/passport/sdk/src/magicAdapter.test.ts
@@ -23,7 +23,6 @@ describe('MagicWallet', () => {
     magicProviderId: providerId,
   } as PassportConfiguration;
   const idToken = 'e30=.e30=.e30=';
-  const preload = jest.fn();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -35,7 +34,6 @@ describe('MagicWallet', () => {
         logout: logoutMock,
       },
       rpcProvider,
-      preload,
     }));
   });
 
@@ -56,7 +54,6 @@ describe('MagicWallet', () => {
       });
       it('starts initialising the magicClient', () => {
         jest.spyOn(window.document, 'readyState', 'get').mockReturnValue('complete');
-        preload.mockResolvedValue(Promise.resolve());
         const magicAdapter = new MagicAdapter(config);
         // @ts-ignore
         expect(magicAdapter.lazyMagicClient).toBeDefined();
@@ -83,7 +80,6 @@ describe('MagicWallet', () => {
 
   describe('login', () => {
     it('should call loginWithOIDC and initialise the provider with the correct arguments', async () => {
-      preload.mockResolvedValue(Promise.resolve());
       const magicAdapter = new MagicAdapter(config);
       const magicProvider = await magicAdapter.login(idToken);
 
@@ -101,7 +97,6 @@ describe('MagicWallet', () => {
     });
 
     it('should throw a PassportError when an error is thrown', async () => {
-      preload.mockResolvedValue(Promise.resolve());
       const magicAdapter = new MagicAdapter(config);
 
       loginWithOIDCMock.mockImplementation(() => {
@@ -121,7 +116,6 @@ describe('MagicWallet', () => {
 
   describe('logout', () => {
     it('calls the logout function', async () => {
-      preload.mockResolvedValue(Promise.resolve());
       const magicAdapter = new MagicAdapter(config);
       await magicAdapter.login(idToken);
       await magicAdapter.logout();

--- a/packages/passport/sdk/src/magicAdapter.ts
+++ b/packages/passport/sdk/src/magicAdapter.ts
@@ -24,7 +24,6 @@ export default class MagicAdapter {
           extensions: [new OpenIdExtension()],
           network: MAINNET, // We always connect to mainnet to ensure addresses are the same across envs
         });
-        client.preload();
         return client;
       });
     }


### PR DESCRIPTION
https://immutable.atlassian.net/browse/ID-2334

# Summary
This PR removes the `preload` call from the Magic SDK. This was actioned previously, but the change was rolled back.

## Removed
- Passport: Removed `preload` call from Magic SDK, as later versions of the Magic SDK trigger this call as part of the Magic constructor.
