### PR TITLE
chore: update the SDK_VERSION number in the sidebar file when a release is cut

### DIFF
--- a/.github/scripts/update-docs-link.sh
+++ b/.github/scripts/update-docs-link.sh
@@ -25,6 +25,15 @@ fi
       sed -i -E "s/SDK_VERSION = '.*'/SDK_VERSION = '$VERSION'/g;" $FILE
   fi
 
+  FILE2=sidebars/sidebars-docs.js
+  if [ "$(uname)" == "Darwin" ]; then
+      # On Mac OS, sed requires an empty string as an argument to -i to avoid creating a backup file
+      sed -i '' -E "s/SDK_VERSION = '.*'/SDK_VERSION = '$VERSION'/g;" $FILE2
+  else
+      sed -i -E "s/SDK_VERSION = '.*'/SDK_VERSION = '$VERSION'/g;" $FILE2
+  fi
+
+
   major=$(echo $VERSION | awk '{ 
     split($0, a, ".");
     print a[1];


### PR DESCRIPTION
# Summary

The docs site needs to link to the correct version number of the SDK Reference from the sidebar. This is not accessible using the existing `UnifiedSDKLink` component since the sidebar is part of the docusaurus configuration scripts, not the react app.

This change updates the SDK_VERSION parameter in the [sidebars/sidebar-docs.js](https://github.com/immutable/docs/blob/main/sidebars/sidebars-docs.js) file using the same technique as was used to update the SDK_VERSION in the UnifiedSDKLink component.

We will need to monitor this and make sure it works when the next release is published.