### PR TITLE
feat: ID-2416 tracking changes

### DIFF
--- a/packages/passport/sdk/src/utils/lazyLoad.ts
+++ b/packages/passport/sdk/src/utils/lazyLoad.ts
@@ -5,16 +5,18 @@ export const lazyLoad = <T, Y = void>(
 
 export const lazyDocumentReady = <T>(initialiseFunction: () => Promise<T> | T): Promise<T> => {
   const documentReadyPromise = () => new Promise<void>((resolve) => {
+    const onReadyStateChange = () => {
+      if (window.document.readyState === 'complete') {
+        resolve();
+        window.document.removeEventListener('readystatechange', onReadyStateChange);
+      }
+    };
+
+    // Add a handler before checking `readyState` to ensure that we don't miss the event
+    window.document.addEventListener('readystatechange', onReadyStateChange);
     if (window.document.readyState === 'complete') {
       resolve();
-    } else {
-      const onReadyStateChange = () => {
-        if (window.document.readyState === 'complete') {
-          resolve();
-          window.document.removeEventListener('readystatechange', onReadyStateChange);
-        }
-      };
-      window.document.addEventListener('readystatechange', onReadyStateChange);
+      window.document.removeEventListener('readystatechange', onReadyStateChange);
     }
   });
 

--- a/packages/passport/sdk/src/utils/metrics.test.ts
+++ b/packages/passport/sdk/src/utils/metrics.test.ts
@@ -16,7 +16,7 @@ describe('passport metrics', () => {
       const mockFn = jest.fn();
       mockFn.mockReturnValue(returnValue);
 
-      expect(withMetrics(mockFn, 'event')).toEqual(returnValue);
+      expect(withMetrics(mockFn, 'myFlow')).toEqual(returnValue);
     });
 
     it('should track and re-throw error', () => {
@@ -25,7 +25,7 @@ describe('passport metrics', () => {
       });
 
       try {
-        withMetrics(mockFn, 'event');
+        withMetrics(mockFn, 'myFlow');
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
         expect(error).toMatchObject({
@@ -34,7 +34,7 @@ describe('passport metrics', () => {
         expect(trackFlow).toBeCalledTimes(1);
         expect(trackError).toHaveBeenCalledWith(
           'passport',
-          'event',
+          'myFlow',
           error,
         );
       }
@@ -47,7 +47,7 @@ describe('passport metrics', () => {
       const mockFn = jest.fn();
       mockFn.mockResolvedValue(returnValue);
 
-      expect(await withMetricsAsync(mockFn, 'event')).toEqual(returnValue);
+      expect(await withMetricsAsync(mockFn, 'myFlow')).toEqual(returnValue);
     });
 
     it('should track and re-throw error', async () => {
@@ -55,7 +55,7 @@ describe('passport metrics', () => {
       errorFunction.mockRejectedValue(new Error('error'));
 
       try {
-        await withMetricsAsync(errorFunction, 'event');
+        await withMetricsAsync(errorFunction, 'myFlow');
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
         expect(error).toMatchObject({
@@ -64,7 +64,7 @@ describe('passport metrics', () => {
         expect(trackFlow).toBeCalledTimes(1);
         expect(trackError).toHaveBeenCalledWith(
           'passport',
-          'event',
+          'myFlow',
           error,
         );
       }

--- a/packages/passport/sdk/src/utils/metrics.ts
+++ b/packages/passport/sdk/src/utils/metrics.ts
@@ -1,16 +1,16 @@
-import { trackError, trackFlow } from '@imtbl/metrics';
+import { Flow, trackError, trackFlow } from '@imtbl/metrics';
 
 export const withMetrics = <T>(
-  fn: () => T,
-  event: string,
+  fn: (flow: Flow) => T,
+  flowName: string,
 ): T => {
-  const flow = trackFlow('passport', event);
+  const flow: Flow = trackFlow('passport', flowName);
 
   try {
-    return fn();
+    return fn(flow);
   } catch (error) {
     if (error instanceof Error) {
-      trackError('passport', event, error);
+      trackError('passport', flowName, error);
     }
     flow.addEvent('errored');
     throw error;
@@ -20,16 +20,16 @@ export const withMetrics = <T>(
 };
 
 export const withMetricsAsync = async <T>(
-  fn: () => Promise<T>,
-  event: string,
+  fn: (flow: Flow) => Promise<T>,
+  flowName: string,
 ): Promise<T> => {
-  const flow = trackFlow('passport', event);
+  const flow: Flow = trackFlow('passport', flowName);
 
   try {
-    return await fn();
+    return await fn(flow);
   } catch (error) {
     if (error instanceof Error) {
-      trackError('passport', event, error);
+      trackError('passport', flowName, error);
     }
     flow.addEvent('errored');
     throw error;


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
This PR wraps the `magicAdapter.login` method with a call to `withMetricsAsync` so that we have better visibility into interactions with Magic.

# Detail and impact of the change
## Added 
- Passport: Added additional Magic tracking

## Changed
- Passport: Updated `lazyLoad` to handle a hypothetical situation in which we do not add a listener before the `readystatechange` event is fired