### PR TITLE
[NO CHANGELOG][Balance Widget] fix: Use token icon if available

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/functions/tokenBalances.ts
@@ -48,12 +48,14 @@ export const getTokenBalances = async (
     ...balanceResult,
     token: {
       ...balanceResult.token,
-      icon: getTokenImageByAddress(
-        checkout.config.environment as Environment,
-        isNativeToken(balanceResult.token.address)
-          ? balanceResult.token.symbol
-          : balanceResult.token.address ?? '',
-      ),
+      icon:
+        balanceResult.token.icon
+        ?? getTokenImageByAddress(
+          checkout.config.environment as Environment,
+          isNativeToken(balanceResult.token.address)
+            ? balanceResult.token.symbol
+            : balanceResult.token.address ?? '',
+        ),
     },
   }));
 


### PR DESCRIPTION
# Summary
Use token icon when available instead of defaulting to checkout config icons

# Detail and impact of the change
Fixes broken token icons on Balances widget