### PR TITLE
fix: Remove manual step in type generator by updating generator template

### DIFF
--- a/packages/internal/generated-clients/templates/blockchain-data/apiInner.mustache
+++ b/packages/internal/generated-clients/templates/blockchain-data/apiInner.mustache
@@ -9,7 +9,7 @@ import { {{classname}} } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
 {{/imports}}
 {{#imports}}
 // @ts-ignore
-export { {{classname}} } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
+export type { {{classname}} } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
 {{/imports}}
 {{/withSeparateModelsAndApi}}
 {{^withSeparateModelsAndApi}}


### PR DESCRIPTION
# Summary

The manual step introduced to be compatible with swc can be automated by updating our internal custom generators

