### PR TITLE
fix: Passport sample app default transaction example hex encoding data string

### DIFF
--- a/packages/passport/sdk-sample-app/src/components/zkevm/EthSendTransactionExamples/DefaultTransaction.tsx
+++ b/packages/passport/sdk-sample-app/src/components/zkevm/EthSendTransactionExamples/DefaultTransaction.tsx
@@ -34,7 +34,7 @@ function ShowGenericConfirmationScreen({ disabled, handleExampleSubmitted }: Req
       setParams([{
         from: fromAddress,
         to: toAddress,
-        data: encUtils.utf8ToHex(data, true),
+        data: data.startsWith('0x') ? data : encUtils.utf8ToHex(data, true),
       }]);
     } catch (err) {
       setDataError(emptyDataError);


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

In the Passport Sample App, the `eth_sendTransaction` Default Transaction example always hex encodes the string entered into the `Data` field. If you want to enter a already hex encoded data string, like one you would get from the orderbook fulfill order endpoint, for example, the data string gets double encoded and submitting the transaction will fail with the error: `Request: Error: Transaction failed to submit with status FAILED. Error message: transaction failed to build: execution reverted`.

This small fix checks if the string has a `0x` prefix and only encodes the data string if it doesn't have a `0x` prefix.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->

## Fixed
- Re-encoding hex strings in the Passport sample app send transaction example.

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
