### PR TITLE
[NO CHANGELOG][OnRamp Widget] Spike: Add option to skip connect screen

### DIFF
--- a/packages/checkout/sdk/src/fiatRamp/fiatRamp.ts
+++ b/packages/checkout/sdk/src/fiatRamp/fiatRamp.ts
@@ -59,7 +59,6 @@ export class FiatRampService {
         ...widgetParams,
         email: encodeURIComponent(params.email),
         isAutoFillUserData: true,
-        disableWalletAddressForm: true,
       };
     }
 
@@ -84,6 +83,12 @@ export class FiatRampService {
       widgetParams = {
         ...widgetParams,
         walletAddress: params.walletAddress,
+        disableWalletAddressForm: true,
+      };
+    } else {
+      widgetParams = {
+        ...widgetParams,
+        disableWalletAddressForm: false,
       };
     }
 

--- a/packages/checkout/sdk/src/sdk.ts
+++ b/packages/checkout/sdk/src/sdk.ts
@@ -682,8 +682,11 @@ export class Checkout {
     let tokenSymbol = 'IMX';
     let email;
 
-    const walletAddress = await params.web3Provider.getSigner().getAddress();
-    const isPassport = (params.web3Provider.provider as any)?.isPassport || false;
+    let walletAddress = params.walletAddress || '';
+    if (params.web3Provider) {
+      walletAddress = await params.web3Provider.getSigner().getAddress();
+    }
+    const isPassport = (params.web3Provider?.provider as any)?.isPassport || false;
 
     if (isPassport && params.passport) {
       const userInfo = await params.passport.getUserInfo();

--- a/packages/checkout/sdk/src/types/fiatRamp.ts
+++ b/packages/checkout/sdk/src/types/fiatRamp.ts
@@ -20,8 +20,9 @@ export enum ExchangeType {
  */
 export interface FiatRampParams {
   exchangeType: ExchangeType;
-  web3Provider: Web3Provider;
+  web3Provider?: Web3Provider;
   tokenAmount?: string;
   tokenAddress?: string;
+  walletAddress?: string;
   passport?: any;
 }

--- a/packages/checkout/sdk/src/widgets/definitions/parameters/checkout.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/parameters/checkout.ts
@@ -42,7 +42,7 @@ export type CheckouWidgetSaleFlowParams = {
   flow: CheckoutFlowType.SALE;
 } & SaleWidgetParams;
 
-export type CheckouWidgetAddFundsFlowParams = {
+export type CheckoutWidgetAddFundsFlowParams = {
   flow: CheckoutFlowType.ADD_FUNDS;
 } & AddFundsWidgetParams;
 
@@ -53,7 +53,7 @@ export type CheckoutWidgetFlowParams =
   | CheckouWidgetBridgeFlowParams
   | CheckouWidgetOnRampFlowParams
   | CheckouWidgetSaleFlowParams
-  | CheckouWidgetAddFundsFlowParams;
+  | CheckoutWidgetAddFundsFlowParams;
 
 export type CheckoutWidgetParams = {
   /** The language to use for the checkout widget */

--- a/packages/checkout/sdk/src/widgets/definitions/parameters/onramp.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/parameters/onramp.ts
@@ -17,4 +17,8 @@ export type OnRampWidgetParams = {
   language?: WidgetLanguage;
   /** Whether to show a back button on the first screen, on click triggers REQUEST_GO_BACK event */
   showBackButton?: boolean;
+  /** Whether to skip the connect screen */
+  skipConnect?: boolean;
+  /** The destination wallet address to receive the funds */
+  toWalletAddress?: string;
 };

--- a/packages/checkout/widgets-lib/src/views/top-up/TopUpView.tsx
+++ b/packages/checkout/widgets-lib/src/views/top-up/TopUpView.tsx
@@ -10,7 +10,6 @@ import {
   IMTBLWidgetEvents,
 } from '@imtbl/checkout-sdk';
 import { Environment } from '@imtbl/config';
-import { Web3Provider } from '@ethersproject/providers';
 import { useTranslation } from 'react-i18next';
 import {
   UserJourney,
@@ -44,7 +43,6 @@ type $Dictionary<T = unknown> = { [key: string]: T };
 interface TopUpViewProps {
   widgetEvent: IMTBLWidgetEvents;
   checkout?: Checkout;
-  provider?: Web3Provider;
   showOnrampOption: boolean;
   showSwapOption: boolean;
   showBridgeOption: boolean;
@@ -77,7 +75,7 @@ export function TopUpView({
   widgetEvent,
   checkout,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  provider, // Keep this for future use
+  // provider, // Keep this for future use
   showOnrampOption,
   showSwapOption,
   showBridgeOption,

--- a/packages/checkout/widgets-lib/src/widgets/checkout/CheckoutWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/checkout/CheckoutWidgetRoot.tsx
@@ -5,6 +5,14 @@ import {
   WidgetProperties,
   WidgetTheme,
   WidgetType,
+  CheckoutWidgetConnectFlowParams,
+  CheckoutWidgetWalletFlowParams,
+  CheckoutWidgetAddFundsFlowParams,
+  CheckouWidgetSwapFlowParams,
+  CheckouWidgetBridgeFlowParams,
+  CheckouWidgetOnRampFlowParams,
+  CheckouWidgetSaleFlowParams,
+  CheckoutFlowType,
 } from '@imtbl/checkout-sdk';
 import React, { Suspense } from 'react';
 import { ThemeProvider } from '../../components/ThemeProvider/ThemeProvider';
@@ -13,6 +21,13 @@ import { HandoverProvider } from '../../context/handover-context/HandoverProvide
 import { LoadingView } from '../../views/loading/LoadingView';
 import { Base } from '../BaseWidgetRoot';
 import i18n from '../../i18n';
+import {
+  isValidAddress,
+  isValidAmount,
+  isValidWalletProvider,
+} from '../../lib/validations/widgetValidators';
+import { deduplicateSaleItemsArray } from './functions/deduplicateSaleItemsArray';
+import { checkoutFlows } from './functions/isValidCheckoutFlow';
 
 const CheckoutWidget = React.lazy(() => import('./CheckoutWidget'));
 
@@ -37,11 +52,191 @@ export class CheckoutWidgetRoot extends Base<WidgetType.CHECKOUT> {
     };
   }
 
+  protected getValidConnectFlowParams(params: CheckoutWidgetConnectFlowParams) {
+    const validatedParams = { ...params };
+
+    if (!Array.isArray(validatedParams.blocklistWalletRdns)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "blocklistWalletRdns" widget input');
+      validatedParams.blocklistWalletRdns = [];
+    }
+
+    return validatedParams;
+  }
+
+  protected getValidWalletFlowParams(params: CheckoutWidgetWalletFlowParams) {
+    return params;
+  }
+
+  protected getValidSaleFlowParams(params: CheckouWidgetSaleFlowParams) {
+    const validatedParams = { ...params };
+
+    if (!isValidWalletProvider(params.walletProviderName)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "walletProviderName" widget input');
+      validatedParams.walletProviderName = undefined;
+    }
+
+    if (!Array.isArray(validatedParams.items)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "items" widget input.');
+      validatedParams.items = [];
+    }
+
+    if (!params.environmentId) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "environmentId" widget input');
+      validatedParams.environmentId = '';
+    }
+
+    if (!params.collectionName) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "collectionName" widget input');
+      validatedParams.collectionName = '';
+    }
+
+    if (
+      params.excludePaymentTypes !== undefined
+      && !Array.isArray(params.excludePaymentTypes)
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "excludePaymentTypes" widget input');
+      validatedParams.excludePaymentTypes = [];
+    }
+
+    return {
+      ...validatedParams,
+      items: deduplicateSaleItemsArray(params.items),
+    };
+  }
+
+  protected getValidAddFundsFlowParams(
+    params: CheckoutWidgetAddFundsFlowParams,
+  ) {
+    const validatedParams = { ...params };
+
+    if (validatedParams.showBridgeOption) {
+      validatedParams.showBridgeOption = true;
+    }
+
+    if (validatedParams.showOnrampOption) {
+      validatedParams.showOnrampOption = true;
+    }
+
+    if (validatedParams.showSwapOption) {
+      validatedParams.showSwapOption = true;
+    }
+
+    if (!isValidAmount(validatedParams.toAmount)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "toAmount" widget input');
+      validatedParams.toAmount = '';
+    }
+
+    if (!isValidAddress(params.toTokenAddress)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "toTokenAddress" widget input');
+      validatedParams.toTokenAddress = '';
+    }
+
+    return validatedParams;
+  }
+
+  protected getValidSwapFlowParams(params: CheckouWidgetSwapFlowParams) {
+    const validatedParams = { ...params };
+
+    if (!isValidAmount(params.amount)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "amount" widget input');
+      validatedParams.amount = '';
+    }
+
+    if (!isValidAddress(params.fromTokenAddress)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "fromTokenAddress" widget input');
+      validatedParams.fromTokenAddress = '';
+    }
+
+    if (!isValidAddress(params.toTokenAddress)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "toTokenAddress" widget input');
+      validatedParams.toTokenAddress = '';
+    }
+
+    if (params.autoProceed) {
+      validatedParams.autoProceed = true;
+    }
+
+    return validatedParams;
+  }
+
+  protected getValidBridgeFlowParams(params: CheckouWidgetBridgeFlowParams) {
+    const validatedParams = { ...params };
+
+    if (!isValidAmount(params.amount)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "amount" widget input');
+      validatedParams.amount = '';
+    }
+
+    if (!isValidAddress(params.tokenAddress)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "tokenAddress" widget input');
+      validatedParams.tokenAddress = '';
+    }
+
+    return validatedParams;
+  }
+
+  protected getValidOnRampFlowParams(params: CheckouWidgetOnRampFlowParams) {
+    const validatedParams = { ...params };
+
+    if (!isValidAmount(params.amount)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "amount" widget input');
+      validatedParams.amount = '';
+    }
+
+    if (!isValidAddress(params.tokenAddress)) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "tokenAddress" widget input');
+      validatedParams.tokenAddress = '';
+    }
+
+    return validatedParams;
+  }
+
   protected getValidatedParameters(
     params: CheckoutWidgetParams,
   ): CheckoutWidgetParams {
-    // TODO: Validate params for each widget
-    return params;
+    // if empty do nothing
+    if (Object.keys(params).length === 0) {
+      return params;
+    }
+
+    const flowType = params.flow;
+    const supportedFlows = checkoutFlows.join(', ');
+
+    switch (flowType) {
+      case CheckoutFlowType.CONNECT:
+        return this.getValidConnectFlowParams(params);
+      case CheckoutFlowType.WALLET:
+        return this.getValidWalletFlowParams(params);
+      case CheckoutFlowType.SALE:
+        return this.getValidSaleFlowParams(params);
+      case CheckoutFlowType.SWAP:
+        return this.getValidSwapFlowParams(params);
+      case CheckoutFlowType.BRIDGE:
+        return this.getValidBridgeFlowParams(params);
+      case CheckoutFlowType.ONRAMP:
+        return this.getValidOnRampFlowParams(params);
+      case CheckoutFlowType.ADD_FUNDS:
+        return this.getValidAddFundsFlowParams(params);
+      default:
+        throw new Error(
+          `[IMTBL]: invalid "flow: ${flowType}" widget input, must be one of the following: ${supportedFlows}`,
+        );
+    }
   }
 
   protected render() {

--- a/packages/checkout/widgets-lib/src/widgets/checkout/functions/deduplicateSaleItemsArray.ts
+++ b/packages/checkout/widgets-lib/src/widgets/checkout/functions/deduplicateSaleItemsArray.ts
@@ -1,0 +1,20 @@
+import { SaleItem } from '@imtbl/checkout-sdk';
+
+export function deduplicateSaleItemsArray(items: SaleItem[] | undefined): SaleItem[] {
+  if (!items || !Array.isArray(items)) return [];
+
+  const uniqueItems = items.reduce((acc, item) => {
+    const itemIndex = acc.findIndex(
+      ({ productId }) => productId === item.productId,
+    );
+
+    if (itemIndex !== -1) {
+      acc[itemIndex] = { ...item, qty: acc[itemIndex].qty + item.qty };
+      return acc;
+    }
+
+    return [...acc, { ...item }];
+  }, [] as SaleItem[]);
+
+  return uniqueItems;
+}

--- a/packages/checkout/widgets-lib/src/widgets/checkout/functions/isValidCheckoutFlow.ts
+++ b/packages/checkout/widgets-lib/src/widgets/checkout/functions/isValidCheckoutFlow.ts
@@ -1,0 +1,19 @@
+import { CheckoutFlowType } from '@imtbl/checkout-sdk';
+
+/** Orchestration Events List */
+export const checkoutFlows = [
+  CheckoutFlowType.CONNECT,
+  CheckoutFlowType.WALLET,
+  CheckoutFlowType.SALE,
+  CheckoutFlowType.SWAP,
+  CheckoutFlowType.BRIDGE,
+  CheckoutFlowType.ONRAMP,
+  CheckoutFlowType.ADD_FUNDS,
+];
+
+/**
+ * Check if event is orchestration event
+ */
+export function isValidCheckoutFlow(flow: string): boolean {
+  return checkoutFlows.includes(flow as CheckoutFlowType);
+}

--- a/packages/checkout/widgets-lib/src/widgets/on-ramp/OnRampWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/on-ramp/OnRampWidget.tsx
@@ -1,14 +1,20 @@
+import { useContext, useMemo, useReducer } from 'react';
 import {
-  useContext, useEffect, useMemo, useReducer, useState,
-} from 'react';
-import { IMTBLWidgetEvents, OnRampWidgetParams } from '@imtbl/checkout-sdk';
+  Checkout,
+  IMTBLWidgetEvents,
+  OnRampWidgetParams,
+} from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
+import { Web3Provider } from '@ethersproject/providers';
 import { UserJourney } from '../../context/analytics-provider/SegmentAnalyticsProvider';
 import { NATIVE } from '../../lib';
 import { StrongCheckoutWidgetsConfig } from '../../lib/withDefaultWidgetConfig';
 import {
   SharedViews,
-  ViewActions, ViewContext, initialViewState, viewReducer,
+  ViewActions,
+  ViewContext,
+  initialViewState,
+  viewReducer,
 } from '../../context/view-context/ViewContext';
 import {
   OnRampFailView,
@@ -16,9 +22,12 @@ import {
   OnRampWidgetViews,
 } from '../../context/view-context/OnRampViewContextTypes';
 import { LoadingView } from '../../views/loading/LoadingView';
-import { ConnectLoaderContext } from '../../context/connect-loader-context/ConnectLoaderContext';
 import { TopUpView } from '../../views/top-up/TopUpView';
-import { sendOnRampFailedEvent, sendOnRampSuccessEvent, sendOnRampWidgetCloseEvent } from './OnRampWidgetEvents';
+import {
+  sendOnRampFailedEvent,
+  sendOnRampSuccessEvent,
+  sendOnRampWidgetCloseEvent,
+} from './OnRampWidgetEvents';
 import { OnRampMain } from './views/OnRampMain';
 import { StatusType } from '../../components/Status/StatusType';
 import { StatusView } from '../../components/Status/StatusView';
@@ -26,26 +35,38 @@ import { EventTargetContext } from '../../context/event-target-context/EventTarg
 import { OrderInProgress } from './views/OrderInProgress';
 
 export type OnRampWidgetInputs = OnRampWidgetParams & {
-  config: StrongCheckoutWidgetsConfig
+  config: StrongCheckoutWidgetsConfig;
+  checkout: Checkout;
+  web3Provider?: Web3Provider;
 };
 
 export default function OnRampWidget({
-  amount, tokenAddress, config, showBackButton,
+  amount,
+  tokenAddress,
+  config,
+  showBackButton,
+  checkout,
+  web3Provider,
+  toWalletAddress,
 }: OnRampWidgetInputs) {
-  const {
-    isOnRampEnabled, isSwapEnabled, isBridgeEnabled,
-  } = config;
+  const { isOnRampEnabled, isSwapEnabled, isBridgeEnabled } = config;
   const [viewState, viewDispatch] = useReducer(viewReducer, {
     ...initialViewState,
     history: [],
   });
-  const viewReducerValues = useMemo(() => ({ viewState, viewDispatch }), [viewState, viewReducer]);
+  const viewReducerValues = useMemo(
+    () => ({ viewState, viewDispatch }),
+    [viewState, viewReducer],
+  );
 
-  const { connectLoaderState } = useContext(ConnectLoaderContext);
-  const { checkout, provider } = connectLoaderState;
-  const [tknAddr, setTknAddr] = useState(tokenAddress);
+  const tknAddr = useMemo(
+    () => (tokenAddress?.toLocaleLowerCase() === NATIVE ? NATIVE : tokenAddress),
+    [tokenAddress],
+  );
 
-  const { eventTargetState: { eventTarget } } = useContext(EventTargetContext);
+  const {
+    eventTargetState: { eventTarget },
+  } = useContext(EventTargetContext);
 
   const { t } = useTranslation();
 
@@ -54,91 +75,73 @@ export default function OnRampWidget({
     [viewState.view.type],
   );
 
-  useEffect(() => {
-    if (!checkout || !provider) return;
-    (async () => {
-      const network = await checkout.getNetworkInfo({
-        provider,
-      });
-      /* If the provider's network is not supported, return out of this and let the
-    connect loader handle the switch network functionality */
-      if (!network.isSupported) {
-        return;
-      }
-      const address = tknAddr?.toLocaleLowerCase() === NATIVE
-        ? NATIVE
-        : tokenAddress;
-
-      setTknAddr(address);
-    })();
-  }, [checkout, provider, viewDispatch]);
-
   return (
     <ViewContext.Provider value={viewReducerValues}>
       {viewState.view.type === SharedViews.LOADING_VIEW && (
-      <LoadingView loadingText={t('views.ONRAMP.initialLoadingText')} />
+        <LoadingView loadingText={t('views.ONRAMP.initialLoadingText')} />
       )}
       {viewState.view.type === OnRampWidgetViews.IN_PROGRESS_LOADING && (
-      <LoadingView loadingText={t('views.ONRAMP.IN_PROGRESS_LOADING.loading.text')} />
+        <LoadingView
+          loadingText={t('views.ONRAMP.IN_PROGRESS_LOADING.loading.text')}
+        />
       )}
       {viewState.view.type === OnRampWidgetViews.IN_PROGRESS && (
-      <OrderInProgress />
+        <OrderInProgress />
       )}
 
       {viewState.view.type === OnRampWidgetViews.SUCCESS && (
-      <StatusView
-        statusText={t('views.ONRAMP.SUCCESS.text')}
-        actionText={t('views.ONRAMP.SUCCESS.actionText')}
-        onRenderEvent={() => sendOnRampSuccessEvent(
-          eventTarget,
-          (viewState.view as OnRampSuccessView).data.transactionHash,
-        )}
-        onActionClick={() => sendOnRampWidgetCloseEvent(eventTarget)}
-        statusType={StatusType.SUCCESS}
-        testId="success-view"
-      />
+        <StatusView
+          statusText={t('views.ONRAMP.SUCCESS.text')}
+          actionText={t('views.ONRAMP.SUCCESS.actionText')}
+          onRenderEvent={() => sendOnRampSuccessEvent(
+            eventTarget,
+            (viewState.view as OnRampSuccessView).data.transactionHash,
+          )}
+          onActionClick={() => sendOnRampWidgetCloseEvent(eventTarget)}
+          statusType={StatusType.SUCCESS}
+          testId="success-view"
+        />
       )}
 
       {viewState.view.type === OnRampWidgetViews.FAIL && (
-      <StatusView
-        statusText={t('views.ONRAMP.FAIL.text')}
-        actionText={t('views.ONRAMP.FAIL.actionText')}
-        onRenderEvent={() => sendOnRampFailedEvent(
-          eventTarget,
-          (viewState.view as OnRampFailView).reason
-                  ?? 'Transaction failed',
-        )}
-        onActionClick={() => {
-          viewDispatch({
-            payload: {
-              type: ViewActions.UPDATE_VIEW,
-              view: {
-                type: OnRampWidgetViews.ONRAMP,
-                data: viewState.view.data,
+        <StatusView
+          statusText={t('views.ONRAMP.FAIL.text')}
+          actionText={t('views.ONRAMP.FAIL.actionText')}
+          onRenderEvent={() => sendOnRampFailedEvent(
+            eventTarget,
+            (viewState.view as OnRampFailView).reason ?? 'Transaction failed',
+          )}
+          onActionClick={() => {
+            viewDispatch({
+              payload: {
+                type: ViewActions.UPDATE_VIEW,
+                view: {
+                  type: OnRampWidgetViews.ONRAMP,
+                  data: viewState.view.data,
+                },
               },
-            },
-          });
-        }}
-        statusType={StatusType.FAILURE}
-        onCloseClick={() => sendOnRampWidgetCloseEvent(eventTarget)}
-        testId="fail-view"
-      />
+            });
+          }}
+          statusType={StatusType.FAILURE}
+          onCloseClick={() => sendOnRampWidgetCloseEvent(eventTarget)}
+          testId="fail-view"
+        />
       )}
 
       {/* This keeps Transak's iframe instance in dom to listen to transak's events. */}
       {/* We will remove the iframe instance once the processing has been finalised, either as a success or a failure */}
-      {(viewState.view.type !== OnRampWidgetViews.SUCCESS
-        && viewState.view.type !== OnRampWidgetViews.FAIL
-      ) && (
-        <OnRampMain
-          passport={checkout?.passport}
-          showIframe={showIframe}
-          tokenAmount={amount ?? viewState.view.data?.amount}
-          tokenAddress={
-              tknAddr ?? viewState.view.data?.tokenAddress
-          }
-          showBackButton={showBackButton}
-        />
+      {viewState.view.type !== OnRampWidgetViews.SUCCESS
+        && viewState.view.type !== OnRampWidgetViews.FAIL && (
+          <OnRampMain
+            passport={checkout?.passport}
+            showIframe={showIframe}
+            tokenAmount={amount ?? viewState.view.data?.amount}
+            tokenAddress={tknAddr ?? viewState.view.data?.tokenAddress}
+            toWalletAddress={toWalletAddress}
+            showBackButton={showBackButton}
+            checkout={checkout}
+            provider={web3Provider}
+          />
       )}
 
       {viewState.view.type === SharedViews.TOP_UP_VIEW && (
@@ -146,7 +149,6 @@ export default function OnRampWidget({
           analytics={{ userJourney: UserJourney.ON_RAMP }}
           widgetEvent={IMTBLWidgetEvents.IMTBL_ONRAMP_WIDGET_EVENT}
           checkout={checkout}
-          provider={provider}
           showOnrampOption={isOnRampEnabled}
           showSwapOption={isSwapEnabled}
           showBridgeOption={isBridgeEnabled}

--- a/packages/checkout/widgets-sample-app/src/components/ui/checkout/checkout.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/checkout/checkout.tsx
@@ -340,7 +340,7 @@ function CheckoutUI() {
 
   // mount & re-render widget everytime params change
   useEffect(() => {
-    if (params == undefined) return;
+    if (params?.flow === undefined) return;
     if (renderAfterConnect && !web3Provider) return;
 
     mount();

--- a/packages/checkout/widgets-sample-app/src/components/ui/on-ramp/onRamp.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/on-ramp/onRamp.tsx
@@ -1,38 +1,86 @@
-import { Checkout, OnRampEventType, WidgetTheme, WidgetType } from "@imtbl/checkout-sdk";
-import { useEffect, useMemo } from "react";
+import {
+  Checkout,
+  OnRampEventType,
+  WidgetTheme,
+  WidgetType,
+} from "@imtbl/checkout-sdk";
+import { useEffect, useMemo, useState } from "react";
 import { WidgetsFactory } from "@imtbl/checkout-widgets";
 
 function OnRampUI() {
-  const checkout = useMemo(() => new Checkout(), [])
-  const onRamp = useMemo(() => new WidgetsFactory(checkout, {}).create(WidgetType.ONRAMP), [checkout])
+  const checkout = useMemo(() => new Checkout(), []);
+  const onRamp = useMemo(
+    () => new WidgetsFactory(checkout, {}).create(WidgetType.ONRAMP),
+    [checkout]
+  );
+  const [skipConnect, setSkipConnect] = useState<boolean>(false);
+  const [toWalletAddress, setToWalletAddress] = useState<string>("");
 
-  const unmount = () => {onRamp.unmount()}
+  const unmount = () => {
+    onRamp.unmount();
+  };
   const mount = () => {
-    onRamp.mount('onramp', {amount: '55', tokenAddress: '0x0000000000000000000000000000000000001010'})}
-  const update = (theme: WidgetTheme) => {onRamp.update({config: {theme}})}
+    onRamp.mount("onramp", {
+      amount: "55",
+      tokenAddress: "0x0000000000000000000000000000000000001010",
+      skipConnect,
+      toWalletAddress,
+    });
+  };
+  const update = (theme: WidgetTheme) => {
+    onRamp.update({ config: { theme } });
+  };
 
   useEffect(() => {
-    mount()
+    // if skipConnect is true, wait until toWalletAddress is set
+    if (skipConnect && !toWalletAddress) return;
+
+    mount();
     onRamp.addListener(OnRampEventType.SUCCESS, (data) => {
-      console.log('SUCCESS', data)
-    })
+      console.log("SUCCESS", data);
+    });
     onRamp.addListener(OnRampEventType.FAILURE, (data) => {
-      console.log('FAILURE', data)
-    })
+      console.log("FAILURE", data);
+    });
     onRamp.addListener(OnRampEventType.CLOSE_WIDGET, () => {
-      unmount()
-    })
-  }, []);
+      unmount();
+    });
+  }, [skipConnect]);
 
   return (
     <div>
-    <h1 className="sample-heading">Checkout OnRamp</h1>
-    <div id="onramp"></div>
-    <button onClick={unmount}>Unmount</button>
-    <button onClick={mount}>Mount</button>
-    <button onClick={() => update(WidgetTheme.LIGHT)}>Update Config Light</button>
-    <button onClick={() => update(WidgetTheme.DARK)}>Update Config Dark</button>
-  </div>
+      <h1 className="sample-heading">Checkout OnRamp</h1>
+      <div id="onramp"></div>
+      <button onClick={unmount}>Unmount</button>
+      <button onClick={mount}>Mount</button>
+      <button onClick={() => update(WidgetTheme.LIGHT)}>
+        Update Config Light
+      </button>
+      <button onClick={() => update(WidgetTheme.DARK)}>
+        Update Config Dark
+      </button>
+      <div style={{ marginTop: "1rem" }}>
+        <button
+          onClick={() => {
+            unmount();
+            setSkipConnect((prev) => !prev);
+          }}
+        >
+          Skip Connect {skipConnect ? "ON" : "OFF"}
+        </button>
+        {skipConnect && !toWalletAddress && (
+          <p>Please enter a destination wallet address:</p>
+        )}
+        {skipConnect && (
+          <input
+            placeholder="To Wallet Address"
+            type="text"
+            value={toWalletAddress}
+            onChange={(e) => setToWalletAddress(e.target.value)}
+          />
+        )}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
# Summary
Ramping tokens with Transak does not require users to connect their wallet first, as they can provide the address later in Transak's form. However, connecting the wallet beforehand is preferable to ensure transfer of funds to the correct wallet.

In addition, the tracking events require wallet address to be set.

The changes required to support an on-ramp flow without wallet connection are as follows:

- Conditionally wrap the `onRamp` component with a `ConnectLoader`, using a `skipConnect` flag to control this behavior.
- Eliminate the dependency on the `ConnectLoader` state by passing `checkout` and `provider` instances directly from the widget root, instead of relying on the `ConnectLoader` state.
- Introduce `toWalletAddress` as a parameter, as it is needed for analytics and ensures that the wallet address is available upfront. The option to skip the connect step will only be allowed if the user is already logged into the application initiating the on-ramp. In cases where the wallet address is not provided by the app, connecting will remain a requirement.
