### PR TITLE
ITSEC-2205 Add Dependency Review workflow

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,26 @@
+name: 'Dependency Review'
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          # Possible values: "critical", "high", "moderate", "low"
+          fail-on-severity: critical
+
+          # Address https://github.com/actions/dependency-review-action/issues/456
+          base-ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
# Summary
Adds Dependency Review GitHub feature https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#about-dependency-review for new Critical vulnerabilities only.

# Detail and impact of the change
No new PRs will be blocked yet. This will be running in the monitoring mode until we're happy that it works flawlessly. 
