### PR TITLE
[NO CHANGELOG] [Add Funds Widget] CM-997 | Preset and lock deliver to wallet

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/parameters/addFunds.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/parameters/addFunds.ts
@@ -1,3 +1,4 @@
+import { Web3Provider } from '@ethersproject/providers';
 import { WidgetLanguage } from '../configurations';
 
 export type AddFundsWidgetParams = {
@@ -21,4 +22,7 @@ export type AddFundsWidgetParams = {
 
   /** Whether to show a back button on the first screen, on click triggers REQUEST_GO_BACK event */
   showBackButton?: boolean;
+
+  /** The destination wallet provider, when requiring to lock destination of funds */
+  toProvider?: Web3Provider;
 };

--- a/packages/checkout/widgets-lib/src/context/providers-context/ProvidersContext.tsx
+++ b/packages/checkout/widgets-lib/src/context/providers-context/ProvidersContext.tsx
@@ -1,10 +1,14 @@
 import {
   createContext,
-  useContext, useMemo,
+  useContext,
+  useMemo,
   useReducer,
+  useEffect,
 } from 'react';
 import { Web3Provider } from '@ethersproject/providers';
 import { Checkout, EIP6963ProviderInfo } from '@imtbl/checkout-sdk';
+import { getProviderDetailByProvider } from '../../lib/provider/utils';
+import { connectEIP6963Provider } from '../../lib/connectEIP6963Provider';
 
 export interface ProvidersState {
   fromProvider?: Web3Provider;
@@ -14,6 +18,7 @@ export interface ProvidersState {
   toProviderInfo?: EIP6963ProviderInfo;
   toAddress?: string;
   checkout: Checkout;
+  lockedToProvider?: boolean;
 }
 
 export const initialProvidersState: ProvidersState = {
@@ -24,6 +29,7 @@ export const initialProvidersState: ProvidersState = {
   toProviderInfo: undefined,
   toAddress: undefined,
   checkout: {} as Checkout,
+  lockedToProvider: false,
 };
 
 export interface ProvidersContextState {
@@ -38,12 +44,14 @@ export interface ProvidersContextAction {
 type ProvidersContextActionPayload =
   | SetProviderPayload
   | SetCheckoutPayload
-  | ResetStatePayload;
+  | ResetStatePayload
+  | SetLockedToProviderPayload;
 
 export enum ProvidersContextActions {
   SET_PROVIDER = 'SET_PROVIDER',
   SET_CHECKOUT = 'SET_CHECKOUT',
   RESET_STATE = 'RESET_STATE',
+  SET_LOCKED_TO_PROVIDER = 'SET_LOCKED_TO_PROVIDER',
 }
 
 export interface SetProviderPayload {
@@ -66,6 +74,11 @@ export interface ResetStatePayload {
   fromProvider?: Web3Provider;
   toProvider?: Web3Provider;
   checkout: Checkout;
+}
+
+export interface SetLockedToProviderPayload {
+  type: ProvidersContextActions.SET_LOCKED_TO_PROVIDER;
+  lockedToProvider: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -114,6 +127,11 @@ ProvidersContextAction
       return {
         ...initialProvidersState,
       };
+    case ProvidersContextActions.SET_LOCKED_TO_PROVIDER:
+      return {
+        ...state,
+        lockedToProvider: action.payload.lockedToProvider,
+      };
     default:
       return state;
   }
@@ -141,6 +159,43 @@ export function ProvidersContextProvider({
     () => ({ providersState, providersDispatch }),
     [providersState, providersDispatch],
   );
+
+  const { toProvider, checkout } = initialState;
+
+  // if `toProvider` is passed, try to connect and get EIP6963 provider info
+  useEffect(() => {
+    if (!toProvider || providersState.lockedToProvider) return;
+
+    (async () => {
+      const injectedProviders = checkout.getInjectedProviders();
+      const providerDetail = getProviderDetailByProvider(toProvider, [
+        ...injectedProviders,
+      ]);
+
+      if (!providerDetail) return;
+
+      try {
+        await connectEIP6963Provider(providerDetail, checkout, false);
+        const toAddress = await toProvider.getSigner().getAddress();
+        providersDispatch({
+          payload: {
+            type: ProvidersContextActions.SET_PROVIDER,
+            toProvider,
+            toAddress,
+            toProviderInfo: providerDetail.info,
+          },
+        });
+        providersDispatch({
+          payload: {
+            type: ProvidersContextActions.SET_LOCKED_TO_PROVIDER,
+            lockedToProvider: true,
+          },
+        });
+      } catch {
+        /** TODO: handle error */
+      }
+    })();
+  }, [toProvider, providersState.lockedToProvider]);
 
   return (
     <ProvidersContext.Provider value={value}>

--- a/packages/checkout/widgets-lib/src/lib/provider/utils.ts
+++ b/packages/checkout/widgets-lib/src/lib/provider/utils.ts
@@ -13,6 +13,13 @@ export function isWalletConnectProvider(provider?: Web3Provider | null) {
   return (provider?.provider as any)?.isWalletConnect === true;
 }
 
+export const getProviderDetailByProvider = (
+  web3Provider: Web3Provider,
+  providers?: EIP6963ProviderDetail[],
+) => providers?.find(
+  (providerDetail) => providerDetail.provider === web3Provider.provider,
+);
+
 export function getWalletProviderNameByProvider(
   web3Provider: Web3Provider | undefined,
   providers?: EIP6963ProviderDetail[],
@@ -23,7 +30,10 @@ export function getWalletProviderNameByProvider(
 
   if (providers && web3Provider) {
     // Find the matching provider in the providerDetail
-    const matchedProviderDetail = providers.find((providerDetail) => providerDetail.provider === web3Provider.provider);
+    const matchedProviderDetail = getProviderDetailByProvider(
+      web3Provider,
+      providers,
+    );
     if (matchedProviderDetail) {
       return matchedProviderDetail.info.name;
     }

--- a/packages/checkout/widgets-lib/src/widgets/add-funds/AddFundsRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-funds/AddFundsRoot.tsx
@@ -55,6 +55,12 @@ export class AddFunds extends Base<WidgetType.ADD_FUNDS> {
       console.warn('[IMTBL]: invalid "toTokenAddress" widget input');
     }
 
+    if (!params.toProvider?.provider) {
+      // eslint-disable-next-line no-console
+      console.warn('[IMTBL]: invalid "toProvider" widget input');
+      validatedParams.toProvider = undefined;
+    }
+
     return validatedParams;
   }
 
@@ -69,7 +75,10 @@ export class AddFunds extends Base<WidgetType.ADD_FUNDS> {
           <ThemeProvider id="add-funds-container" config={this.strongConfig()}>
             <HandoverProvider>
               <ProvidersContextProvider
-                initialState={{ checkout: this.checkout }}
+                initialState={{
+                  checkout: this.checkout,
+                  toProvider: this.parameters.toProvider,
+                }}
               >
                 <Suspense
                   fallback={

--- a/packages/checkout/widgets-lib/src/widgets/add-funds/AddFundsWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-funds/AddFundsWidget.tsx
@@ -44,7 +44,7 @@ import { amountInputValidation } from '../../lib/validations/amountInputValidati
 import { useError } from './hooks/useError';
 import { AddFundsErrorTypes } from './types';
 
-export type AddFundsWidgetInputs = AddFundsWidgetParams & {
+export type AddFundsWidgetInputs = Omit<AddFundsWidgetParams, 'toProvider'> & {
   config: StrongCheckoutWidgetsConfig;
 };
 

--- a/packages/checkout/widgets-lib/src/widgets/add-funds/components/SelectedWallet.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-funds/components/SelectedWallet.tsx
@@ -2,15 +2,17 @@ import { MouseEventHandler, ReactNode } from 'react';
 import { EllipsizedText, MenuItem, MenuItemProps } from '@biom3/react';
 import { EIP6963ProviderInfo } from '@imtbl/checkout-sdk';
 
+const disabledStyles = {
+  cursor: 'not-allowed',
+  bg: 'base.color.translucent.inverse.800',
+};
+
 export interface SelectedWalletProps {
   children?: ReactNode;
   label: string;
-  providerInfo?: Partial<
-  EIP6963ProviderInfo & {
-    address?: string;
-  }
-  >;
+  providerInfo?: Partial<EIP6963ProviderInfo & { address?: string }>;
   onClick: MouseEventHandler<HTMLSpanElement>;
+  disabled?: boolean;
 }
 
 export function SelectedWallet({
@@ -18,6 +20,7 @@ export function SelectedWallet({
   children,
   onClick,
   providerInfo,
+  disabled,
 }: SelectedWalletProps) {
   const selected = !!children && providerInfo?.rdns;
   const size: MenuItemProps['size'] = selected ? 'xSmall' : 'small';
@@ -25,9 +28,13 @@ export function SelectedWallet({
   return (
     <MenuItem
       size={size}
-      emphasized
-      onClick={onClick}
-      sx={selected ? { py: 'base.spacing.x3' } : undefined}
+      disabled={disabled}
+      emphasized={!disabled}
+      onClick={disabled ? undefined : onClick}
+      sx={{
+        py: selected ? 'base.spacing.x3' : undefined,
+        ...(disabled ? disabledStyles : {}),
+      }}
     >
       {!providerInfo?.icon && (
         <MenuItem.FramedIcon icon="Wallet" variant="bold" emphasized={false} />

--- a/packages/checkout/widgets-lib/src/widgets/add-funds/views/AddFunds.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-funds/views/AddFunds.tsx
@@ -214,6 +214,7 @@ export function AddFunds({
       toProviderInfo,
       fromAddress,
       toAddress,
+      lockedToProvider,
     },
   } = useProvidersContext();
 
@@ -685,6 +686,7 @@ export function AddFunds({
                 address: toAddress,
               }}
               onClick={() => setShowDeliverToDrawer(true)}
+              disabled={lockedToProvider}
             />
           </Stack>
 


### PR DESCRIPTION
# Summary
Adds the ability to set the toProvider and lock the deliver to wallet, by finding the given provider in injected providers.
If the given provider is not found, the deliver to input wont be lock and user will be able to select the deliver to wallet as usual


# Screenshot
<img width="432" alt="Screenshot 2024-10-17 at 11 07 36 AM" src="https://github.com/user-attachments/assets/2c1a8d73-4628-4626-9754-011763b427b6">

