### PR TITLE
fix: add callback to game with invalid function error from the default case

### DIFF
--- a/packages/game-bridge/src/index.ts
+++ b/packages/game-bridge/src/index.ts
@@ -818,8 +818,19 @@ window.callFunction = async (jsonData: string) => {
         });
         break;
       }
-      default:
+      default: {
+        const request = JSON.parse(data);
+        const properties = request.properties ? JSON.parse(request.properties) : {};
+        properties.fxName = fxName;
+        track(moduleName, 'callFunctionDefaultCaseCalled', properties);
+        callbackToGame({
+          responseFor: fxName,
+          requestId,
+          success: false,
+          error: `Invalid game bridge function: ${fxName}`,
+        });
         break;
+      }
     }
   } catch (error: any) {
     console.log(`Error in callFunction: ${error}`);


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

The game bridge call function switch statement default case does not return a callback to the game. A game calling the game bridge with an incorrect function name would never receive a response from the game bridge.

# Detail and impact of the change

Add a callback to the game with an error message to indicate the function they are calling is invalid.

This is probably more of a fix for the Game SDK developers, but could help debug external developer issues too.

## Added 
- Callback to game from game bridge when the `callFunction` default case is hit.

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
