### PR TITLE
Add a security warning comment to the attestations job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,8 +48,8 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=14366
       SDK_PUBLISH_SLACK_WEBHOOK: ${{ secrets.SDK_PUBLISH_SLACK_WEBHOOK }}
     permissions:
-      id-token: write # Required for GitHub Attestation
-      attestations: write # Required for GitHub Attestation
+      id-token: write # ! Required for GitHub Attestations, removing will create a Sev 0 incident !
+      attestations: write # ! Required for GitHub Attestations, removing will create a Sev 0 incident !
     steps:
       - name: Check Public Release Branch
         if: contains(env.RELEASE_TYPE , 'release') && (github.ref != 'refs/heads/main')
@@ -130,6 +130,7 @@ jobs:
           tag: ${{ contains(env.RELEASE_TYPE, 'alpha') && 'alpha' }}
           dry-run: ${{ env.DRY_RUN }}
 
+      # ! Do NOT remove - this will cause a Sev 0 incident !
       - name: Generate SDK attestation
         uses: actions/attest-build-provenance@v1
         with:


### PR DESCRIPTION
Removing or preventing GitHub from attesting the code will cause a critical security incident - clarify in the comments.