### PR TITLE
[NO CHANGELOG] [Add Tokens Widget] Only disconnect Passport wallet for from wallet

### DIFF
--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
@@ -121,19 +121,21 @@ export function ConnectWalletDrawer({
       },
     });
 
-    const { isConnected } = await checkout.checkIsWalletConnected({
-      provider: new Web3Provider(providerDetail.provider!),
-    });
+    if (info.rdns === WalletProviderRdns.PASSPORT) {
+      const { isConnected } = await checkout.checkIsWalletConnected({
+        provider: new Web3Provider(providerDetail.provider!),
+      });
 
-    if (isConnected) {
-      const isFromPassportProvider = providerType === 'from' && info.rdns === WalletProviderRdns.PASSPORT;
-      const isToPassportProvider = providerType === 'to' && info.rdns === WalletProviderRdns.PASSPORT;
-      const isFromProviderNotPassport = !isPassportProvider(fromProvider);
+      if (isConnected) {
+        const isFromPassportProvider = providerType === 'from' && info.rdns === WalletProviderRdns.PASSPORT;
+        const isToPassportProvider = providerType === 'to' && info.rdns === WalletProviderRdns.PASSPORT;
+        const isFromProviderNotPassport = !isPassportProvider(fromProvider);
 
-      const shouldLogoutPassport = isFromPassportProvider || (isToPassportProvider && isFromProviderNotPassport);
+        const shouldLogoutPassport = isFromPassportProvider || (isToPassportProvider && isFromProviderNotPassport);
 
-      if (shouldLogoutPassport) {
-        await checkout.passport?.logout();
+        if (shouldLogoutPassport) {
+          await checkout.passport?.logout();
+        }
       }
     }
 

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
@@ -122,7 +122,7 @@ export function ConnectWalletDrawer({
     });
 
     // Proceed to disconnect current provider if Passport
-    if (info.rdns === WalletProviderRdns.PASSPORT) {
+    if (providerType === 'from' && info.rdns === WalletProviderRdns.PASSPORT) {
       const { isConnected } = await checkout.checkIsWalletConnected({
         provider: new Web3Provider(providerDetail.provider!),
       });
@@ -136,6 +136,7 @@ export function ConnectWalletDrawer({
 
     // Proceed to connect selected provider
     const shouldRequestWalletPermissions = getShouldRequestWalletPermissions?.(info);
+
     try {
       const { provider } = await connectEIP6963Provider(
         providerDetail,

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
@@ -121,18 +121,18 @@ export function ConnectWalletDrawer({
       },
     });
 
-    const isFromPassportProvider = providerType === 'from' && info.rdns === WalletProviderRdns.PASSPORT;
-    const isToPassportProvider = providerType === 'to' && info.rdns === WalletProviderRdns.PASSPORT;
-    const isFromProviderNotPassport = !isPassportProvider(fromProvider);
+    const { isConnected } = await checkout.checkIsWalletConnected({
+      provider: new Web3Provider(providerDetail.provider!),
+    });
 
-    const shouldLogoutPassport = isFromPassportProvider || (isToPassportProvider && isFromProviderNotPassport);
+    if (isConnected) {
+      const isFromPassportProvider = providerType === 'from' && info.rdns === WalletProviderRdns.PASSPORT;
+      const isToPassportProvider = providerType === 'to' && info.rdns === WalletProviderRdns.PASSPORT;
+      const isFromProviderNotPassport = !isPassportProvider(fromProvider);
 
-    if (shouldLogoutPassport) {
-      const { isConnected } = await checkout.checkIsWalletConnected({
-        provider: new Web3Provider(providerDetail.provider!),
-      });
+      const shouldLogoutPassport = isFromPassportProvider || (isToPassportProvider && isFromProviderNotPassport);
 
-      if (isConnected) {
+      if (shouldLogoutPassport) {
         await checkout.passport?.logout();
       }
     }

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
@@ -127,13 +127,7 @@ export function ConnectWalletDrawer({
       });
 
       if (isConnected) {
-        const isFromPassportProvider = providerType === 'from' && info.rdns === WalletProviderRdns.PASSPORT;
-        const isToPassportProvider = providerType === 'to' && info.rdns === WalletProviderRdns.PASSPORT;
-        const isFromProviderNotPassport = !isPassportProvider(fromProvider);
-
-        const shouldLogoutPassport = isFromPassportProvider || (isToPassportProvider && isFromProviderNotPassport);
-
-        if (shouldLogoutPassport) {
+        if (providerType === 'from' || (providerType === 'to' && !isPassportProvider(fromProvider))) {
           await checkout.passport?.logout();
         }
       }

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/DeliverToWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/DeliverToWalletDrawer.tsx
@@ -58,7 +58,7 @@ export function DeliverToWalletDrawer({
     }
   };
 
-  // Becuase wallets extensions don't support multiple wallet connections
+  // Because wallets extensions don't support multiple wallet connections
   // UX decides to have the user use the same wallet type they selected to pay with
   // ie: Metamask to Metamsk, will send to same wallet address
   const selectedSameFromWalletType = (

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/components/RouteFees.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/components/RouteFees.tsx
@@ -30,7 +30,7 @@ export function RouteFees({
     () => routeData?.route.estimate.feeCosts.map((fee) => ({
       label: fee.name,
       amount: getFormattedNumber(fee.amount, fee.token.decimals),
-      fiatAmount: `${t('views.ADD_TOKENS.fees.fiatPricePrefix')}${getFormattedAmounts(fee.amountUsd)}`,
+      fiatAmount: `${t('views.ADD_TOKENS.fees.fiatPricePrefix')} ${getFormattedAmounts(fee.amountUsd)}`,
       token: {
         name: fee.token.name,
         symbol: fee.token.symbol,
@@ -47,7 +47,7 @@ export function RouteFees({
     () => routeData?.route.estimate.gasCosts.map((fee) => ({
       label: 'Gas (transaction)',
       amount: getFormattedNumber(fee.amount, fee.token.decimals),
-      fiatAmount: `${t('views.ADD_TOKENS.fees.fiatPricePrefix')}${getFormattedAmounts(fee.amountUsd)}`,
+      fiatAmount: `${t('views.ADD_TOKENS.fees.fiatPricePrefix')} ${getFormattedAmounts(fee.amountUsd)}`,
       token: {
         name: fee.token.name,
         symbol: fee.token.symbol,


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
When "from wallet" is already selected to be Passport, currently when we choose Passport for "to wallet", it disconnects the current Passport and asks the user to reconnect. 

This changes so that the "toWallet" reuses the same Passport as "from wallet".