### PR TITLE
[NO CHANGELOG] [Add Tokens Widget] Fix to use networkName instead of chainName

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/functions/fetchChains.ts
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/functions/fetchChains.ts
@@ -3,7 +3,7 @@ import { SQUID_API_BASE_URL } from '../utils/config';
 
 type SquidChain = {
   chainId: string;
-  chainName: string;
+  networkName: string;
   chainIconURI: string;
   chainType: string;
   nativeCurrency: SquidNativeCurrency;
@@ -35,7 +35,7 @@ export const fetchChains = async (): Promise<Chain[]> => {
 
   return data.chains.map((chain: SquidChain) => ({
     id: chain.chainId.toString(),
-    name: chain.chainName,
+    name: chain.networkName,
     iconUrl: chain.chainIconURI,
     type: chain.chainType,
     nativeCurrency: {


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Squid has advised to use `networkName` not `chainName`
