### PR TITLE
fix: ID-2791 Fix zero nonce issue for ejection transactions

### DIFF
--- a/packages/passport/sdk/src/mocks/zkEvm/msw.ts
+++ b/packages/passport/sdk/src/mocks/zkEvm/msw.ts
@@ -10,6 +10,7 @@ export const relayerId = '0x745';
 export const transactionHash = '0x867';
 
 const mandatoryHandlers = [
+  rest.get('https://api.sandbox.immutable.com/v1/sdk/session-activity/check', async (req, res, ctx) => res(ctx.status(404))),
   rest.post('https://rpc.testnet.immutable.com', async (req, res, ctx) => {
     const body = await req.json<JsonRpcRequestPayload>();
     switch (body.method) {

--- a/packages/passport/sdk/src/zkEvm/transactionHelpers.test.ts
+++ b/packages/passport/sdk/src/zkEvm/transactionHelpers.test.ts
@@ -286,5 +286,28 @@ describe('transactionHelpers', () => {
         flow,
       })).rejects.toThrow('Transaction send failed');
     });
+
+    describe('when the nonce is 0', () => {
+      it('prepares and signs transaction correctly', async () => {
+        const result = await prepareAndSignTransaction({
+          transactionRequest: {
+            ...transactionRequest,
+            nonce: 0,
+          },
+          ethSigner,
+          rpcProvider,
+          guardianClient,
+          relayerClient,
+          zkEvmAddress,
+          flow,
+        });
+
+        expect(result).toEqual({
+          signedTransactions,
+          relayerId,
+          nonce,
+        });
+      });
+    });
   });
 });

--- a/packages/passport/sdk/src/zkEvm/transactionHelpers.ts
+++ b/packages/passport/sdk/src/zkEvm/transactionHelpers.ts
@@ -230,7 +230,7 @@ const buildMetaTransactionForEjection = async (
     );
   }
 
-  if (!transactionRequest.nonce) {
+  if (typeof transactionRequest.nonce === 'undefined') {
     throw new JsonRpcError(
       RpcErrorCode.INVALID_PARAMS,
       'im_signEjectionTransaction requires a "nonce" field',


### PR DESCRIPTION
# Summary
This PR fixes an issue with an error being thrown when `im_signEjectionTransaction` is called with an integer value of 0.

# Detail and impact of the change

## Fixed
- Passport: Resolved an issue with `im_signEjectionTransaction` that would result in an error when an integer value of zero was provided as the nonce.

# Anything else worth calling out?
The changes to `msw.ts` resolve a number of errors that were being thrown when the tests in `Passport.int.test.ts` were run.
