### PR TITLE
[NO CHANGELOG] [Add Tokens Widget] Nuke changed your mind drawer

### DIFF
--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
@@ -20,7 +20,6 @@ import {
   useProvidersContext,
 } from '../../context/providers-context/ProvidersContext';
 import { UnableToConnectDrawer } from '../UnableToConnectDrawer/UnableToConnectDrawer';
-import { ChangedYourMindDrawer } from '../ChangedYourMindDrawer/ChangedYourMindDrawer';
 import {
   connectEIP6963Provider,
   ConnectEIP6963ProviderError,
@@ -70,7 +69,6 @@ export function ConnectWalletDrawer({
   const prevWalletChangeEvent = useRef<WalletChangeEvent | undefined>();
 
   const [showUnableToConnectDrawer, setShowUnableToConnectDrawer] = useState(false);
-  const [showChangedMindDrawer, setShowChangedMindDrawer] = useState(false);
   const [showEOAWarningDrawer, setShowEOAWarningDrawer] = useState(false);
 
   const setProviderInContext = async (
@@ -155,9 +153,6 @@ export function ConnectWalletDrawer({
     } catch (error: ConnectEIP6963ProviderError | any) {
       let errorType = error.message;
       switch (error.message) {
-        case ConnectEIP6963ProviderError.USER_REJECTED_REQUEST_ERROR:
-          setShowChangedMindDrawer(true);
-          break;
         case ConnectEIP6963ProviderError.SANCTIONED_ADDRESS:
         case ConnectEIP6963ProviderError.CONNECT_ERROR:
           setShowUnableToConnectDrawer(true);
@@ -194,11 +189,6 @@ export function ConnectWalletDrawer({
     }
   };
 
-  const handleCloseChangedMindDrawer = () => {
-    retrySelectedWallet();
-    setShowChangedMindDrawer(false);
-  };
-
   const handleProceedEOA = () => {
     retrySelectedWallet();
     setShowEOAWarningDrawer(false);
@@ -229,12 +219,6 @@ export function ConnectWalletDrawer({
         checkout={checkout!}
         onCloseDrawer={() => setShowUnableToConnectDrawer(false)}
         onTryAgain={() => setShowUnableToConnectDrawer(false)}
-      />
-      <ChangedYourMindDrawer
-        visible={showChangedMindDrawer}
-        checkout={checkout!}
-        onCloseDrawer={() => setShowChangedMindDrawer(false)}
-        onTryAgain={handleCloseChangedMindDrawer}
       />
       <EOAWarningDrawer
         visible={showEOAWarningDrawer}


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Removing `changed your mind` drawer as this is not needed. This component was created 8 months ago when Passport has not yet implemented pop-up blocking retry overlay. Currently Passport shows an overlay when pop-up blocking happens.
