### PR TITLE
refactor: Update chains endpoint response

### DIFF
--- a/packages/internal/generated-clients/src/blockchain-data-openapi.json
+++ b/packages/internal/generated-clients/src/blockchain-data-openapi.json
@@ -47,6 +47,22 @@
     {
       "name": "demopage",
       "description": "Temporary HTML endpoint for demo purposes"
+    },
+    {
+      "name": "verification"
+    },
+    {
+      "name": "operatorallowlist"
+    },
+    {
+      "name": "crafting"
+    },
+    {
+      "name": "pricing",
+      "description": "Pricing Endpoints"
+    },
+    {
+      "name": "metadata-search"
     }
   ],
   "paths": {
@@ -3411,8 +3427,8 @@
         "properties": {
           "display_type": {
             "description": "Display type for this attribute",
-            "nullable": true,
             "type": "string",
+            "nullable": true,
             "enum": [
               "number",
               "boost_percentage",
@@ -3692,10 +3708,22 @@
                 "type": "string",
                 "nullable": true,
                 "description": "URL for RPC node"
+              },
+              "operator_allowlist_address": {
+                "type": "string",
+                "nullable": true,
+                "description": "The address of the Operator Allowlist - https://docs.immutable.com/products/zkevm/minting/royalties/allowlist-spec/"
+              },
+              "minter_address": {
+                "type": "string",
+                "nullable": true,
+                "description": "The address of the minter used in the Minting API - https://docs.immutable.com/products/zkEVM/minting/minting-api#minting-api-prerequisites"
               }
             },
             "required": [
-              "rpc_url"
+              "rpc_url",
+              "operator_allowlist_address",
+              "minter_address"
             ]
           }
         ]

--- a/packages/internal/generated-clients/src/blockchain-data/models/chain-with-details-all-of.ts
+++ b/packages/internal/generated-clients/src/blockchain-data/models/chain-with-details-all-of.ts
@@ -26,5 +26,17 @@ export interface ChainWithDetailsAllOf {
      * @memberof ChainWithDetailsAllOf
      */
     'rpc_url': string | null;
+    /**
+     * The address of the Operator Allowlist - https://docs.immutable.com/products/zkevm/minting/royalties/allowlist-spec/
+     * @type {string}
+     * @memberof ChainWithDetailsAllOf
+     */
+    'operator_allowlist_address': string | null;
+    /**
+     * The address of the minter used in the Minting API - https://docs.immutable.com/products/zkEVM/minting/minting-api#minting-api-prerequisites
+     * @type {string}
+     * @memberof ChainWithDetailsAllOf
+     */
+    'minter_address': string | null;
 }
 

--- a/packages/internal/generated-clients/src/mr-openapi.json
+++ b/packages/internal/generated-clients/src/mr-openapi.json
@@ -98,9 +98,8 @@
       "x-displayName": "pricing"
     },
     {
-      "name": "stacks",
-      "description": "Stacks Endpoints",
-      "x-displayName": "stacks"
+      "name": "metadata-search",
+      "x-displayName": "metadata-search"
     }
   ],
   "paths": {
@@ -4698,6 +4697,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "includeSimulation",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Include simulation results"
           }
         ],
         "responses": {
@@ -6389,10 +6396,22 @@
                 "type": "string",
                 "nullable": true,
                 "description": "URL for RPC node"
+              },
+              "operator_allowlist_address": {
+                "type": "string",
+                "nullable": true,
+                "description": "The address of the Operator Allowlist - https://docs.immutable.com/products/zkevm/minting/royalties/allowlist-spec/"
+              },
+              "minter_address": {
+                "type": "string",
+                "nullable": true,
+                "description": "The address of the minter used in the Minting API - https://docs.immutable.com/products/zkEVM/minting/minting-api#minting-api-prerequisites"
               }
             },
             "required": [
-              "rpc_url"
+              "rpc_url",
+              "operator_allowlist_address",
+              "minter_address"
             ]
           }
         ]
@@ -7603,7 +7622,7 @@
           },
           "token_id": {
             "type": "string",
-            "description": "Token ID for the ERC721 or ERC1155 token",
+            "description": "Token ID for the ERC721 or ERC1155 token when fulfilling a collection order",
             "example": "123",
             "pattern": "\\d+"
           }
@@ -7617,11 +7636,17 @@
       "FulfillableOrder": {
         "type": "object",
         "properties": {
-          "extra_data": {
-            "type": "string"
-          },
           "order": {
             "$ref": "#/components/schemas/Order"
+          },
+          "token_id": {
+            "type": "string",
+            "description": "Token ID for the ERC721 or ERC1155 token when fulfilling a collection order",
+            "example": "123",
+            "pattern": "\\d+"
+          },
+          "extra_data": {
+            "type": "string"
           }
         },
         "required": [
@@ -7636,6 +7661,12 @@
             "type": "string",
             "description": "OrderID for the requested but unfulfillable order",
             "example": "7df3e99e-f7b3-459c-bef6-ffb66a18bb59"
+          },
+          "token_id": {
+            "type": "string",
+            "description": "Token ID for the ERC721 or ERC1155 token when fulfilling a collection order",
+            "example": "123",
+            "pattern": "\\d+"
           },
           "reason": {
             "type": "string",
@@ -10503,6 +10534,11 @@
             "description": "The name of the collection",
             "example": "0x8a90cab2b38dba80c64b7734e58ee1db38b8992e"
           },
+          "image_url": {
+            "type": "string",
+            "description": "The URL of the collection image",
+            "example": "https://example.com/nft.jpeg"
+          },
           "amount": {
             "type": "string",
             "description": "A string representing the total units of an ERC721 token which the user is buying",
@@ -10525,6 +10561,7 @@
         "required": [
           "type",
           "contract_address",
+          "image_url",
           "amount",
           "immutable_verification_status"
         ]
@@ -10545,6 +10582,11 @@
             "description": "Address of ERC1155 token",
             "example": "0x692edAd005237c7E737bB2c0F3D8ccCc10D3479E",
             "pattern": "^0x[a-fA-F0-9]{40}$"
+          },
+          "image_url": {
+            "type": "string",
+            "description": "The URL of the collection image",
+            "example": "https://example.com/nft.jpeg"
           },
           "contract_name": {
             "type": "string",
@@ -10574,6 +10616,7 @@
         ],
         "required": [
           "type",
+          "image_url",
           "contract_address",
           "amount",
           "immutable_verification_status"
@@ -11008,7 +11051,6 @@
           },
           "validation": {
             "description": "Validation results",
-            "type": "object",
             "$ref": "#/components/schemas/ValidationResult",
             "nullable": true
           }
@@ -11274,6 +11316,11 @@
           "data": {
             "description": "evm message data",
             "$ref": "#/components/schemas/EIP712Message"
+          },
+          "validation": {
+            "description": "Validation results",
+            "$ref": "#/components/schemas/ValidationResult",
+            "nullable": true
           }
         }
       },
@@ -11317,13 +11364,17 @@
           },
           {
             "$ref": "#/components/schemas/ValidationErrorResults"
+          },
+          {
+            "$ref": "#/components/schemas/ValidationSimulationFailedResults"
           }
         ],
         "discriminator": {
           "propertyName": "status",
           "mapping": {
             "error": "#/components/schemas/ValidationErrorResults",
-            "success": "#/components/schemas/ValidationSuccessResults"
+            "success": "#/components/schemas/ValidationSuccessResults",
+            "simulation_failed": "#/components/schemas/ValidationSimulationFailedResults"
           }
         }
       },
@@ -11351,6 +11402,22 @@
           }
         }
       },
+      "ValidationSimulationFailedResults": {
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ValidationStatus"
+          },
+          "error": {
+            "description": "human-readable error message representing a failure to simulate the transaction",
+            "type": "string"
+          }
+        }
+      },
       "ValidationErrorResults": {
         "type": "object",
         "required": [
@@ -11362,7 +11429,7 @@
             "$ref": "#/components/schemas/ValidationStatus"
           },
           "error": {
-            "description": "human-readable error message",
+            "description": "human-readable error message representing a failure with the simulated transaction, such as a reversion",
             "type": "string"
           }
         }
@@ -11420,7 +11487,8 @@
         "description": "Status of the validation",
         "enum": [
           "success",
-          "error"
+          "error",
+          "simulation_failed"
         ]
       },
       "ERC191Message": {
@@ -11430,50 +11498,5 @@
         "minLength": 1
       }
     }
-  },
-  "x-tagGroups": [
-    {
-      "name": "Multi Rollup API",
-      "tags": [
-        "activities",
-        "chains",
-        "collections",
-        "nfts",
-        "nft owners",
-        "metadata",
-        "tokens",
-        "demopage",
-        "verification",
-        "operatorallowlist",
-        "crafting",
-        "listings",
-        "orders"
-      ]
-    },
-    {
-      "name": "Passport MR",
-      "tags": [
-        "passport"
-      ]
-    },
-    {
-      "name": "Passport Profile Service API",
-      "tags": [
-        "passport profile"
-      ]
-    },
-    {
-      "name": "Guardian",
-      "tags": [
-        "guardian"
-      ]
-    },
-    {
-      "name": "Indexer Marketplace APIs",
-      "tags": [
-        "pricing",
-        "stacks"
-      ]
-    }
-  ]
+  }
 }

--- a/packages/internal/generated-clients/src/multi-rollup/.openapi-generator/FILES
+++ b/packages/internal/generated-clients/src/multi-rollup/.openapi-generator/FILES
@@ -213,6 +213,7 @@ models/unknown-typed-data-metadata.ts
 models/user-info.ts
 models/validation-error-results.ts
 models/validation-result.ts
+models/validation-simulation-failed-results.ts
 models/validation-status.ts
 models/validation-success-results.ts
 models/verification-request-contract-type.ts

--- a/packages/internal/generated-clients/src/multi-rollup/domain/guardian-api.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/domain/guardian-api.ts
@@ -343,10 +343,11 @@ export const GuardianApiAxiosParamCreator = function (configuration?: Configurat
          * Get an evm message by id
          * @summary Info for a specific evm message
          * @param {string} messageID The id of the evm message
+         * @param {boolean} [includeSimulation] Include simulation results
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getMessageByID: async (messageID: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getMessageByID: async (messageID: string, includeSimulation?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'messageID' is not null or undefined
             assertParamExists('getMessageByID', 'messageID', messageID)
             const localVarPath = `/guardian/v1/messages/{messageID}`
@@ -365,6 +366,10 @@ export const GuardianApiAxiosParamCreator = function (configuration?: Configurat
             // authentication BearerAuth required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (includeSimulation !== undefined) {
+                localVarQueryParameter['includeSimulation'] = includeSimulation;
+            }
 
 
     
@@ -525,11 +530,12 @@ export const GuardianApiFp = function(configuration?: Configuration) {
          * Get an evm message by id
          * @summary Info for a specific evm message
          * @param {string} messageID The id of the evm message
+         * @param {boolean} [includeSimulation] Include simulation results
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getMessageByID(messageID: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<EVMMessage>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getMessageByID(messageID, options);
+        async getMessageByID(messageID: string, includeSimulation?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<EVMMessage>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getMessageByID(messageID, includeSimulation, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -634,7 +640,7 @@ export const GuardianApiFactory = function (configuration?: Configuration, baseP
          * @throws {RequiredError}
          */
         getMessageByID(requestParameters: GuardianApiGetMessageByIDRequest, options?: AxiosRequestConfig): AxiosPromise<EVMMessage> {
-            return localVarFp.getMessageByID(requestParameters.messageID, options).then((request) => request(axios, basePath));
+            return localVarFp.getMessageByID(requestParameters.messageID, requestParameters.includeSimulation, options).then((request) => request(axios, basePath));
         },
         /**
          * Get a transaction by payload hash
@@ -773,6 +779,13 @@ export interface GuardianApiGetMessageByIDRequest {
      * @memberof GuardianApiGetMessageByID
      */
     readonly messageID: string
+
+    /**
+     * Include simulation results
+     * @type {boolean}
+     * @memberof GuardianApiGetMessageByID
+     */
+    readonly includeSimulation?: boolean
 }
 
 /**
@@ -910,7 +923,7 @@ export class GuardianApi extends BaseAPI {
      * @memberof GuardianApi
      */
     public getMessageByID(requestParameters: GuardianApiGetMessageByIDRequest, options?: AxiosRequestConfig) {
-        return GuardianApiFp(this.configuration).getMessageByID(requestParameters.messageID, options).then((request) => request(this.axios, this.basePath));
+        return GuardianApiFp(this.configuration).getMessageByID(requestParameters.messageID, requestParameters.includeSimulation, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/internal/generated-clients/src/multi-rollup/models/chain-with-details-all-of.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/chain-with-details-all-of.ts
@@ -26,5 +26,17 @@ export interface ChainWithDetailsAllOf {
      * @memberof ChainWithDetailsAllOf
      */
     'rpc_url': string | null;
+    /**
+     * The address of the Operator Allowlist - https://docs.immutable.com/products/zkevm/minting/royalties/allowlist-spec/
+     * @type {string}
+     * @memberof ChainWithDetailsAllOf
+     */
+    'operator_allowlist_address': string | null;
+    /**
+     * The address of the minter used in the Minting API - https://docs.immutable.com/products/zkEVM/minting/minting-api#minting-api-prerequisites
+     * @type {string}
+     * @memberof ChainWithDetailsAllOf
+     */
+    'minter_address': string | null;
 }
 

--- a/packages/internal/generated-clients/src/multi-rollup/models/evmmessage.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/evmmessage.ts
@@ -16,6 +16,9 @@
 // May contain unused imports in some cases
 // @ts-ignore
 import { EIP712Message } from './eip712-message';
+// May contain unused imports in some cases
+// @ts-ignore
+import { ValidationResult } from './validation-result';
 
 /**
  * 
@@ -53,5 +56,11 @@ export interface EVMMessage {
      * @memberof EVMMessage
      */
     'data': EIP712Message;
+    /**
+     * 
+     * @type {ValidationResult}
+     * @memberof EVMMessage
+     */
+    'validation'?: ValidationResult;
 }
 

--- a/packages/internal/generated-clients/src/multi-rollup/models/fulfillable-order.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/fulfillable-order.ts
@@ -25,15 +25,21 @@ import { Order } from './order';
 export interface FulfillableOrder {
     /**
      * 
-     * @type {string}
-     * @memberof FulfillableOrder
-     */
-    'extra_data': string;
-    /**
-     * 
      * @type {Order}
      * @memberof FulfillableOrder
      */
     'order': Order;
+    /**
+     * Token ID for the ERC721 or ERC1155 token when fulfilling a collection order
+     * @type {string}
+     * @memberof FulfillableOrder
+     */
+    'token_id'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof FulfillableOrder
+     */
+    'extra_data': string;
 }
 

--- a/packages/internal/generated-clients/src/multi-rollup/models/fulfillment-data-request.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/fulfillment-data-request.ts
@@ -42,7 +42,7 @@ export interface FulfillmentDataRequest {
      */
     'fees': Array<Fee>;
     /**
-     * Token ID for the ERC721 or ERC1155 token
+     * Token ID for the ERC721 or ERC1155 token when fulfilling a collection order
      * @type {string}
      * @memberof FulfillmentDataRequest
      */

--- a/packages/internal/generated-clients/src/multi-rollup/models/index.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/index.ts
@@ -191,6 +191,7 @@ export * from './unknown-typed-data-metadata';
 export * from './user-info';
 export * from './validation-error-results';
 export * from './validation-result';
+export * from './validation-simulation-failed-results';
 export * from './validation-status';
 export * from './validation-success-results';
 export * from './verification-request';

--- a/packages/internal/generated-clients/src/multi-rollup/models/seaport-erc1155-collection-item.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/seaport-erc1155-collection-item.ts
@@ -36,6 +36,12 @@ export interface SeaportERC1155CollectionItem {
      */
     'contract_address': string;
     /**
+     * The URL of the collection image
+     * @type {string}
+     * @memberof SeaportERC1155CollectionItem
+     */
+    'image_url': string;
+    /**
      * The name of the collection
      * @type {string}
      * @memberof SeaportERC1155CollectionItem

--- a/packages/internal/generated-clients/src/multi-rollup/models/seaport-erc721-collection-item.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/seaport-erc721-collection-item.ts
@@ -42,6 +42,12 @@ export interface SeaportERC721CollectionItem {
      */
     'contract_name'?: string | null;
     /**
+     * The URL of the collection image
+     * @type {string}
+     * @memberof SeaportERC721CollectionItem
+     */
+    'image_url': string;
+    /**
      * A string representing the total units of an ERC721 token which the user is buying
      * @type {string}
      * @memberof SeaportERC721CollectionItem

--- a/packages/internal/generated-clients/src/multi-rollup/models/unfulfillable-order.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/unfulfillable-order.ts
@@ -27,6 +27,12 @@ export interface UnfulfillableOrder {
      */
     'order_id': string;
     /**
+     * Token ID for the ERC721 or ERC1155 token when fulfilling a collection order
+     * @type {string}
+     * @memberof UnfulfillableOrder
+     */
+    'token_id'?: string;
+    /**
      * Nullable string containing error reason if the signing is unsuccessful for the order
      * @type {string}
      * @memberof UnfulfillableOrder

--- a/packages/internal/generated-clients/src/multi-rollup/models/validation-result.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/validation-result.ts
@@ -24,6 +24,9 @@ import { HighestSeverity } from './highest-severity';
 import { ValidationErrorResults } from './validation-error-results';
 // May contain unused imports in some cases
 // @ts-ignore
+import { ValidationSimulationFailedResults } from './validation-simulation-failed-results';
+// May contain unused imports in some cases
+// @ts-ignore
 import { ValidationStatus } from './validation-status';
 // May contain unused imports in some cases
 // @ts-ignore
@@ -33,6 +36,6 @@ import { ValidationSuccessResults } from './validation-success-results';
  * @type ValidationResult
  * @export
  */
-export type ValidationResult = { status: 'error' } & ValidationErrorResults | { status: 'success' } & ValidationSuccessResults;
+export type ValidationResult = { status: 'error' } & ValidationErrorResults | { status: 'simulation_failed' } & ValidationSimulationFailedResults | { status: 'success' } & ValidationSuccessResults;
 
 

--- a/packages/internal/generated-clients/src/multi-rollup/models/validation-simulation-failed-results.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/validation-simulation-failed-results.ts
@@ -20,19 +20,19 @@ import { ValidationStatus } from './validation-status';
 /**
  * 
  * @export
- * @interface ValidationErrorResults
+ * @interface ValidationSimulationFailedResults
  */
-export interface ValidationErrorResults {
+export interface ValidationSimulationFailedResults {
     /**
      * 
      * @type {ValidationStatus}
-     * @memberof ValidationErrorResults
+     * @memberof ValidationSimulationFailedResults
      */
     'status': ValidationStatus;
     /**
-     * human-readable error message representing a failure with the simulated transaction, such as a reversion
+     * human-readable error message representing a failure to simulate the transaction
      * @type {string}
-     * @memberof ValidationErrorResults
+     * @memberof ValidationSimulationFailedResults
      */
     'error': string;
 }

--- a/packages/internal/generated-clients/src/multi-rollup/models/validation-status.ts
+++ b/packages/internal/generated-clients/src/multi-rollup/models/validation-status.ts
@@ -22,7 +22,8 @@
 
 export const ValidationStatus = {
     Success: 'success',
-    Error: 'error'
+    Error: 'error',
+    SimulationFailed: 'simulation_failed'
 } as const;
 
 export type ValidationStatus = typeof ValidationStatus[keyof typeof ValidationStatus];

--- a/packages/x-client/src/utils/formatError.test.ts
+++ b/packages/x-client/src/utils/formatError.test.ts
@@ -49,7 +49,7 @@ describe('formatError', () => {
 
     const client = new ImmutableX(config);
     await expect(client.getUser('')).rejects.toThrowError(
-      'Error: Request failed with status code 404',
+      'no matching operation was found',
     );
   });
 });


### PR DESCRIPTION
# Summary

Regenerate openapi spec for blockchain data package - update chains endpoint response to include `minter_address` and `operator_allowlist_address`

# Detail and impact of the change

Non breaking additive change

## Added 

Chains endpoint response:
- `minter_address`: The address of the minter used in the Minting API - https://docs.immutable.com/products/zkEVM/minting/minting-api#minting-api-prerequisites
- `operator_allowlist_address`: The address of the Operator Allowlist - https://docs.immutable.com/products/zkevm/minting/royalties/allowlist-spec/
