### PR TITLE
chore: Remove risk assessment check from Connect widget

### DIFF
--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
@@ -153,7 +153,6 @@ export function ConnectWalletDrawer({
     } catch (error: ConnectEIP6963ProviderError | any) {
       let errorType = error.message;
       switch (error.message) {
-        case ConnectEIP6963ProviderError.SANCTIONED_ADDRESS:
         case ConnectEIP6963ProviderError.CONNECT_ERROR:
           setShowUnableToConnectDrawer(true);
           break;

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/DeliverToWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/DeliverToWalletDrawer.tsx
@@ -3,15 +3,8 @@ import {
   EIP6963ProviderInfo,
 } from '@imtbl/checkout-sdk';
 import { Web3Provider } from '@ethersproject/providers';
-import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConnectWalletDrawer } from './ConnectWalletDrawer';
-import { ConnectEIP6963ProviderError } from '../../lib/connectEIP6963Provider';
-import {
-  SharedViews,
-  ViewActions,
-  ViewContext,
-} from '../../context/view-context/ViewContext';
 import { useProvidersContext } from '../../context/providers-context/ProvidersContext';
 
 type DeliverToWalletDrawerProps = {
@@ -35,28 +28,11 @@ export function DeliverToWalletDrawer({
     providersState: { fromProviderInfo },
   } = useProvidersContext();
 
-  const { viewDispatch } = useContext(ViewContext);
-
   const handleOnConnect = (
     provider: Web3Provider,
     providerInfo: EIP6963ProviderInfo,
   ) => {
     onConnect?.('to', provider, providerInfo);
-  };
-
-  const handleOnError = (errorType: ConnectEIP6963ProviderError) => {
-    if (errorType === ConnectEIP6963ProviderError.SANCTIONED_ADDRESS) {
-      onClose();
-      viewDispatch({
-        payload: {
-          type: ViewActions.UPDATE_VIEW,
-          view: {
-            type: SharedViews.SERVICE_UNAVAILABLE_ERROR_VIEW,
-            error: new Error(errorType),
-          },
-        },
-      });
-    }
   };
 
   // Because wallets extensions don't support multiple wallet connections
@@ -74,7 +50,6 @@ export function DeliverToWalletDrawer({
       providerType="to"
       walletOptions={walletOptions}
       onConnect={handleOnConnect}
-      onError={handleOnError}
       getShouldRequestWalletPermissions={
         selectedSameFromWalletType
       }

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/PayWithWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/PayWithWalletDrawer.tsx
@@ -1,12 +1,10 @@
 import { EIP6963ProviderDetail, EIP6963ProviderInfo } from '@imtbl/checkout-sdk';
-import { useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 import { MenuItem } from '@biom3/react';
 import { Web3Provider } from '@ethersproject/providers';
 import { useTranslation } from 'react-i18next';
 import { ConnectWalletDrawer } from './ConnectWalletDrawer';
 import { useProvidersContext } from '../../context/providers-context/ProvidersContext';
-import { ConnectEIP6963ProviderError } from '../../lib/connectEIP6963Provider';
-import { SharedViews, ViewActions, ViewContext } from '../../context/view-context/ViewContext';
 
 type PayWithWalletDrawerProps = {
   visible: boolean;
@@ -29,7 +27,6 @@ export function PayWithWalletDrawer({
 }: PayWithWalletDrawerProps) {
   const { t } = useTranslation();
   const { providersState: { fromProviderInfo } } = useProvidersContext();
-  const { viewDispatch } = useContext(ViewContext);
 
   const disabledOptions = useMemo(() => {
     if (insufficientBalance && fromProviderInfo) {
@@ -44,21 +41,6 @@ export function PayWithWalletDrawer({
 
   const handleOnConnect = (provider: Web3Provider, providerInfo: EIP6963ProviderInfo) => {
     onConnect('from', provider, providerInfo);
-  };
-
-  const handleOnError = (errorType: ConnectEIP6963ProviderError) => {
-    if (errorType === ConnectEIP6963ProviderError.SANCTIONED_ADDRESS) {
-      onClose();
-      viewDispatch({
-        payload: {
-          type: ViewActions.UPDATE_VIEW,
-          view: {
-            type: SharedViews.SERVICE_UNAVAILABLE_ERROR_VIEW,
-            error: new Error(errorType),
-          },
-        },
-      });
-    }
   };
 
   const payWithCardItem = useMemo(() => {
@@ -97,7 +79,6 @@ export function PayWithWalletDrawer({
       disabledOptions={disabledOptions}
       bottomSlot={payWithCardItem}
       onConnect={handleOnConnect}
-      onError={handleOnError}
     />
   );
 }

--- a/packages/checkout/widgets-lib/src/lib/connectEIP6963Provider.ts
+++ b/packages/checkout/widgets-lib/src/lib/connectEIP6963Provider.ts
@@ -10,7 +10,6 @@ import { getProviderSlugFromRdns } from './provider';
 
 export enum ConnectEIP6963ProviderError {
   CONNECT_ERROR = 'CONNECT_ERROR',
-  SANCTIONED_ADDRESS = 'SANCTIONED_ADDRESS',
   USER_REJECTED_REQUEST_ERROR = 'USER_REJECTED_REQUEST_ERROR',
 }
 
@@ -45,8 +44,6 @@ export const connectEIP6963Provider = async (
         throw new Error(
           ConnectEIP6963ProviderError.USER_REJECTED_REQUEST_ERROR,
         );
-      case ConnectEIP6963ProviderError.SANCTIONED_ADDRESS:
-        throw new Error(ConnectEIP6963ProviderError.SANCTIONED_ADDRESS);
       default:
         throw new Error(ConnectEIP6963ProviderError.CONNECT_ERROR);
     }

--- a/packages/checkout/widgets-lib/src/lib/connectEIP6963Provider.ts
+++ b/packages/checkout/widgets-lib/src/lib/connectEIP6963Provider.ts
@@ -1,7 +1,6 @@
 import { Web3Provider } from '@ethersproject/providers';
 import {
   Checkout,
-  CheckoutError,
   CheckoutErrorType,
   EIP6963ProviderDetail,
   WalletProviderRdns,
@@ -34,16 +33,6 @@ export const connectEIP6963Provider = async (
       provider: web3Provider,
       requestWalletPermissions,
     });
-
-    const address = await connectResult.provider.getSigner().getAddress();
-    const riskAssessment = await checkout.getRiskAssessment([address]);
-
-    if (checkout.checkIsAddressSanctioned(riskAssessment, address)) {
-      throw new CheckoutError(
-        'Sanctioned address',
-        ConnectEIP6963ProviderError.SANCTIONED_ADDRESS,
-      );
-    }
 
     addProviderListenersForWidgetRoot(connectResult.provider);
     return {

--- a/packages/checkout/widgets-lib/src/widgets/connect/components/WalletList.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/connect/components/WalletList.tsx
@@ -4,8 +4,6 @@ import {
   ChainId,
   CheckoutErrorType,
   EIP6963ProviderDetail,
-  fetchRiskAssessment,
-  isAddressSanctioned,
   WalletProviderName,
   WalletProviderRdns,
 } from '@imtbl/checkout-sdk';
@@ -26,7 +24,6 @@ import { ConnectWidgetViews } from '../../../context/view-context/ConnectViewCon
 import { ConnectActions, ConnectContext } from '../context/ConnectContext';
 import { WalletItem } from './WalletItem';
 import {
-  SharedViews,
   ViewActions,
   ViewContext,
 } from '../../../context/view-context/ViewContext';
@@ -179,22 +176,6 @@ export function WalletList(props: WalletListProps) {
             provider: web3Provider,
             requestWalletPermissions: changeAccount,
           });
-
-          // CM-793 Check for sanctioned address
-          const address = await connectResult.provider.getSigner().getAddress();
-          const sanctions = await fetchRiskAssessment([address], checkout.config);
-          if (isAddressSanctioned(sanctions, address)) {
-            viewDispatch({
-              payload: {
-                type: ViewActions.UPDATE_VIEW,
-                view: {
-                  type: SharedViews.SERVICE_UNAVAILABLE_ERROR_VIEW,
-                  error: new Error('Sanctioned address'),
-                },
-              },
-            });
-            return;
-          }
 
           // Set up EIP-1193 provider event listeners for widget root instances
           addProviderListenersForWidgetRoot(connectResult.provider);


### PR DESCRIPTION
# Summary
Risk assessments are done before a transaction occurs, so this check isn't needed anymore.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
