### PR TITLE
[NO CHANGELOG] [Add tokens Widget] Fix/add tokens invalid input

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/functions/amountValidation.ts
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/functions/amountValidation.ts
@@ -8,9 +8,8 @@ const VALID_NUMBER_REGEX = /^(0|[1-9]\d*)(\.\d*)?$/;
 export const validateToAmount = (amount: string) => {
   const value = amount || '';
   const sanitizedValue = value.replace(/^0+(?=\d)/, '');
-  const floatAmount = parseFloat(sanitizedValue);
+  const isValid = VALID_NUMBER_REGEX.test(sanitizedValue);
+  const floatAmount = isValid ? parseFloat(sanitizedValue) : NaN;
 
-  const isValid = VALID_NUMBER_REGEX.test(sanitizedValue) && floatAmount > 0;
-
-  return { value: sanitizedValue, amount: floatAmount, isValid };
+  return { value: sanitizedValue, amount: floatAmount, isValid: isValid && floatAmount > 0 };
 };

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/functions/amountValidation.ts
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/functions/amountValidation.ts
@@ -1,4 +1,4 @@
-const VALID_NUMBER_REGEX = /^[0-9]+(\.[0-9]+)?$/;
+const VALID_NUMBER_REGEX = /^(0|[1-9]\d*)(\.\d*)?$/;
 
 /**
  * Validate the amount input
@@ -6,7 +6,7 @@ const VALID_NUMBER_REGEX = /^[0-9]+(\.[0-9]+)?$/;
  * @returns An object containing the sanitized value, the float amount, and a boolean indicating if the amount is valid
  */
 export const validateToAmount = (amount: string) => {
-  const value = amount || '0';
+  const value = amount || '';
   const sanitizedValue = value.replace(/^0+(?=\d)/, '');
   const floatAmount = parseFloat(sanitizedValue);
 

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/views/AddTokens.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/views/AddTokens.tsx
@@ -193,6 +193,16 @@ export function AddTokens({
 
       if (amount > 0) {
         setSelectedAmount(value);
+
+        track({
+          userJourney: UserJourney.ADD_TOKENS,
+          screen: 'InputScreen',
+          control: 'AmountInput',
+          controlType: 'TextInput',
+          extras: {
+            toAmount: value,
+          },
+        });
       } else {
         setSelectedAmount('');
       }

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/views/AddTokens.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/views/AddTokens.tsx
@@ -189,12 +189,14 @@ export function AddTokens({
   const handleOnAmountInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { value, amount, isValid } = validateToAmount(event.target.value);
 
-    if (!isValid && amount < 0) {
-      return;
+    if (isValid || amount === 0 || value === '') {
+      setInputValue(value);
+      if (amount > 0) {
+        setSelectedAmount(value);
+      } else {
+        setSelectedAmount('');
+      }
     }
-
-    setInputValue(value);
-    setSelectedAmount(value);
   };
 
   const {
@@ -512,7 +514,7 @@ export function AddTokens({
             <Body>Add Token</Body>
           ) : (
             <HeroFormControl
-              validationStatus={inputValue === '0' ? 'error' : 'success'}
+              validationStatus={validateToAmount(inputValue).isValid || inputValue === '' ? 'success' : 'error'}
             >
               <HeroFormControl.Label>
                 Add
@@ -522,9 +524,9 @@ export function AddTokens({
               <HeroTextInput
                 inputRef={inputRef}
                 testId="add-tokens-amount-input"
-                type="number"
+                type="text"
                 value={inputValue}
-                onChange={(value) => handleOnAmountInputChange(value)}
+                onChange={(event) => handleOnAmountInputChange(event)}
                 placeholder="0"
                 maxTextSize="xLarge"
               />
@@ -552,7 +554,7 @@ export function AddTokens({
             <SelectedWallet
               sx={selectedToken
                 && !fromAddress
-                && inputValue
+                && selectedAmount
                 ? { animation: `${PULSE_SHADOW} 2s infinite ease-in-out` }
                 : {}}
               label="Send from"
@@ -565,7 +567,7 @@ export function AddTokens({
                 setShowPayWithDrawer(true);
               }}
             >
-              {selectedToken && fromAddress && inputValue && (
+              {selectedToken && fromAddress && selectedAmount && (
               <>
                 <MenuItem.BottomSlot.Divider
                   sx={fromAddress ? { ml: 'base.spacing.x4' } : undefined}
@@ -602,7 +604,7 @@ export function AddTokens({
               sx={selectedToken
                 && fromAddress
                 && !toAddress
-                && inputValue
+                && selectedAmount
                 ? { animation: `${PULSE_SHADOW} 2s infinite ease-in-out` }
                 : {}}
               label="Deliver to"


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Fix some edge cases:

- the user shouldn’t be able to enter a first `.` only if there is a number before it
- no `-` is allowed, currently the input doesn’t show that this is an error
- `.01111` should be invalid, currently the input doesn’t show that this is an error
- they should be able to remove all input, currently when all is removed it defaults to 0
- only pulsate if the amount is valid, otherwise let them fix it first before pulsating the next step again
