### PR TITLE
Fix/widgets stale latest version

### DIFF
--- a/packages/checkout/sdk/src/sdk.ts
+++ b/packages/checkout/sdk/src/sdk.ts
@@ -143,7 +143,8 @@ export class Checkout {
     // Determine the version of the widgets to load
     const validatedBuildVersion = validateAndBuildVersion(init.version);
     const initVersionProvided = init.version !== undefined;
-    const widgetsVersion = determineWidgetsVersion(
+
+    const widgetsVersion = await determineWidgetsVersion(
       validatedBuildVersion,
       initVersionProvided,
       versionConfig,

--- a/packages/checkout/sdk/src/widgets/version.test.ts
+++ b/packages/checkout/sdk/src/widgets/version.test.ts
@@ -357,7 +357,7 @@ describe('CheckoutWidgets', () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          'dist-tags': { latest: '1.82.3' },
+          version: '1.82.3',
         }),
       });
 

--- a/packages/checkout/sdk/src/widgets/version.test.ts
+++ b/packages/checkout/sdk/src/widgets/version.test.ts
@@ -1,7 +1,7 @@
 import { SDK_VERSION_MARKER } from '../env';
 import { CheckoutWidgetsVersionConfig } from '../types';
 import { SemanticVersion } from './definitions/types';
-import { determineWidgetsVersion, validateAndBuildVersion } from './version';
+import { determineWidgetsVersion, getLatestVersionFromNpm, validateAndBuildVersion } from './version';
 
 describe('CheckoutWidgets', () => {
   const SDK_VERSION = SDK_VERSION_MARKER;
@@ -333,14 +333,87 @@ describe('CheckoutWidgets', () => {
     ];
 
     determineWidgetVersionTestCases.forEach((testCase) => {
-      it(`should determine correct widget version when ${testCase.title}`, () => {
-        const widgetVersion = determineWidgetsVersion(
+      it(`should determine correct widget version when ${testCase.title}`, async () => {
+        const widgetVersion = await determineWidgetsVersion(
           testCase.validatedBuildVersion,
           testCase.initVersionProvided,
           testCase?.checkoutVersionConfig,
         );
         expect(widgetVersion).toEqual(testCase.expectedVersion);
       });
+    });
+  });
+
+  describe('Get Latest Version from NPM', () => {
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return the latest version when the fetch succeeds', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.82.3' },
+        }),
+      });
+
+      const version = await getLatestVersionFromNpm();
+      expect(version).toBe('1.82.3');
+    });
+
+    it('should return "latest" if the response is not ok', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      });
+
+      const version = await getLatestVersionFromNpm();
+      expect(version).toBe('latest');
+    });
+
+    it('should return "latest" if the response has no "dist-tags"', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const version = await getLatestVersionFromNpm();
+      expect(version).toBe('latest');
+    });
+
+    it('should return "latest" if the "latest" tag is empty or missing', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '' },
+        }),
+      });
+
+      const version = await getLatestVersionFromNpm();
+      expect(version).toBe('latest');
+    });
+
+    it('should return "latest" if fetch throws a network error', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network Error'));
+
+      const version = await getLatestVersionFromNpm();
+      expect(version).toBe('latest');
+    });
+
+    it('should return "latest" if the JSON response is invalid', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      const version = await getLatestVersionFromNpm();
+      expect(version).toBe('latest');
     });
   });
 });

--- a/packages/checkout/sdk/src/widgets/version.ts
+++ b/packages/checkout/sdk/src/widgets/version.ts
@@ -73,8 +73,9 @@ export async function getLatestVersionFromNpm() {
 
     const data = await response.json();
 
-    const latestVersion = data['dist-tags']?.latest;
-    if (typeof latestVersion === 'string' && latestVersion.trim() !== '') {
+    const latestVersion = data.version;
+
+    if (typeof data.version === 'string' && latestVersion.trim() !== '') {
       return latestVersion;
     }
     return fallbackVersion;

--- a/packages/checkout/sdk/src/widgets/version.ts
+++ b/packages/checkout/sdk/src/widgets/version.ts
@@ -60,8 +60,8 @@ export function validateAndBuildVersion(
  * Falls back to 'latest' if an error occurs or if the response is invalid.
  * @returns {Promise<string>} A promise resolving to the latest version string or 'latest'.
  */
-export async function getLatestVersionFromNpm() {
-  const npmRegistryUrl = 'https://registry.npmjs.org/@imtbl/sdk';
+export async function getLatestVersionFromNpm(): Promise<string> {
+  const npmRegistryUrl = 'https://registry.npmjs.org/@imtbl/sdk/latest';
   const fallbackVersion = 'latest';
 
   try {
@@ -72,12 +72,12 @@ export async function getLatestVersionFromNpm() {
     }
 
     const data = await response.json();
+    const version = data.version?.trim();
 
-    const latestVersion = data.version;
-
-    if (typeof data.version === 'string' && latestVersion.trim() !== '') {
-      return latestVersion;
+    if (version) {
+      return version;
     }
+
     return fallbackVersion;
   } catch (error) {
     return fallbackVersion;


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Currently, when the widgets are requesting the `@latest` version from the CDN, the CDN provides the stale version as its caching policy is 12 hours while the browser caching policy is 7 days. This means that when a new version is released, the users might not be able to access it until days later. This is especially important when a patch is released to fix a production bug. 

To solve this, instead of loading `@latest` version, we try to load a specific version, e.g. `1.70.5`. This avoids the problem where the `@latest` cache entry is stale. 

Fallback to use `@latest` version if the npm registry is unavailable. 


