### PR TITLE
ID-2747 - Adding waitForReceipt function to track when tx confirms

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/hooks/useExecute.ts
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/hooks/useExecute.ts
@@ -22,17 +22,17 @@ export const useExecute = (environment: Environment) => {
       async () => {
         const receipt = await provider.getTransactionReceipt(txHash);
         if (!receipt) {
-          throw new Error('Receipt not found');
+          throw new Error('receipt not found');
         }
         if (receipt.status === 0) {
-          throw new Error('Transaction failed');
+          throw new Error('status failed');
         }
         return receipt;
       },
       {
         retries: maxAttempts,
         retryIntervalMs: 1000,
-        nonRetryable: (error) => error.message === 'Transaction failed',
+        nonRetryable: (error) => error.message === 'status failed',
       },
     );
 

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/hooks/useExecute.ts
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/hooks/useExecute.ts
@@ -19,18 +19,13 @@ export const useExecute = (environment: Environment) => {
   const waitForReceipt = async (provider: Web3Provider, txHash: string, maxAttempts = 60) => {
     let attempts = 0;
     while (attempts < maxAttempts) {
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const receipt = await provider.getTransactionReceipt(txHash);
-        if (receipt) {
-          if (receipt.status === 0) {
-            throw new Error('Transaction failed');
-          }
-          return receipt;
+      // eslint-disable-next-line no-await-in-loop
+      const receipt = await provider.getTransactionReceipt(txHash);
+      if (receipt) {
+        if (receipt.status === 0) {
+          throw new Error('Transaction failed');
         }
-      } catch (err) {
-        console.warn('Error checking receipt:', err);
-        throw err;
+        return receipt;
       }
       attempts += 1;
       // eslint-disable-next-line no-await-in-loop, no-promise-executor-return


### PR DESCRIPTION
# Summary

`tx.wait()` is taking a lot longer to return, this is likely due to the RPC of our chain not having websockets enabled. This simple function polls every 1 second for the tx receipt and also checks the status (which wasn't being checked before).


https://github.com/user-attachments/assets/a3bd99b3-4cfa-4ab4-a13f-b701c0c166ca


# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
