### PR TITLE
fix: Skip identifyUser call when connecting destination wallet

### DIFF
--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/ConnectWalletDrawer.tsx
@@ -45,6 +45,7 @@ type ConnectWalletDrawerProps = {
     rdns: string;
   }[];
   getShouldRequestWalletPermissions?: (providerInfo: EIP6963ProviderInfo) => boolean | undefined;
+  shouldIdentifyUser?: boolean;
 };
 
 export function ConnectWalletDrawer({
@@ -59,6 +60,7 @@ export function ConnectWalletDrawer({
   menuItemSize = 'small',
   disabledOptions = [],
   getShouldRequestWalletPermissions,
+  shouldIdentifyUser = true,
 }: ConnectWalletDrawerProps) {
   const {
     providersState: { checkout, fromProvider },
@@ -143,8 +145,11 @@ export function ConnectWalletDrawer({
         checkout,
         shouldRequestWalletPermissions,
       );
-      // Identify connected wallet
-      await identifyUser(identify, provider);
+
+      if (shouldIdentifyUser) {
+        // Identify connected wallet
+        await identifyUser(identify, provider);
+      }
 
       // Store selected provider as fromProvider in context
       address = await setProviderInContext(provider, providerDetail.info);

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/DeliverToWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/DeliverToWalletDrawer.tsx
@@ -53,6 +53,7 @@ export function DeliverToWalletDrawer({
       getShouldRequestWalletPermissions={
         selectedSameFromWalletType
       }
+      shouldIdentifyUser={false}
     />
   );
 }


### PR DESCRIPTION
# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

The user is being identified through Segment twice, one for each connection. In case the destination wallet is different than the source, tracking goes off as the anonymous ID is re-generated.

Identify should only be called once, from the source wallet.