### PR TITLE
Wait for geoblock results before sending Segment event

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/context/AddTokensContext.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/context/AddTokensContext.tsx
@@ -15,7 +15,7 @@ export interface AddTokensState {
   selectedRouteData: RouteData | undefined;
   selectedToken: TokenInfo | undefined;
   selectedAmount: string;
-  isSwapAvailable: boolean;
+  isSwapAvailable: boolean | undefined;
 }
 
 export const initialAddTokensState: AddTokensState = {
@@ -29,7 +29,7 @@ export const initialAddTokensState: AddTokensState = {
   selectedRouteData: undefined,
   selectedToken: undefined,
   selectedAmount: '',
-  isSwapAvailable: false,
+  isSwapAvailable: undefined,
 };
 
 export interface AddTokensContextState {

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/views/AddTokens.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/views/AddTokens.tsx
@@ -255,7 +255,8 @@ export function AddTokens({
   );
 
   useEffect(() => {
-    if (!id) { return; }
+    if (!id || isSwapAvailable === undefined) { return; }
+
     page({
       userJourney: UserJourney.ADD_TOKENS,
       screen: 'InputScreen',


### PR DESCRIPTION
# Summary
When the result for the geoblock is false, `isSwapAvailable` changes from `false` to `true`, triggering this event twice. 
