### PR TITLE
[NO CHANGELOG] [Add Tokens Widget] fix: Add immutableZkEVMTxHash success track event 

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/views/Review.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/views/Review.tsx
@@ -26,6 +26,7 @@ import { RouteResponse } from '@0xsquid/squid-types';
 import { t } from 'i18next';
 import { Trans } from 'react-i18next';
 import { Environment } from '@imtbl/config';
+import { ChainId } from '@imtbl/checkout-sdk';
 import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
 import { AddTokensContext } from '../context/AddTokensContext';
 import { useRoutes } from '../hooks/useRoutes';
@@ -381,7 +382,10 @@ export function Review({
         action: 'Succeeded',
         extras: {
           contextId: id,
-          txHash: executeTxnReceipt.transactionHash,
+          ...(route.route.params.fromChain !== ChainId.IMTBL_ZKEVM_MAINNET.toString()
+            && { txHash: executeTxnReceipt.transactionHash }),
+          ...(route.route.params.fromChain === ChainId.IMTBL_ZKEVM_MAINNET.toString()
+            && { immutableZkEVMTxHash: executeTxnReceipt.transactionHash }),
         },
       });
 


### PR DESCRIPTION
# Summary
Add to send immutableZkEVMTxHash for immutable zkEVM chain
for other chains txHash

![Screenshot 2024-11-28 at 4 23 39 PM](https://github.com/user-attachments/assets/aab5d6be-953a-4ec8-95b3-5f7e6ebf02cf)
![Screenshot 2024-11-28 at 4 22 36 PM](https://github.com/user-attachments/assets/f6b258d9-c31a-4c93-aae3-dbc2fbc66767)


