### PR TITLE
chore: Prepend zero to decimal amounts when dot is the first input

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/functions/amountValidation.ts
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/functions/amountValidation.ts
@@ -6,7 +6,12 @@ const VALID_NUMBER_REGEX = /^(0|[1-9]\d*)(\.\d*)?$/;
  * @returns An object containing the sanitized value, the float amount, and a boolean indicating if the amount is valid
  */
 export const validateToAmount = (amount: string) => {
-  const value = amount || '';
+  let value = amount || '';
+
+  if (amount === '.') {
+    value = '0.';
+  }
+
   const sanitizedValue = value.replace(/^0+(?=\d)/, '');
   const isValid = VALID_NUMBER_REGEX.test(sanitizedValue);
   const floatAmount = isValid ? parseFloat(sanitizedValue) : NaN;


### PR DESCRIPTION
# Summary
When inputting a decimal, some users will start with a dot instead of a zero. That case was invalid, so we're prepending a zero now.
