### PR TITLE
fix: Move identify call to destination wallet on Add Tokens flow

### DIFF
--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/DeliverToWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/DeliverToWalletDrawer.tsx
@@ -53,7 +53,6 @@ export function DeliverToWalletDrawer({
       getShouldRequestWalletPermissions={
         selectedSameFromWalletType
       }
-      shouldIdentifyUser={false}
     />
   );
 }

--- a/packages/checkout/widgets-lib/src/components/WalletDrawer/PayWithWalletDrawer.tsx
+++ b/packages/checkout/widgets-lib/src/components/WalletDrawer/PayWithWalletDrawer.tsx
@@ -79,6 +79,7 @@ export function PayWithWalletDrawer({
       disabledOptions={disabledOptions}
       bottomSlot={payWithCardItem}
       onConnect={handleOnConnect}
+      shouldIdentifyUser={false}
     />
   );
 }

--- a/packages/checkout/widgets-sample-app/src/components/ui/add-tokens/addTokens.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/add-tokens/addTokens.tsx
@@ -45,7 +45,8 @@ function AddTokensUI() {
     [checkout]
   );
 
-  const [presetToProvider, setPresetToProvider] = useState<boolean>(false);
+  const getPersistedToPresetProvider = () => localStorage.getItem('imtbl/addtokens_presetToProvider') === 'true';
+  const [presetToProvider, setPresetToProvider] = useState<boolean>(getPersistedToPresetProvider());
   const [toProvider, setToProvider] = useState<Web3Provider | undefined>(undefined);
 
   const [toTokenAddress, setToTokenAddress] = useState<string | undefined>(undefined);
@@ -81,6 +82,12 @@ function AddTokensUI() {
   }, []);
 
   useEffect(() => {
+    const presetToProviderValue = getPersistedToPresetProvider();
+
+    if (presetToProviderValue !== presetToProvider) {
+      localStorage.setItem('imtbl/addtokens_presetToProvider', presetToProvider.toString());
+    }
+
     if (!checkout || !factory) return;
     if (!presetToProvider) {
       toProvider && addTokens.unmount();


### PR DESCRIPTION
# Summary
Given the wallet being funded is most likely to be our target user, we're shifting the `identify` call to only happen once the "to" wallet is filled. The `identify` call should also happen when a `toProvider` is passed on the initial widget config.
