### PR TITLE
Fix/autoupdating cdn downtime

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -136,6 +136,12 @@ jobs:
         with:
           subject-path: './sdk'
 
+      - name: Generate last_updated.json
+        if: (env.DRY_RUN) == 'false'
+        run: |
+          echo "{\"last_updated\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > ./sdk/last_updated.json
+          cp ./sdk/last_updated.json ./sdk/dist/
+
       - name: Authenticate NPM
         if: contains(env.RELEASE_TYPE, 'release')
         run: npm config set //registry.npmjs.org/:_authToken ${{ secrets.TS_IMMUTABLE_SDK_NPM_TOKEN }}

--- a/packages/checkout/sdk/src/widgets/version.ts
+++ b/packages/checkout/sdk/src/widgets/version.ts
@@ -85,33 +85,6 @@ export async function getLatestVersionFromNpm(): Promise<string> {
 }
 
 /**
- * Checks if the provided version is available on the CDN.
- * @param {string} version - The version to check.
- * @returns {Promise<boolean>} A promise resolving to a boolean indicating if the version is available on the CDN.
- */
-async function isVersionAvailableOnCDN(version: string): Promise<boolean> {
-  const files = ['widgets-esm.js', 'widgets.js'];
-  const baseUrl = `https://cdn.jsdelivr.net/npm/@imtbl/sdk@${version}/dist/browser/checkout/`;
-
-  try {
-    const checks = files.map(async (file) => {
-      const response = await fetch(`${baseUrl}${file}`, { method: 'HEAD' });
-      if (!response.ok) {
-        return false;
-      }
-      return true;
-    });
-
-    const results = await Promise.all(checks);
-    const allFilesAvailable = results.every((isAvailable) => isAvailable);
-
-    return allFilesAvailable;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Returns the latest compatible version based on the provided checkout version config.
  * If no compatible version markers are provided, it returns 'latest'.
  */
@@ -125,6 +98,38 @@ function latestCompatibleVersion(
     }
   }
   return 'latest';
+}
+
+/**
+ * Checks if the last_updated.json file exists on the CDN and validates its timestamp.
+ * @param {string} version - The version to check.
+ * @returns {Promise<boolean>} A promise resolving to `true` if last_updated.json exists and is older than 15 minutes, `false` otherwise.
+ */
+async function checkLastUpdatedTimestamp(version: string): Promise<boolean> {
+  const lastUpdatedJsonUrl = `https://cdn.jsdelivr.net/npm/@imtbl/sdk@${version}/dist/last_updated.json`;
+
+  try {
+    const response = await fetch(lastUpdatedJsonUrl);
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const lastUpdatedData = await response.json();
+
+    if (lastUpdatedData.timestamp) {
+      const timestamp = new Date(lastUpdatedData.timestamp);
+      const now = new Date();
+      const diffInMs = now.getTime() - timestamp.getTime();
+      const diffInMinutes = diffInMs / (1000 * 60);
+
+      return diffInMinutes > 15; // Return true if the timestamp is older than 15 minutes
+    }
+  } catch (error) {
+    return false;
+  }
+
+  return false;
 }
 
 /**
@@ -158,13 +163,14 @@ export async function determineWidgetsVersion(
     versionConfig.compatibleVersionMarkers,
   );
 
-  // If `latest` is returned, query NPM registry for the actual latest version and check if it's available on the CDN
+  // If `latest` is returned, query NPM registry for the actual latest version and check timestamp
   if (compatibleVersion === 'latest') {
     const latestVersion = await getLatestVersionFromNpm();
-    const isAvailable = await isVersionAvailableOnCDN(latestVersion);
-    if (isAvailable) {
+
+    if (await checkLastUpdatedTimestamp(latestVersion)) {
       return latestVersion;
     }
+
     return 'latest';
   }
 

--- a/packages/checkout/sdk/src/widgets/version.ts
+++ b/packages/checkout/sdk/src/widgets/version.ts
@@ -106,6 +106,8 @@ function latestCompatibleVersion(
  * @returns {Promise<boolean>} A promise resolving to `true` if last_updated.json exists and is older than 15 minutes, `false` otherwise.
  */
 async function checkLastUpdatedTimestamp(version: string): Promise<boolean> {
+  const WAIT_TIME_IN_MINUTES = 15;
+
   const lastUpdatedJsonUrl = `https://cdn.jsdelivr.net/npm/@imtbl/sdk@${version}/dist/last_updated.json`;
 
   try {
@@ -123,7 +125,7 @@ async function checkLastUpdatedTimestamp(version: string): Promise<boolean> {
       const diffInMs = now.getTime() - timestamp.getTime();
       const diffInMinutes = diffInMs / (1000 * 60);
 
-      return diffInMinutes > 15; // Return true if the timestamp is older than 15 minutes
+      return diffInMinutes > WAIT_TIME_IN_MINUTES;
     }
   } catch (error) {
     return false;

--- a/packages/checkout/sdk/src/widgets/version.ts
+++ b/packages/checkout/sdk/src/widgets/version.ts
@@ -106,7 +106,7 @@ function latestCompatibleVersion(
  * @returns {Promise<boolean>} A promise resolving to `true` if last_updated.json exists and is older than 15 minutes, `false` otherwise.
  */
 async function checkLastUpdatedTimestamp(version: string): Promise<boolean> {
-  const WAIT_TIME_IN_MINUTES = 15;
+  const WAIT_TIME_IN_MINUTES = 20;
 
   const lastUpdatedJsonUrl = `https://cdn.jsdelivr.net/npm/@imtbl/sdk@${version}/dist/last_updated.json`;
 


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
To resolve issues with CDN and browser caching when loading the `@latest` version of the package, we have previously introduced a mechanism to query the NPM registry for a specific version.

This approach ensures that apps hosting the widget load a precise version of the package, such as:
https://cdn.jsdelivr.net/npm/@imtbl/sdk@1.76.0/dist/browser/checkout/widgets-esm.js.

While this resolves caching issues, it introduces a new issue: CDN propagation delays. It typically takes 5–10 minutes for the new version to become fully available on the CDN. During this period, if a user accesses the app, the widget's files for the specific the specific latest version may not yet be accessible.

This PR adds a `last_updated.json` file containing a timestamp recorded just before the package is published to NPM. The widget:

1. Queries the NPM registry for the latest specific version.
2. Checks the `last_updated.json` file on the CDN.
3. If less than 20 mins have passed since the release timestamp, it falls back to the `@latest` version (https://cdn.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout/widgets-esm.js).
4. If more than 20 mins have passed, it loads the specific latest version.

This ensures users have access to the latest version of widgets while avoiding the downtime due to CDN propagation delays. The experience remains seamless, requiring no user intervention (e.g. no need for hard browser reloads to clear browser cache).


