### PR TITLE
Fix typo in last_updated.json

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: Generate last_updated.json
         if: (env.DRY_RUN) == 'false'
         run: |
-          echo "{\"last_updated\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > ./sdk/last_updated.json
+          echo "{\"timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > ./sdk/last_updated.json
           cp ./sdk/last_updated.json ./sdk/dist/
 
       - name: Authenticate NPM


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Fix typo, as the widgets access the value `timestamp` in `last_updated.json` file not `last_updated`.