### PR TITLE
Fix/Move last updated file generation to be above attestations step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -130,17 +130,17 @@ jobs:
           tag: ${{ contains(env.RELEASE_TYPE, 'alpha') && 'alpha' }}
           dry-run: ${{ env.DRY_RUN }}
 
+      - name: Generate last_updated.json
+        if: (env.DRY_RUN) == 'false'
+        run: |
+          echo "{\"timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > ./sdk/last_updated.json
+          cp ./sdk/last_updated.json ./sdk/dist/
+
       # ! Do NOT remove - this will cause a Sev 0 incident !
       - name: Generate SDK attestation
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: './sdk'
-
-      - name: Generate last_updated.json
-        if: (env.DRY_RUN) == 'false'
-        run: |
-          echo "{\"last_updated\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > ./sdk/last_updated.json
-          cp ./sdk/last_updated.json ./sdk/dist/
 
       - name: Authenticate NPM
         if: contains(env.RELEASE_TYPE, 'release')

--- a/packages/checkout/sdk/src/widgets/version.ts
+++ b/packages/checkout/sdk/src/widgets/version.ts
@@ -106,7 +106,7 @@ function latestCompatibleVersion(
  * @returns {Promise<boolean>} A promise resolving to `true` if last_updated.json exists and is older than 15 minutes, `false` otherwise.
  */
 async function checkLastUpdatedTimestamp(version: string): Promise<boolean> {
-  const WAIT_TIME_IN_MINUTES = 20;
+  const WAIT_TIME_IN_MINUTES = 45;
 
   const lastUpdatedJsonUrl = `https://cdn.jsdelivr.net/npm/@imtbl/sdk@${version}/dist/last_updated.json`;
 


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Moved `Generate last_updated.json` step to be above `Generate SDK attestation` step based on https://imtbl.slack.com/archives/C051FKT784S/p1734394527440039

Bumped the wait time as `Generate SDK attestation` step on average takes around 20 minutes.
