### PR TITLE
refactor: use version.json for autoupdating & remove dependency on npm registry for checking for latest version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -130,12 +130,6 @@ jobs:
           tag: ${{ contains(env.RELEASE_TYPE, 'alpha') && 'alpha' }}
           dry-run: ${{ env.DRY_RUN }}
 
-      - name: Generate last_updated.json
-        if: (env.DRY_RUN) == 'false'
-        run: |
-          echo "{\"timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}" > ./sdk/last_updated.json
-          cp ./sdk/last_updated.json ./sdk/dist/
-
       # ! Do NOT remove - this will cause a Sev 0 incident !
       - name: Generate SDK attestation
         uses: actions/attest-build-provenance@v1
@@ -157,6 +151,13 @@ jobs:
         run: |
           wget https://cdn.jsdelivr.net/npm/@imtbl/sdk/dist/browser/checkout/widgets.js
           wget https://cdn.jsdelivr.net/npm/@imtbl/sdk/dist/browser/checkout/sdk.js
+
+      - name: Purge CDN Cache for @latest version
+        id: purge_cdn
+        if: contains(env.RELEASE_TYPE, 'release') && env.DRY_RUN == 'false'
+        run: |
+          curl -X GET https://purge.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout
+          echo "CDN cache purged for https://cdn.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout"
 
       # Wait for 30 seconds to make sure the tag is available on GitHub
       - uses: GuillaumeFalourd/wait-sleep-action@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -94,6 +94,11 @@ jobs:
         id: version
         run: |
           echo "NEXT_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+          
+      - name: Generate version.json
+        run: |
+          echo '{ "version": "${{ steps.version.outputs.NEXT_VERSION }}" }' > ./sdk/version.json
+          cp ./sdk/version.json ./sdk/dist/
 
       - name: Typecheck
         run: yarn typecheck
@@ -152,13 +157,6 @@ jobs:
           wget https://cdn.jsdelivr.net/npm/@imtbl/sdk/dist/browser/checkout/widgets.js
           wget https://cdn.jsdelivr.net/npm/@imtbl/sdk/dist/browser/checkout/sdk.js
 
-      - name: Purge CDN Cache for @latest version
-        id: purge_cdn
-        if: contains(env.RELEASE_TYPE, 'release') && env.DRY_RUN == 'false'
-        run: |
-          curl -X GET https://purge.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout
-          echo "CDN cache purged for https://cdn.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout"
-
       # Wait for 30 seconds to make sure the tag is available on GitHub
       - uses: GuillaumeFalourd/wait-sleep-action@v1
         with:
@@ -187,3 +185,10 @@ jobs:
         uses: ./.github/actions/notify-slack-publish-status
         with:
           message: "❌ Failed to publish SDK version ${{steps.version.outputs.NEXT_VERSION}} to NPM. ${{ github.triggering_actor }} please check the logs for more details."
+
+      - name: Purge CDN Cache for @latest version
+        id: purge_cdn
+        if: contains(env.RELEASE_TYPE, 'release') && env.DRY_RUN == 'false'
+        run: |
+          curl -X GET https://purge.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout
+          echo "CDN cache purged for https://cdn.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -186,9 +186,29 @@ jobs:
         with:
           message: "❌ Failed to publish SDK version ${{steps.version.outputs.NEXT_VERSION}} to NPM. ${{ github.triggering_actor }} please check the logs for more details."
 
-      - name: Purge CDN Cache for @latest version
+    - name: Wait for NPM @latest Update
+        id: wait_for_npm_update
+        if: contains(env.RELEASE_TYPE, 'release') && env.DRY_RUN == 'false'
+        run: |
+          VERSION="${{ steps.version.outputs.NEXT_VERSION }}"
+          echo "Waiting for NPM registry to reflect version: $VERSION"
+
+          for i in {1..20}; do
+            LATEST_VERSION=$(npm view @imtbl/sdk@latest version)
+            if [[ "$LATEST_VERSION" == "$VERSION" ]]; then
+              echo "NPM registry updated to version: $LATEST_VERSION"
+              exit 0
+            fi
+            echo "NPM registry not updated yet, retrying in 15 seconds..."
+            sleep 15
+          done
+
+          echo "NPM registry failed to update after 5 minutes."
+          exit 1
+
+      - name: Purge CDN Cache for version.json
         id: purge_cdn
         if: contains(env.RELEASE_TYPE, 'release') && env.DRY_RUN == 'false'
         run: |
-          curl -X GET https://purge.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout
-          echo "CDN cache purged for https://cdn.jsdelivr.net/npm/@imtbl/sdk@latest/dist/browser/checkout"
+          curl -X GET https://purge.jsdelivr.net/npm/@imtbl/sdk@latest/dist/version.json
+          echo "CDN cache purged for https://cdn.jsdelivr.net/npm/@imtbl/sdk@latest/dist/version.json"

--- a/packages/checkout/sdk/src/sdk.ts
+++ b/packages/checkout/sdk/src/sdk.ts
@@ -77,7 +77,7 @@ import { isMatchingAddress } from './utils/utils';
 import * as wallet from './wallet';
 import { WidgetConfiguration } from './widgets/definitions/configurations';
 import { getWidgetsEsmUrl, loadUnresolvedBundle } from './widgets/load';
-import { determineWidgetsVersion, getLatestVersionFromNpm, validateAndBuildVersion } from './widgets/version';
+import { determineWidgetsVersion, getLatestVersion, validateAndBuildVersion } from './widgets/version';
 import { globalPackageVersion } from './env';
 import { AssessmentResult, fetchRiskAssessment, isAddressSanctioned } from './riskAssessment';
 
@@ -274,9 +274,9 @@ export class Checkout {
     try {
       return await tryLoadEsModule(validVersion);
     } catch (err: any) {
-      const latestVersion = await getLatestVersionFromNpm();
+      const latestVersion = await getLatestVersion();
 
-      if (validVersion === latestVersion) {
+      if (validVersion === latestVersion && validVersion !== 'latest') {
         try {
           return await tryLoadEsModule('latest');
         } catch (retryErr: any) {

--- a/packages/checkout/sdk/src/widgets/version.test.ts
+++ b/packages/checkout/sdk/src/widgets/version.test.ts
@@ -1,7 +1,7 @@
 import { SDK_VERSION_MARKER } from '../env';
 import { CheckoutWidgetsVersionConfig } from '../types';
 import { SemanticVersion } from './definitions/types';
-import { determineWidgetsVersion, getLatestVersionFromNpm, validateAndBuildVersion } from './version';
+import { determineWidgetsVersion, validateAndBuildVersion } from './version';
 
 describe('CheckoutWidgets', () => {
   const SDK_VERSION = SDK_VERSION_MARKER;
@@ -341,79 +341,6 @@ describe('CheckoutWidgets', () => {
         );
         expect(widgetVersion).toEqual(testCase.expectedVersion);
       });
-    });
-  });
-
-  describe('Get Latest Version from NPM', () => {
-    beforeEach(() => {
-      global.fetch = jest.fn();
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it('should return the latest version when the fetch succeeds', async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          version: '1.82.3',
-        }),
-      });
-
-      const version = await getLatestVersionFromNpm();
-      expect(version).toBe('1.82.3');
-    });
-
-    it('should return "latest" if the response is not ok', async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({}),
-      });
-
-      const version = await getLatestVersionFromNpm();
-      expect(version).toBe('latest');
-    });
-
-    it('should return "latest" if the response has no "dist-tags"', async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({}),
-      });
-
-      const version = await getLatestVersionFromNpm();
-      expect(version).toBe('latest');
-    });
-
-    it('should return "latest" if the "latest" tag is empty or missing', async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          'dist-tags': { latest: '' },
-        }),
-      });
-
-      const version = await getLatestVersionFromNpm();
-      expect(version).toBe('latest');
-    });
-
-    it('should return "latest" if fetch throws a network error', async () => {
-      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network Error'));
-
-      const version = await getLatestVersionFromNpm();
-      expect(version).toBe('latest');
-    });
-
-    it('should return "latest" if the JSON response is invalid', async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => {
-          throw new Error('Invalid JSON');
-        },
-      });
-
-      const version = await getLatestVersionFromNpm();
-      expect(version).toBe('latest');
     });
   });
 });

--- a/packages/checkout/sdk/src/widgets/version.ts
+++ b/packages/checkout/sdk/src/widgets/version.ts
@@ -101,40 +101,6 @@ function latestCompatibleVersion(
 }
 
 /**
- * Checks if the last_updated.json file exists on the CDN and validates its timestamp.
- * @param {string} version - The version to check.
- * @returns {Promise<boolean>} A promise resolving to `true` if last_updated.json exists and is older than 15 minutes, `false` otherwise.
- */
-async function checkLastUpdatedTimestamp(version: string): Promise<boolean> {
-  const WAIT_TIME_IN_MINUTES = 45;
-
-  const lastUpdatedJsonUrl = `https://cdn.jsdelivr.net/npm/@imtbl/sdk@${version}/dist/last_updated.json`;
-
-  try {
-    const response = await fetch(lastUpdatedJsonUrl);
-
-    if (!response.ok) {
-      return false;
-    }
-
-    const lastUpdatedData = await response.json();
-
-    if (lastUpdatedData.timestamp) {
-      const timestamp = new Date(lastUpdatedData.timestamp);
-      const now = new Date();
-      const diffInMs = now.getTime() - timestamp.getTime();
-      const diffInMinutes = diffInMs / (1000 * 60);
-
-      return diffInMinutes > WAIT_TIME_IN_MINUTES;
-    }
-  } catch (error) {
-    return false;
-  }
-
-  return false;
-}
-
-/**
  * Determines the version of the widgets to use based on the provided validated build version and checkout version config.
  * If a version is provided in the widget init parameters, it uses that version.
  * If the build version is an alpha, it uses that version.
@@ -165,15 +131,9 @@ export async function determineWidgetsVersion(
     versionConfig.compatibleVersionMarkers,
   );
 
-  // If `latest` is returned, query NPM registry for the actual latest version and check timestamp
+  // If `latest` is returned, query NPM registry for the actual latest version
   if (compatibleVersion === 'latest') {
-    const latestVersion = await getLatestVersionFromNpm();
-
-    if (await checkLastUpdatedTimestamp(latestVersion)) {
-      return latestVersion;
-    }
-
-    return 'latest';
+    return await getLatestVersionFromNpm();
   }
 
   return compatibleVersion;

--- a/packages/checkout/sdk/src/widgets/version.ts
+++ b/packages/checkout/sdk/src/widgets/version.ts
@@ -55,17 +55,16 @@ export function validateAndBuildVersion(
 }
 
 /**
- * Fetches the latest version of the package from the NPM registry.
- * Loads a specific latest version instead of relying on the latest tag helps with caching issues.
- * Falls back to 'latest' if an error occurs or if the response is invalid.
+ * Fetches the latest version of the package from the JSDelivr version.json file.
+ * Falls back to 'latest' if an error occurs or the response is invalid.
  * @returns {Promise<string>} A promise resolving to the latest version string or 'latest'.
  */
-export async function getLatestVersionFromNpm(): Promise<string> {
-  const npmRegistryUrl = 'https://registry.npmjs.org/@imtbl/sdk/latest';
+export async function getLatestVersion(): Promise<string> {
+  const cacheBustingUrl = `https://cdn.jsdelivr.net/npm/@imtbl/sdk@latest/dist/version.json?t=${Date.now()}`;
   const fallbackVersion = 'latest';
 
   try {
-    const response = await fetch(npmRegistryUrl);
+    const response = await fetch(cacheBustingUrl);
 
     if (!response.ok) {
       return fallbackVersion;
@@ -131,9 +130,9 @@ export async function determineWidgetsVersion(
     versionConfig.compatibleVersionMarkers,
   );
 
-  // If `latest` is returned, query NPM registry for the actual latest version
+  // If `latest` is returned, query CDN for the actual latest version
   if (compatibleVersion === 'latest') {
-    return await getLatestVersionFromNpm();
+    return await getLatestVersion();
   }
 
   return compatibleVersion;


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

This PR enhances the widgets autoupdating strategy by removing the dependency on the NPM registry endpoint `https://registry.npmjs.org/@imtbl/sdk/latest`. The new approach uses a dedicated `version.json` file created during the publishing workflow. 

Currently, we rely on the NPM registry endpoint `https://registry.npmjs.org/@imtbl/sdk/latest` to get the specific latest version. This solves our browser and CDN caching issues for the `@latest` version but requires anyone using the widgets to whitelist `registry.npmjs.org` in CSP. The browser and CDN caching issue will persist if the app's CSP policy is blocking the `registry.npmjs.org`. 

The workflow now creates the `version.json` file and uploads it to `dist`.  It waits for the NPM to propagate the latest version successfully, then purges the CDN cache for `version.json` file. 

The widgets will fetch the specific latest version from this file using a cache-busting timestamp to avoid browser caching issues `https://cdn.jsdelivr.net/npm/@imtbl/sdk@latest/dist/version.json?t=${Date.now()}`.

If the widgets factory cannot be created for the latest specific version, potentially due to CDN propagation delays, the widgets fall back to the `@latest `version.

