### PR TITLE
chore: add Security to .github as approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @immutable/sdk
-./github/CODEOWNERS @immutable/security @immutable/sdk
+./github @immutable/security @immutable/sdk
 /.husky @immutable/sdk
 /.nvmrc @immutable/sdk
 /sdk @immutable/sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @immutable/sdk
-./github @immutable/security @immutable/sdk
+.github @immutable/security @immutable/sdk
 /.husky @immutable/sdk
 /.nvmrc @immutable/sdk
 /sdk @immutable/sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 * @immutable/sdk
+./github/CODEOWNERS @immutable/security @immutable/sdk
 /.husky @immutable/sdk
 /.nvmrc @immutable/sdk
 /sdk @immutable/sdk


### PR DESCRIPTION
# Summary
Adds Security as approvers in CODEOWNERS to `.github`, along with the SDK team
