### PR TITLE
[SRE-2781] Set publishing workflows to use prod env

### DIFF
--- a/.github/workflows/publish-major-version.yaml
+++ b/.github/workflows/publish-major-version.yaml
@@ -30,6 +30,7 @@ on:
 jobs:
   PublishMajorVersion:
     name: Publish Workflow
+    environment: prod
     runs-on: ubuntu-latest-4-cores
     env:
       GH_TOKEN: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
@@ -108,7 +109,7 @@ jobs:
           key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
       - name: Lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,6 +42,7 @@ concurrency:
 jobs:
   Publish:
     name: Publish Workflow
+    environment: prod
     runs-on: ubuntu-latest-4-cores
     env:
       GH_TOKEN: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
@@ -140,7 +141,7 @@ jobs:
       - name: Generate SDK attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: './sdk'
+          subject-path: "./sdk"
 
       - name: Authenticate NPM
         if: contains(env.RELEASE_TYPE, 'release')


### PR DESCRIPTION
TS_IMMUTABLE_SDK_NPM_TOKEN secret will now be stored as an environment secret in prod environment, meaning it will only be accessible from workflows running against prod env. This is to ensure only protected main brain with required reviews is able to publish to NPM to mitigate potential security incidents. 

Prod env will require reviewers from the sdk team, and these workflows will only be executable against main. 