### PR TITLE
fix: Move version.json generation to be after build step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -94,12 +94,6 @@ jobs:
         id: version
         run: |
           echo "NEXT_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
-          
-      - name: Generate version.json
-        if: (env.DRY_RUN) == 'false'
-        run: |
-          echo '{ "version": "${{ steps.version.outputs.NEXT_VERSION }}" }' > ./sdk/version.json
-          cp ./sdk/version.json ./sdk/dist/
 
       - name: Typecheck
         run: yarn typecheck
@@ -118,6 +112,12 @@ jobs:
           export NODE_OPTIONS=--max-old-space-size=6144 && RELEASE_TYPE=${{ env.RELEASE_TYPE }} yarn build
           ls -l ./sdk/dist/browser/checkout || echo 1
           [ -d "./sdk/dist/browser/checkout" ] || { echo "Error: Directory does not exist." && exit 1; }
+
+      - name: Generate version.json
+        if: (env.DRY_RUN) == 'false'
+        run: |
+          echo '{ "version": "${{ steps.version.outputs.NEXT_VERSION }}" }' > ./sdk/version.json
+          cp ./sdk/version.json ./sdk/dist/
 
       - name: Push tags
         # Boolean inputs are not actually booleans, see https://github.com/actions/runner/issues/1483


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
- Move the `Generate version.json` step to be after the `Build` step as `./sdk/dist/` directory is created during the `Build` step

This PR is related to https://github.com/immutable/ts-immutable-sdk/pull/2471

