### PR TITLE
chore: bust cache for publish docs action

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -95,7 +95,7 @@ jobs:
           key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
+        # if: steps.restore-cache-node_modules.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
       - name: Build


### PR DESCRIPTION
# Summary
Refersh dependency cache for publish docs action in hope to fix https://github.com/immutable/ts-immutable-sdk/actions/runs/12642926453/job/35228101920#step:12:289
