### PR TITLE
Revert "chore: bust cache for publish docs action"

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -95,7 +95,7 @@ jobs:
           key: ${{ runner.os }}-build-cache-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        # if: steps.restore-cache-node_modules.outputs.cache-hit != 'true'
+        if: steps.restore-cache-node_modules.outputs.cache-hit != 'true' 
         run: yarn install --immutable
 
       - name: Build


### PR DESCRIPTION
Reverts immutable/ts-immutable-sdk#2487

This is to re-enable cache for documentation publish action