### PR TITLE
fix: add-concurrency-group-for-publish-docs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: public-docs
+  cancel-in-progress: false
+
 jobs:
   AlphaCheck:
     name: Check if SDK version is alpha


### PR DESCRIPTION
# Summary
Add concurrency group for publish docs to avoid race conditions like [this](https://github.com/immutable/ts-immutable-sdk/actions/runs/12664314204/job/35292257860)
