### PR TITLE
refactor: generalise useExecute hook

### DIFF
--- a/packages/checkout/widgets-lib/src/lib/squid/functions/verifyAndSwitchChain.ts
+++ b/packages/checkout/widgets-lib/src/lib/squid/functions/verifyAndSwitchChain.ts
@@ -1,0 +1,47 @@
+import { Web3Provider } from '@ethersproject/providers';
+
+interface VerifyAndSwitchChainResponse {
+  isChainCorrect: boolean;
+  error?: string;
+}
+
+/**
+ * Ensure the provider is connected to the correct chain.
+ * If not, attempts to switch to the desired chain.
+ */
+export const verifyAndSwitchChain = async (
+  provider: Web3Provider,
+  chainId: string,
+): Promise<VerifyAndSwitchChainResponse> => {
+  if (!provider.provider.request) {
+    return {
+      isChainCorrect: false,
+      error: 'Provider does not support the request method.',
+    };
+  }
+
+  try {
+    const targetChainHex = `0x${parseInt(chainId, 10).toString(16)}`;
+    const currentChainId = await provider.provider.request({
+      method: 'eth_chainId',
+    });
+
+    if (targetChainHex !== currentChainId) {
+      await provider.provider.request({
+        method: 'wallet_switchEthereumChain',
+        params: [
+          {
+            chainId: targetChainHex,
+          },
+        ],
+      });
+    }
+    return { isChainCorrect: true };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+    return {
+      isChainCorrect: false,
+      error: errorMessage,
+    };
+  }
+};

--- a/packages/checkout/widgets-lib/src/lib/squid/hooks/useExecute.ts
+++ b/packages/checkout/widgets-lib/src/lib/squid/hooks/useExecute.ts
@@ -15,7 +15,8 @@ import { isRejectedError } from '../../../functions/errorType';
 const TRANSACTION_NOT_COMPLETED = 'transaction not completed';
 
 export const useExecute = (
-  onTransactionError: (err: unknown) => void,
+  userJourney: UserJourney,
+  onTransactionError?: (err: unknown) => void,
 ) => {
   const { user } = useAnalytics();
 
@@ -79,7 +80,7 @@ export const useExecute = (
 
       return ethers.constants.MaxUint256; // no approval is needed for native tokens
     } catch (error) {
-      onTransactionError(error);
+      onTransactionError?.(error);
       return undefined;
     }
   };
@@ -135,14 +136,14 @@ export const useExecute = (
       if (!isSquidNativeToken(routeResponse?.route?.params.fromToken)) {
         return await withMetricsAsync(
           (flow) => callApprove(flow, fromProviderInfo, provider, routeResponse),
-          `${UserJourney.ADD_TOKENS}_Approve`,
+          `${userJourney}_Approve`,
           await getAnonymousId(),
           (error) => (isRejectedError(error) ? 'rejected' : ''),
         );
       }
       return undefined;
     } catch (error) {
-      onTransactionError(error);
+      onTransactionError?.(error);
       return undefined;
     }
   };
@@ -175,12 +176,12 @@ export const useExecute = (
     try {
       return await withMetricsAsync(
         (flow) => callExecute(flow, squid, fromProviderInfo, provider, routeResponse),
-        `${UserJourney.ADD_TOKENS}_Execute`,
+        `${userJourney}_Execute`,
         await getAnonymousId(),
         (error) => (isRejectedError(error) ? 'rejected' : ''),
       );
     } catch (error) {
-      onTransactionError(error);
+      onTransactionError?.(error);
       return undefined;
     }
   };
@@ -222,7 +223,7 @@ export const useExecute = (
         },
       );
     } catch (error) {
-      onTransactionError(error);
+      onTransactionError?.(error);
       return undefined;
     }
   };

--- a/packages/checkout/widgets-lib/src/lib/squid/hooks/useExecute.ts
+++ b/packages/checkout/widgets-lib/src/lib/squid/hooks/useExecute.ts
@@ -104,38 +104,6 @@ export const useExecute = (contextId: string, environment: Environment) => {
     showErrorHandover(errorType, { contextId, error });
   };
 
-  // @TODO: Move to util function
-  const checkProviderChain = async (
-    provider: Web3Provider,
-    chainId: string,
-  ): Promise<boolean> => {
-    if (!provider.provider.request) {
-      throw new Error('provider does not have request method');
-    }
-    try {
-      const fromChainHex = `0x${parseInt(chainId, 10).toString(16)}`;
-      const providerChainId = await provider.provider.request({
-        method: 'eth_chainId',
-      });
-
-      if (fromChainHex !== providerChainId) {
-        await provider.provider.request({
-          method: 'wallet_switchEthereumChain',
-          params: [
-            {
-              chainId: fromChainHex,
-            },
-          ],
-        });
-        return true;
-      }
-      return true;
-    } catch (error) {
-      handleTransactionError(error);
-      return false;
-    }
-  };
-
   const getAllowance = async (
     provider: Web3Provider,
     routeResponse: RouteResponse,
@@ -313,7 +281,6 @@ export const useExecute = (contextId: string, environment: Environment) => {
   };
 
   return {
-    checkProviderChain,
     getAllowance,
     approve,
     execute,

--- a/packages/checkout/widgets-lib/src/lib/squid/hooks/useExecute.ts
+++ b/packages/checkout/widgets-lib/src/lib/squid/hooks/useExecute.ts
@@ -1,18 +1,12 @@
 import { Web3Provider } from '@ethersproject/providers';
-import { useContext } from 'react';
 import { RouteResponse } from '@0xsquid/squid-types';
 import { Squid } from '@0xsquid/sdk';
 import { ethers } from 'ethers';
-import { Environment } from '@imtbl/config';
 
 import { StatusResponse } from '@0xsquid/sdk/dist/types';
 import { Flow } from '@imtbl/metrics';
 import { EIP6963ProviderInfo } from '@imtbl/checkout-sdk';
 import { isSquidNativeToken } from '../functions/isSquidNativeToken';
-import { useError } from './useError';
-import { AddTokensError, AddTokensErrorTypes } from '../../../widgets/add-tokens/types';
-import { EventTargetContext } from '../../../context/event-target-context/EventTargetContext';
-import { sendAddTokensFailedEvent } from '../../../widgets/add-tokens/AddTokensWidgetEvents';
 import { retry } from '../../retry';
 import { withMetricsAsync } from '../../metrics';
 import { useAnalytics, UserJourney } from '../../../context/analytics-provider/SegmentAnalyticsProvider';
@@ -20,12 +14,10 @@ import { isRejectedError } from '../../../functions/errorType';
 
 const TRANSACTION_NOT_COMPLETED = 'transaction not completed';
 
-export const useExecute = (contextId: string, environment: Environment) => {
-  const { showErrorHandover } = useError(environment);
+export const useExecute = (
+  onTransactionError: (err: unknown) => void,
+) => {
   const { user } = useAnalytics();
-  const {
-    eventTargetState: { eventTarget },
-  } = useContext(EventTargetContext);
 
   const waitForReceipt = async (
     provider: Web3Provider,
@@ -59,51 +51,6 @@ export const useExecute = (contextId: string, environment: Environment) => {
     return result;
   };
 
-  const handleTransactionError = (err: unknown) => {
-    const reason = `${
-      (err as any)?.reason || (err as any)?.message || ''
-    }`.toLowerCase();
-
-    let errorType = AddTokensErrorTypes.WALLET_FAILED;
-
-    if (reason.includes('failed') && reason.includes('open confirmation')) {
-      errorType = AddTokensErrorTypes.WALLET_POPUP_BLOCKED;
-    }
-
-    if (reason.includes('rejected') && reason.includes('user')) {
-      errorType = AddTokensErrorTypes.WALLET_REJECTED;
-    }
-
-    if (
-      reason.includes('failed to submit')
-      && reason.includes('highest gas limit')
-    ) {
-      errorType = AddTokensErrorTypes.WALLET_REJECTED_NO_FUNDS;
-    }
-
-    if (
-      reason.includes('status failed')
-      || reason.includes('transaction failed')
-    ) {
-      errorType = AddTokensErrorTypes.TRANSACTION_FAILED;
-      sendAddTokensFailedEvent(eventTarget, errorType);
-    }
-
-    if (
-      reason.includes('unrecognized chain')
-      || reason.includes('unrecognized chain')
-    ) {
-      errorType = AddTokensErrorTypes.UNRECOGNISED_CHAIN;
-    }
-
-    const error: AddTokensError = {
-      type: errorType,
-      data: { error: err },
-    };
-
-    showErrorHandover(errorType, { contextId, error });
-  };
-
   const getAllowance = async (
     provider: Web3Provider,
     routeResponse: RouteResponse,
@@ -132,7 +79,7 @@ export const useExecute = (contextId: string, environment: Environment) => {
 
       return ethers.constants.MaxUint256; // no approval is needed for native tokens
     } catch (error) {
-      showErrorHandover(AddTokensErrorTypes.DEFAULT, { contextId, error });
+      onTransactionError(error);
       return undefined;
     }
   };
@@ -195,7 +142,7 @@ export const useExecute = (contextId: string, environment: Environment) => {
       }
       return undefined;
     } catch (error) {
-      handleTransactionError(error);
+      onTransactionError(error);
       return undefined;
     }
   };
@@ -233,7 +180,7 @@ export const useExecute = (contextId: string, environment: Environment) => {
         (error) => (isRejectedError(error) ? 'rejected' : ''),
       );
     } catch (error) {
-      handleTransactionError(error);
+      onTransactionError(error);
       return undefined;
     }
   };
@@ -275,7 +222,7 @@ export const useExecute = (contextId: string, environment: Environment) => {
         },
       );
     } catch (error) {
-      handleTransactionError(error);
+      onTransactionError(error);
       return undefined;
     }
   };

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/hooks/useErrorHandler.ts
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/hooks/useErrorHandler.ts
@@ -1,0 +1,68 @@
+import { useContext } from 'react';
+import { AddTokensError, AddTokensErrorTypes } from '../types';
+import { EventTargetContext } from '../../../context/event-target-context/EventTargetContext';
+import { sendAddTokensFailedEvent } from '../AddTokensWidgetEvents';
+import { useError } from '../../../lib/squid/hooks/useError';
+import { AddTokensContext } from '../context/AddTokensContext';
+import { useProvidersContext } from '../../../context/providers-context/ProvidersContext';
+
+export const useErrorHandler = () => {
+  const {
+    addTokensState: { id: contextId },
+  } = useContext(AddTokensContext);
+
+  const {
+    providersState: {
+      checkout,
+    },
+  } = useProvidersContext();
+
+  const { showErrorHandover } = useError(checkout.config.environment);
+
+  const {
+    eventTargetState: { eventTarget },
+  } = useContext(EventTargetContext);
+
+  const handleTransactionError = (err: unknown) => {
+    const reason = `${(err as any)?.reason || (err as any)?.message || ''
+    }`.toLowerCase();
+
+    let errorType = AddTokensErrorTypes.WALLET_FAILED;
+
+    if (reason.includes('failed') && reason.includes('open confirmation')) {
+      errorType = AddTokensErrorTypes.WALLET_POPUP_BLOCKED;
+    }
+
+    if (reason.includes('rejected') && reason.includes('user')) {
+      errorType = AddTokensErrorTypes.WALLET_REJECTED;
+    }
+
+    if (
+      reason.includes('failed to submit')
+            && reason.includes('highest gas limit')
+    ) {
+      errorType = AddTokensErrorTypes.WALLET_REJECTED_NO_FUNDS;
+    }
+
+    if (
+      reason.includes('status failed')
+            || reason.includes('transaction failed')
+    ) {
+      errorType = AddTokensErrorTypes.TRANSACTION_FAILED;
+      sendAddTokensFailedEvent(eventTarget, errorType);
+    }
+
+    if (reason.includes('unrecognized chain')) {
+      errorType = AddTokensErrorTypes.UNRECOGNISED_CHAIN;
+    }
+
+    const error: AddTokensError = {
+      type: errorType,
+      data: { error: err },
+    };
+
+    showErrorHandover(errorType, { contextId, error });
+  };
+
+  return { handleTransactionError };
+};

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/hooks/useErrorHandler.ts
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/hooks/useErrorHandler.ts
@@ -23,7 +23,7 @@ export const useErrorHandler = () => {
     eventTargetState: { eventTarget },
   } = useContext(EventTargetContext);
 
-  const handleTransactionError = (err: unknown) => {
+  const onTransactionError = (err: unknown) => {
     const reason = `${(err as any)?.reason || (err as any)?.message || ''
     }`.toLowerCase();
 
@@ -64,5 +64,5 @@ export const useErrorHandler = () => {
     showErrorHandover(errorType, { contextId, error });
   };
 
-  return { handleTransactionError };
+  return { onTransactionError };
 };

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/views/Review.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/views/Review.tsx
@@ -25,7 +25,6 @@ import {
 import { RouteResponse } from '@0xsquid/squid-types';
 import { t } from 'i18next';
 import { Trans } from 'react-i18next';
-import { Environment } from '@imtbl/config';
 import { ChainId } from '@imtbl/checkout-sdk';
 import { trackFlow } from '@imtbl/metrics';
 import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
@@ -57,7 +56,6 @@ import { getTotalRouteFees } from '../../../lib/squid/functions/getTotalRouteFee
 import { getRouteChains } from '../../../lib/squid/functions/getRouteChains';
 
 import { SquidFooter } from '../../../lib/squid/components/SquidFooter';
-import { useError } from '../../../lib/squid/hooks/useError';
 import {
   sendAddTokensCloseEvent,
   sendAddTokensSuccessEvent,
@@ -74,6 +72,8 @@ import { getDurationFormatted } from '../../../functions/getDurationFormatted';
 import { getFormattedNumber, getFormattedAmounts } from '../../../functions/getFormattedNumber';
 import { RiveStateMachineInput } from '../../../types/HandoverTypes';
 import { verifyAndSwitchChain } from '../../../lib/squid/functions/verifyAndSwitchChain';
+import { useErrorHandler } from '../hooks/useErrorHandler';
+import { useError } from '../../../lib/squid/hooks/useError';
 
 interface ReviewProps {
   data: AddTokensReviewData;
@@ -112,6 +112,8 @@ export function Review({
     },
   } = useProvidersContext();
 
+  const { showErrorHandover } = useError(checkout.config.environment);
+
   const {
     eventTargetState: { eventTarget },
   } = useContext(EventTargetContext);
@@ -127,11 +129,11 @@ export function Review({
     id: HandoverTarget.GLOBAL,
   });
 
-  const { showErrorHandover } = useError(checkout.config.environment);
+  const { onTransactionError } = useErrorHandler();
 
   const {
     getAllowance, approve, execute, getStatus,
-  } = useExecute(id, checkout?.config.environment || Environment.SANDBOX);
+  } = useExecute(onTransactionError);
 
   useEffect(() => {
     page({

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/views/Review.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/views/Review.tsx
@@ -133,7 +133,7 @@ export function Review({
 
   const {
     getAllowance, approve, execute, getStatus,
-  } = useExecute(onTransactionError);
+  } = useExecute(UserJourney.ADD_TOKENS, onTransactionError);
 
   useEffect(() => {
     page({

--- a/packages/checkout/widgets-lib/src/widgets/add-tokens/views/Review.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/add-tokens/views/Review.tsx
@@ -73,6 +73,7 @@ import { RouteFees } from '../../../components/RouteFees/RouteFees';
 import { getDurationFormatted } from '../../../functions/getDurationFormatted';
 import { getFormattedNumber, getFormattedAmounts } from '../../../functions/getFormattedNumber';
 import { RiveStateMachineInput } from '../../../types/HandoverTypes';
+import { verifyAndSwitchChain } from '../../../lib/squid/functions/verifyAndSwitchChain';
 
 interface ReviewProps {
   data: AddTokensReviewData;
@@ -129,7 +130,7 @@ export function Review({
   const { showErrorHandover } = useError(checkout.config.environment);
 
   const {
-    checkProviderChain, getAllowance, approve, execute, getStatus,
+    getAllowance, approve, execute, getStatus,
   } = useExecute(id, checkout?.config.environment || Environment.SANDBOX);
 
   useEffect(() => {
@@ -358,12 +359,12 @@ export function Review({
       fromProvider,
     );
 
-    const isValidNetwork = await checkProviderChain(
+    const verifyChainResult = await verifyAndSwitchChain(
       changeableProvider,
       route.route.params.fromChain,
     );
 
-    if (!isValidNetwork) {
+    if (!verifyChainResult.isChainCorrect) {
       return;
     }
 
@@ -653,7 +654,6 @@ export function Review({
     getRouteIntervalIdRef,
     approve,
     showHandover,
-    checkProviderChain,
     getAllowance,
     execute,
     closeHandover,


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

Refactor `useExecute` hook to be used in both Add Tokens and Purchase widgets.

- Move Add Tokens error handling out of `useExecute` by providing `onTransactionError` callback
- Move Add Tokens event tracking out of `useExecute` 
