### PR TITLE
feat: Add Squid SDK, tokens and chains to Purchase context

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/purchase/PurchaseWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/purchase/PurchaseWidget.tsx
@@ -18,7 +18,10 @@ import { sendPurchaseCloseEvent } from './PurchaseWidgetEvents';
 import { orchestrationEvents } from '../../lib/orchestrationEvents';
 import { EventTargetContext } from '../../context/event-target-context/EventTargetContext';
 import { getRemoteImage } from '../../lib/utils';
+import { useSquid } from '../../lib/squid/hooks/useSquid';
+import { useTokens } from '../../lib/squid/hooks/useTokens';
 import { useProvidersContext } from '../../context/providers-context/ProvidersContext';
+import { fetchChains } from '../../lib/squid/functions/fetchChains';
 
 export type PurchaseWidgetInputs = PurchaseWidgetParams & {
   config: StrongCheckoutWidgetsConfig;
@@ -39,10 +42,6 @@ export default function PurchaseWidget({
     view: { type: PurchaseWidgetViews.PURCHASE },
     history: [{ type: PurchaseWidgetViews.PURCHASE }],
   });
-
-  const {
-    providersState: { checkout },
-  } = useProvidersContext();
 
   const viewReducerValues = useMemo(
     () => ({
@@ -68,6 +67,47 @@ export default function PurchaseWidget({
   const {
     eventTargetState: { eventTarget },
   } = useContext(EventTargetContext);
+
+  const {
+    providersState: { checkout },
+  } = useProvidersContext();
+
+  const { squid: { squid } } = purchaseState;
+
+  const squidSdk = useSquid(checkout);
+  const tokensResponse = useTokens(checkout);
+
+  useEffect(() => {
+    if (!squidSdk) return;
+
+    purchaseDispatch({
+      payload: {
+        type: PurchaseActions.SET_SQUID,
+        squid: squidSdk,
+      },
+    });
+  }, [squidSdk]);
+
+  useEffect(() => {
+    if (!tokensResponse) return;
+    purchaseDispatch({
+      payload: {
+        type: PurchaseActions.SET_SQUID_TOKENS,
+        tokens: tokensResponse,
+      },
+    });
+  }, [tokensResponse]);
+
+  useEffect(() => {
+    if (!squid) return;
+
+    purchaseDispatch({
+      payload: {
+        type: PurchaseActions.SET_SQUID_CHAINS,
+        chains: fetchChains(squid),
+      },
+    });
+  }, [squid]);
 
   useEffect(
     () => {

--- a/packages/checkout/widgets-lib/src/widgets/purchase/context/PurchaseContext.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/purchase/context/PurchaseContext.tsx
@@ -1,14 +1,23 @@
 import { Squid } from '@0xsquid/sdk';
 import { PurchaseItem } from '@imtbl/checkout-sdk';
 import { createContext } from 'react';
+import { Chain, Token } from '../../../lib/squid/types';
 
 export interface PurchaseState {
-  squid: Squid | null;
+  squid: {
+    squid: Squid | null;
+    chains: Chain[] | null;
+    tokens: Token[] | null;
+  };
   items: PurchaseItem[];
 }
 
 export const initialPurchaseState: PurchaseState = {
-  squid: null,
+  squid: {
+    squid: null,
+    chains: null,
+    tokens: null,
+  },
   items: [],
 };
 
@@ -23,16 +32,30 @@ export interface PurchaseAction {
 
 type ActionPayload =
   | SetSquid
+  | SetSquidChains
+  | SetSquidTokens
   | SetItems;
 
 export enum PurchaseActions {
   SET_SQUID = 'SET_SQUID',
+  SET_SQUID_CHAINS = 'SET_SQUID_CHAINS',
+  SET_SQUID_TOKENS = 'SET_SQUID_TOKENS',
   SET_ITEMS = 'SET_ITEMS',
 }
 
 export interface SetSquid {
   type: PurchaseActions.SET_SQUID;
   squid: Squid;
+}
+
+export interface SetSquidChains {
+  type: PurchaseActions.SET_SQUID_CHAINS;
+  chains: Chain[];
+}
+
+export interface SetSquidTokens {
+  type: PurchaseActions.SET_SQUID_TOKENS;
+  tokens: Token[];
 }
 
 export interface SetItems {
@@ -58,7 +81,26 @@ export const purchaseReducer: Reducer<PurchaseState, PurchaseAction> = (
     case PurchaseActions.SET_SQUID:
       return {
         ...state,
-        squid: action.payload.squid,
+        squid: {
+          ...state.squid,
+          squid: action.payload.squid,
+        },
+      };
+    case PurchaseActions.SET_SQUID_CHAINS:
+      return {
+        ...state,
+        squid: {
+          ...state.squid,
+          chains: action.payload.chains,
+        },
+      };
+    case PurchaseActions.SET_SQUID_TOKENS:
+      return {
+        ...state,
+        squid: {
+          ...state.squid,
+          tokens: action.payload.tokens,
+        },
       };
     case PurchaseActions.SET_ITEMS:
       return {


### PR DESCRIPTION
This data will be used by the Purchase view.