### PR TITLE
fix: ID-3186 Resolve @imtbl/orderbook Seaport module issue 

### DIFF
--- a/packages/orderbook/.eslintrc.cjs
+++ b/packages/orderbook/.eslintrc.cjs
@@ -61,6 +61,16 @@ module.exports = {
         "format": ["camelCase","snake_case"]
       }
     ],
-    "import/prefer-default-export": ["off"]
+    "import/prefer-default-export": ["off"],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [],
+        // Importing types from seaport-js using a relative path (e.g. @opensea/seaport-js/lib/constants)
+        // can cause issues for consumers of the SDK, e.g: https://github.com/immutable/ts-immutable-sdk/issues/2472.
+        // Instead, alias or duplicate the types in src/seaport/types.ts and import from there.
+        "patterns": ["@opensea/seaport-js/*"]
+      }
+    ]
   }
 }

--- a/packages/orderbook/src/api-client/api-client.test.ts
+++ b/packages/orderbook/src/api-client/api-client.test.ts
@@ -1,8 +1,8 @@
 import {
   anything, deepEqual, instance, mock, when,
 } from 'ts-mockito';
-import type { OrderComponents } from '@opensea/seaport-js/src/types';
-import { OrderType } from '@opensea/seaport-js/src/constants';
+import type { OrderComponents } from '../seaport/types';
+import { OrderType } from '../seaport/constants';
 import { ListingResult, OrdersService } from '../openapi/sdk';
 import { ItemType } from '../seaport';
 import { ImmutableApiClient } from './api-client';

--- a/packages/orderbook/src/api-client/api-client.test.ts
+++ b/packages/orderbook/src/api-client/api-client.test.ts
@@ -1,8 +1,8 @@
 import {
   anything, deepEqual, instance, mock, when,
 } from 'ts-mockito';
-import type { OrderComponents } from '@opensea/seaport-js/lib/types';
-import { OrderType } from '@opensea/seaport-js/lib/constants';
+import type { OrderComponents } from '@opensea/seaport-js/src/types';
+import { OrderType } from '@opensea/seaport-js/src/constants';
 import { ListingResult, OrdersService } from '../openapi/sdk';
 import { ItemType } from '../seaport';
 import { ImmutableApiClient } from './api-client';

--- a/packages/orderbook/src/seaport/components.ts
+++ b/packages/orderbook/src/seaport/components.ts
@@ -1,11 +1,11 @@
-import { ItemType, OrderType } from '@opensea/seaport-js/src/constants';
+import { BigNumber } from 'ethers';
 import type {
   ConsiderationItem,
   OfferItem,
   OrderComponents,
-} from '@opensea/seaport-js/src/types';
-import { BigNumber } from 'ethers';
+} from './types';
 import { getBulkOrderTree } from './lib/bulk-orders';
+import { ItemType, OrderType } from './constants';
 
 function orderTypeStringToEnum(orderTypeString: string): OrderType {
   if (

--- a/packages/orderbook/src/seaport/components.ts
+++ b/packages/orderbook/src/seaport/components.ts
@@ -1,9 +1,9 @@
-import { ItemType, OrderType } from '@opensea/seaport-js/lib/constants';
+import { ItemType, OrderType } from '@opensea/seaport-js/src/constants';
 import type {
   ConsiderationItem,
   OfferItem,
   OrderComponents,
-} from '@opensea/seaport-js/lib/types';
+} from '@opensea/seaport-js/src/types';
 import { BigNumber } from 'ethers';
 import { getBulkOrderTree } from './lib/bulk-orders';
 

--- a/packages/orderbook/src/seaport/lib/bulk-orders.ts
+++ b/packages/orderbook/src/seaport/lib/bulk-orders.ts
@@ -1,4 +1,4 @@
-import type { OrderComponents } from '@opensea/seaport-js/lib/types';
+import type { OrderComponents } from '@opensea/seaport-js/src/types';
 import { TypedDataEncoder, keccak256, toUtf8Bytes } from 'ethers-v6';
 import { EIP_712_ORDER_TYPE } from '../constants';
 

--- a/packages/orderbook/src/seaport/lib/bulk-orders.ts
+++ b/packages/orderbook/src/seaport/lib/bulk-orders.ts
@@ -1,5 +1,5 @@
-import type { OrderComponents } from '@opensea/seaport-js/src/types';
 import { TypedDataEncoder, keccak256, toUtf8Bytes } from 'ethers-v6';
+import type { OrderComponents } from '../types';
 import { EIP_712_ORDER_TYPE } from '../constants';
 
 import { Eip712MerkleTree } from './merkle';

--- a/packages/orderbook/src/seaport/map-to-immutable-order.ts
+++ b/packages/orderbook/src/seaport/map-to-immutable-order.ts
@@ -1,7 +1,10 @@
-import { ConsiderationItem, OfferItem } from '@opensea/seaport-js/src/types';
-import { ItemType, OrderType } from '@opensea/seaport-js/src/constants';
+import { ItemType, OrderType } from './constants';
+import { ConsiderationItem, OfferItem } from './types';
 import {
-  AssetCollectionItem, ERC20Item, Item, ProtocolData,
+  AssetCollectionItem,
+  ERC20Item,
+  Item,
+  ProtocolData,
 } from '../openapi/sdk';
 import { exhaustiveSwitch } from '../utils';
 

--- a/packages/orderbook/src/seaport/map-to-immutable-order.ts
+++ b/packages/orderbook/src/seaport/map-to-immutable-order.ts
@@ -1,5 +1,5 @@
-import { ConsiderationItem, OfferItem } from '@opensea/seaport-js/lib/types';
-import { ItemType, OrderType } from '@opensea/seaport-js/lib/constants';
+import { ConsiderationItem, OfferItem } from '@opensea/seaport-js/src/types';
+import { ItemType, OrderType } from '@opensea/seaport-js/src/constants';
 import {
   AssetCollectionItem, ERC20Item, Item, ProtocolData,
 } from '../openapi/sdk';

--- a/packages/orderbook/src/seaport/map-to-seaport-order.ts
+++ b/packages/orderbook/src/seaport/map-to-seaport-order.ts
@@ -3,7 +3,7 @@ import {
   OfferItem,
   OrderComponents,
   TipInputItem,
-} from '@opensea/seaport-js/lib/types';
+} from '@opensea/seaport-js/src/types';
 import { constants } from 'ethers';
 import { Item, Order, ProtocolData } from '../openapi/sdk';
 import { exhaustiveSwitch } from '../utils';

--- a/packages/orderbook/src/seaport/map-to-seaport-order.ts
+++ b/packages/orderbook/src/seaport/map-to-seaport-order.ts
@@ -15,7 +15,7 @@ function mapImmutableItemToSeaportOfferItem(item: Item): OfferItem {
       throw new Error('NATIVE items are not supported in the offer');
     case 'ERC20':
       return {
-        itemType: ItemType.ERC20,
+        itemType: ItemType.ERC20.valueOf(),
         token: item.contract_address,
         identifierOrCriteria: '0',
         startAmount: item.amount,
@@ -23,7 +23,7 @@ function mapImmutableItemToSeaportOfferItem(item: Item): OfferItem {
       };
     case 'ERC721':
       return {
-        itemType: ItemType.ERC721,
+        itemType: ItemType.ERC721.valueOf(),
         token: item.contract_address,
         identifierOrCriteria: item.token_id,
         startAmount: '1',
@@ -31,7 +31,7 @@ function mapImmutableItemToSeaportOfferItem(item: Item): OfferItem {
       };
     case 'ERC1155':
       return {
-        itemType: ItemType.ERC1155,
+        itemType: ItemType.ERC1155.valueOf(),
         token: item.contract_address,
         identifierOrCriteria: item.token_id,
         startAmount: item.amount,
@@ -53,7 +53,7 @@ function mapImmutableItemToSeaportConsiderationItem(
   switch (item.type) {
     case 'NATIVE':
       return {
-        itemType: ItemType.NATIVE,
+        itemType: ItemType.NATIVE.valueOf(),
         startAmount: item.amount,
         endAmount: item.amount,
         token: constants.AddressZero,
@@ -62,7 +62,7 @@ function mapImmutableItemToSeaportConsiderationItem(
       };
     case 'ERC20':
       return {
-        itemType: ItemType.ERC20,
+        itemType: ItemType.ERC20.valueOf(),
         startAmount: item.amount,
         endAmount: item.amount,
         token: item.contract_address,
@@ -71,7 +71,7 @@ function mapImmutableItemToSeaportConsiderationItem(
       };
     case 'ERC721':
       return {
-        itemType: ItemType.ERC721,
+        itemType: ItemType.ERC721.valueOf(),
         startAmount: '1',
         endAmount: '1',
         token: item.contract_address,
@@ -80,7 +80,7 @@ function mapImmutableItemToSeaportConsiderationItem(
       };
     case 'ERC1155':
       return {
-        itemType: ItemType.ERC1155,
+        itemType: ItemType.ERC1155.valueOf(),
         startAmount: item.amount,
         endAmount: item.amount,
         token: item.contract_address,
@@ -89,7 +89,7 @@ function mapImmutableItemToSeaportConsiderationItem(
       };
     case 'ERC721_COLLECTION':
       return {
-        itemType: ItemType.ERC721_WITH_CRITERIA,
+        itemType: ItemType.ERC721_WITH_CRITERIA.valueOf(),
         startAmount: item.amount,
         endAmount: item.amount,
         token: item.contract_address,
@@ -98,7 +98,7 @@ function mapImmutableItemToSeaportConsiderationItem(
       };
     case 'ERC1155_COLLECTION':
       return {
-        itemType: ItemType.ERC1155_WITH_CRITERIA,
+        itemType: ItemType.ERC1155_WITH_CRITERIA.valueOf(),
         startAmount: item.amount,
         endAmount: item.amount,
         token: item.contract_address,
@@ -156,7 +156,7 @@ export function mapImmutableOrderToSeaportOrderComponents(
       zone: order.protocol_data.zone_address,
       offer: offerItems,
       consideration: considerationItems,
-      orderType: seaportOrderType,
+      orderType: seaportOrderType.valueOf(),
       startTime: Math.round(
         new Date(order.start_at).getTime() / 1000,
       ).toString(),

--- a/packages/orderbook/src/seaport/map-to-seaport-order.ts
+++ b/packages/orderbook/src/seaport/map-to-seaport-order.ts
@@ -1,13 +1,13 @@
+import { constants } from 'ethers';
+import { Item, Order, ProtocolData } from '../openapi/sdk';
+import { exhaustiveSwitch } from '../utils';
+import { ItemType, OrderType } from './constants';
 import {
   ConsiderationItem,
   OfferItem,
   OrderComponents,
   TipInputItem,
-} from '@opensea/seaport-js/src/types';
-import { constants } from 'ethers';
-import { Item, Order, ProtocolData } from '../openapi/sdk';
-import { exhaustiveSwitch } from '../utils';
-import { ItemType, OrderType } from './constants';
+} from './types';
 
 function mapImmutableItemToSeaportOfferItem(item: Item): OfferItem {
   switch (item.type) {

--- a/packages/orderbook/src/seaport/seaport.test.ts
+++ b/packages/orderbook/src/seaport/seaport.test.ts
@@ -16,7 +16,8 @@ import {
 import { ProtocolData, Order, OrderStatusName } from '../openapi/sdk';
 import {
   EIP_712_ORDER_TYPE,
-  ItemType, OrderType,
+  ItemType,
+  OrderType,
   SEAPORT_CONTRACT_NAME,
   SEAPORT_CONTRACT_VERSION_V1_5,
 } from './constants';

--- a/packages/orderbook/src/seaport/seaport.test.ts
+++ b/packages/orderbook/src/seaport/seaport.test.ts
@@ -1,7 +1,7 @@
 import {
   anything, deepEqual, instance, mock, when,
 } from 'ts-mockito';
-import type { TransactionMethods } from '@opensea/seaport-js/lib/utils/usecase';
+import type { TransactionMethods } from '@opensea/seaport-js/src/utils/usecase';
 import { ContractTransaction, ZeroHash, ZeroAddress } from 'ethers-v6';
 import { Seaport as SeaportLib } from '@opensea/seaport-js';
 import type {
@@ -11,9 +11,9 @@ import type {
   ExchangeAction,
   OfferItem,
   OrderComponents,
-} from '@opensea/seaport-js/lib/types';
+} from '@opensea/seaport-js/src/types';
 import { BigNumber, providers } from 'ethers';
-import { OrderType } from '@opensea/seaport-js/lib/constants';
+import { OrderType } from '@opensea/seaport-js/src/constants';
 import {
   ActionType,
   TransactionAction,

--- a/packages/orderbook/src/seaport/seaport.test.ts
+++ b/packages/orderbook/src/seaport/seaport.test.ts
@@ -1,19 +1,11 @@
 import {
   anything, deepEqual, instance, mock, when,
 } from 'ts-mockito';
-import type { TransactionMethods } from '@opensea/seaport-js/src/utils/usecase';
+import type { TransactionMethods } from '@opensea/seaport-js/lib/utils/usecase';
 import { ContractTransaction, ZeroHash, ZeroAddress } from 'ethers-v6';
 import { Seaport as SeaportLib } from '@opensea/seaport-js';
-import type {
-  ApprovalAction,
-  ConsiderationItem,
-  CreateOrderAction,
-  ExchangeAction,
-  OfferItem,
-  OrderComponents,
-} from '@opensea/seaport-js/src/types';
 import { BigNumber, providers } from 'ethers';
-import { OrderType } from '@opensea/seaport-js/src/constants';
+import { ExchangeAction } from '@opensea/seaport-js/lib/types';
 import {
   ActionType,
   TransactionAction,
@@ -26,12 +18,15 @@ import {
 import { ProtocolData, Order, OrderStatusName } from '../openapi/sdk';
 import {
   EIP_712_ORDER_TYPE,
-  ItemType,
+  ItemType, OrderType,
   SEAPORT_CONTRACT_NAME,
   SEAPORT_CONTRACT_VERSION_V1_5,
 } from './constants';
 import { Seaport } from './seaport';
 import { SeaportLibFactory } from './seaport-lib-factory';
+import {
+  ApprovalAction, ConsiderationItem, CreateOrderAction, OfferItem, OrderComponents,
+} from './types';
 
 const fakeExtraData = '0x0000000000000000000000000000000000000000000000000064ec2faca1186bef338313426612ad6ed494b50e5ddc65ad4e6067df53d6625f921b22156ac9435d4fd946bc5f07859ecd7aca94f87da703b9204f9c09f0089be18d5c268a5f36c80c779ed3cbf6ed54b7c7bf2991a4b11065b01c1a2594619f1a0d49f9';
 

--- a/packages/orderbook/src/seaport/seaport.test.ts
+++ b/packages/orderbook/src/seaport/seaport.test.ts
@@ -26,9 +26,11 @@ import {
   ApprovalAction,
   ConsiderationItem,
   CreateOrderAction,
-  CreateOrderReturnType, ExchangeAction,
+  CreateOrderReturnType,
+  ExchangeAction,
   OfferItem,
-  OrderComponents, TransactionMethods,
+  OrderComponents,
+  TransactionMethods,
 } from './types';
 
 const fakeExtraData = '0x0000000000000000000000000000000000000000000000000064ec2faca1186bef338313426612ad6ed494b50e5ddc65ad4e6067df53d6625f921b22156ac9435d4fd946bc5f07859ecd7aca94f87da703b9204f9c09f0089be18d5c268a5f36c80c779ed3cbf6ed54b7c7bf2991a4b11065b01c1a2594619f1a0d49f9';

--- a/packages/orderbook/src/seaport/seaport.test.ts
+++ b/packages/orderbook/src/seaport/seaport.test.ts
@@ -1,11 +1,9 @@
 import {
   anything, deepEqual, instance, mock, when,
 } from 'ts-mockito';
-import type { TransactionMethods } from '@opensea/seaport-js/lib/utils/usecase';
 import { ContractTransaction, ZeroHash, ZeroAddress } from 'ethers-v6';
 import { Seaport as SeaportLib } from '@opensea/seaport-js';
 import { BigNumber, providers } from 'ethers';
-import { ExchangeAction } from '@opensea/seaport-js/lib/types';
 import {
   ActionType,
   TransactionAction,
@@ -25,7 +23,12 @@ import {
 import { Seaport } from './seaport';
 import { SeaportLibFactory } from './seaport-lib-factory';
 import {
-  ApprovalAction, ConsiderationItem, CreateOrderAction, OfferItem, OrderComponents,
+  ApprovalAction,
+  ConsiderationItem,
+  CreateOrderAction,
+  CreateOrderReturnType, ExchangeAction,
+  OfferItem,
+  OrderComponents, TransactionMethods,
 } from './types';
 
 const fakeExtraData = '0x0000000000000000000000000000000000000000000000000064ec2faca1186bef338313426612ad6ed494b50e5ddc65ad4e6067df53d6625f921b22156ac9435d4fd946bc5f07859ecd7aca94f87da703b9204f9c09f0089be18d5c268a5f36c80c779ed3cbf6ed54b7c7bf2991a4b11065b01c1a2594619f1a0d49f9';
@@ -171,7 +174,7 @@ describe('Seaport', () => {
           Promise.resolve({
             actions: [createActionInstance],
             executeAllActions: () => undefined as any,
-          }),
+          } as CreateOrderReturnType),
         );
 
         sut = new Seaport(
@@ -397,7 +400,7 @@ describe('Seaport', () => {
           Promise.resolve({
             actions: [approvalActionInstance, createActionInstance],
             executeAllActions: () => undefined as any,
-          }),
+          } as CreateOrderReturnType),
         );
 
         sut = new Seaport(

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -55,13 +55,13 @@ function mapImmutableSdkItemToSeaportSdkCreateInputItem(
       };
     case 'ERC721':
       return {
-        itemType: ItemType.ERC721,
+        itemType: ItemType.ERC721.valueOf(),
         token: item.contractAddress,
         identifier: item.tokenId,
       };
     case 'ERC1155':
       return {
-        itemType: ItemType.ERC1155,
+        itemType: ItemType.ERC1155.valueOf(),
         token: item.contractAddress,
         identifier: item.tokenId,
         amount: item.amount,
@@ -95,14 +95,14 @@ function mapImmutableSdkItemToSeaportSdkConsiderationInputItem(
       };
     case 'ERC721':
       return {
-        itemType: ItemType.ERC721,
+        itemType: ItemType.ERC721.valueOf(),
         token: item.contractAddress,
         identifier: item.tokenId,
         recipient,
       };
     case 'ERC1155':
       return {
-        itemType: ItemType.ERC1155,
+        itemType: ItemType.ERC1155.valueOf(),
         token: item.contractAddress,
         identifier: item.tokenId,
         amount: item.amount,
@@ -111,7 +111,7 @@ function mapImmutableSdkItemToSeaportSdkConsiderationInputItem(
     case 'ERC721_COLLECTION':
       return {
         // seaport will handle mapping an ERC721 item with no identifier to a criteria based item
-        itemType: ItemType.ERC721,
+        itemType: ItemType.ERC721.valueOf(),
         token: item.contractAddress,
         amount: item.amount,
         identifiers: [],
@@ -120,7 +120,7 @@ function mapImmutableSdkItemToSeaportSdkConsiderationInputItem(
     case 'ERC1155_COLLECTION':
       return {
         // seaport will handle mapping an ERC1155 item with no identifier to a criteria based item
-        itemType: ItemType.ERC1155,
+        itemType: ItemType.ERC1155.valueOf(),
         token: item.contractAddress,
         amount: item.amount,
         identifiers: [],
@@ -161,9 +161,9 @@ export class Seaport {
       orderInputs,
     );
 
-    const approvalActions: ApprovalAction[] | undefined = seaportActions.filter(
+    const approvalActions = seaportActions.filter(
       (action) => action.type === 'approval',
-    );
+    ) as ApprovalAction[];
 
     const network = await this.provider.getNetwork();
     const actions: Action[] = approvalActions.map((approvalAction) => ({
@@ -176,7 +176,7 @@ export class Seaport {
       ),
     }));
 
-    const createAction: CreateBulkOrdersAction | undefined = seaportActions.find((action) => action.type === 'createBulk');
+    const createAction = seaportActions.find((action) => action.type === 'createBulk') as CreateBulkOrdersAction | undefined;
 
     if (!createAction) {
       throw new Error('No create bulk order action found');
@@ -225,9 +225,9 @@ export class Seaport {
 
     const actions: Action[] = [];
 
-    const approvalAction: ApprovalAction | undefined = seaportActions.find(
+    const approvalAction = seaportActions.find(
       (action) => action.type === 'approval',
-    );
+    ) as ApprovalAction | undefined;
 
     if (approvalAction) {
       actions.push({
@@ -241,9 +241,9 @@ export class Seaport {
       });
     }
 
-    const createAction: CreateOrderAction | undefined = seaportActions.find(
+    const createAction = seaportActions.find(
       (action) => action.type === 'create',
-    );
+    ) as CreateOrderAction | undefined;
 
     if (!createAction) {
       throw new Error('No create order action found');
@@ -295,9 +295,9 @@ export class Seaport {
 
     const fulfillmentActions: TransactionAction[] = [];
 
-    const approvalActions: ApprovalAction[] = seaportActions.filter(
+    const approvalActions = seaportActions.filter(
       (action) => action.type === 'approval',
-    );
+    ) as ApprovalAction[];
 
     if (approvalActions.length > 0) {
       approvalActions.forEach((approvalAction) => {
@@ -313,9 +313,9 @@ export class Seaport {
       });
     }
 
-    const fulfilOrderAction: ApprovalAction = seaportActions.find(
+    const fulfilOrderAction = seaportActions.find(
       (action) => action.type === 'exchange',
-    );
+    ) as ApprovalAction | undefined;
 
     if (!fulfilOrderAction) {
       throw new Error('No exchange action found');
@@ -377,9 +377,9 @@ export class Seaport {
 
     const fulfillmentActions: TransactionAction[] = [];
 
-    const approvalActions: ApprovalAction[] = seaportActions.filter(
+    const approvalActions = seaportActions.filter(
       (action) => action.type === 'approval',
-    );
+    ) as ApprovalAction[];
 
     const chainID = (await this.provider.getNetwork()).chainId;
 
@@ -419,7 +419,7 @@ export class Seaport {
       actions: fulfillmentActions,
       // return the shortest expiration out of all extraData - they should be very close
       expiration: fulfillOrderDetails
-        .map((d) => Seaport.getExpirationISOTimeFromExtraData(d.extraData))
+        .map((d) => Seaport.getExpirationISOTimeFromExtraData(d.extraData!))
         .reduce((p, c) => (new Date(p) < new Date(c) ? p : c)),
     };
   }
@@ -464,7 +464,7 @@ export class Seaport {
       orderStart: Date;
       orderExpiry: Date;
     }[],
-  ): CreateBulkOrdersReturnType {
+  ): Promise<CreateBulkOrdersReturnType> {
     const seaportLib = this.getSeaportLib();
 
     return seaportLib.createBulkOrders(
@@ -509,7 +509,7 @@ export class Seaport {
     allowPartialFills: boolean,
     orderStart: Date,
     orderExpiry: Date,
-  ): CreateOrderReturnType {
+  ): Promise<CreateOrderReturnType> {
     const seaportLib = this.getSeaportLib();
 
     return seaportLib.createOrder(

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -41,6 +41,7 @@ import {
   CreateInputItem,
   CreateOrderAction,
   CreateOrderReturnType,
+  ExchangeAction,
   FulfillmentOrderDetails,
   InputCriteria,
   OrderComponents,
@@ -317,7 +318,7 @@ export class Seaport {
 
     const fulfilOrderAction = seaportActions.find(
       (action) => action.type === 'exchange',
-    ) as ApprovalAction | undefined;
+    ) as ExchangeAction | undefined;
 
     if (!fulfilOrderAction) {
       throw new Error('No exchange action found');

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -281,7 +281,7 @@ export class Seaport {
         parameters: orderComponents,
         signature: order.signature,
       },
-      unitsToFill: unitsToFill || '',
+      unitsToFill: unitsToFill!,
       extraData,
       tips,
     };
@@ -358,7 +358,7 @@ export class Seaport {
           parameters: orderComponents,
           signature: o.order.signature,
         },
-        unitsToFill: o.unitsToFill || '',
+        unitsToFill: o.unitsToFill!,
         extraData: o.extraData,
         tips,
       };

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -1,14 +1,4 @@
 import { Seaport as SeaportLib } from '@opensea/seaport-js';
-import type {
-  ConsiderationInputItem,
-  CreateBulkOrdersAction,
-  CreateInputItem,
-  CreateOrderAction,
-  ExchangeAction,
-  InputCriteria,
-  OrderComponents,
-  OrderUseCase,
-} from '@opensea/seaport-js/src/types';
 import { providers } from 'ethers';
 import { mapOrderFromOpenApiOrder } from '../openapi/mapper';
 import { Order as OpenApiOrder } from '../openapi/sdk';
@@ -43,8 +33,16 @@ import {
 import { mapImmutableOrderToSeaportOrderComponents } from './map-to-seaport-order';
 import { SeaportLibFactory } from './seaport-lib-factory';
 import { prepareTransaction } from './transaction';
-
-type FulfillmentOrderDetails = Parameters<SeaportLib['fulfillOrders']>[0]['fulfillOrderDetails'][0] & { extraData: string };
+import {
+  ApprovalAction, ConsiderationInputItem,
+  CreateBulkOrdersAction,
+  CreateBulkOrdersReturnType,
+  CreateInputItem, CreateOrderAction,
+  CreateOrderReturnType,
+  FulfillmentOrderDetails,
+  InputCriteria,
+  OrderComponents,
+} from './types';
 
 function mapImmutableSdkItemToSeaportSdkCreateInputItem(
   item: ERC20Item | ERC721Item | ERC1155Item,
@@ -163,7 +161,7 @@ export class Seaport {
       orderInputs,
     );
 
-    const approvalActions = seaportActions.filter(
+    const approvalActions: ApprovalAction[] | undefined = seaportActions.filter(
       (action) => action.type === 'approval',
     );
 
@@ -227,7 +225,7 @@ export class Seaport {
 
     const actions: Action[] = [];
 
-    const approvalAction = seaportActions.find(
+    const approvalAction: ApprovalAction | undefined = seaportActions.find(
       (action) => action.type === 'approval',
     );
 
@@ -283,7 +281,7 @@ export class Seaport {
         parameters: orderComponents,
         signature: order.signature,
       },
-      unitsToFill,
+      unitsToFill: unitsToFill || '',
       extraData,
       tips,
     };
@@ -297,7 +295,7 @@ export class Seaport {
 
     const fulfillmentActions: TransactionAction[] = [];
 
-    const approvalActions = seaportActions.filter(
+    const approvalActions: ApprovalAction[] = seaportActions.filter(
       (action) => action.type === 'approval',
     );
 
@@ -315,7 +313,7 @@ export class Seaport {
       });
     }
 
-    const fulfilOrderAction: ExchangeAction | undefined = seaportActions.find(
+    const fulfilOrderAction: ApprovalAction = seaportActions.find(
       (action) => action.type === 'exchange',
     );
 
@@ -360,7 +358,7 @@ export class Seaport {
           parameters: orderComponents,
           signature: o.order.signature,
         },
-        unitsToFill: o.unitsToFill,
+        unitsToFill: o.unitsToFill || '',
         extraData: o.extraData,
         tips,
       };
@@ -379,7 +377,7 @@ export class Seaport {
 
     const fulfillmentActions: TransactionAction[] = [];
 
-    const approvalActions = seaportActions.filter(
+    const approvalActions: ApprovalAction[] = seaportActions.filter(
       (action) => action.type === 'approval',
     );
 
@@ -399,7 +397,7 @@ export class Seaport {
       });
     }
 
-    const fulfilOrderAction: ExchangeAction | undefined = seaportActions.find(
+    const fulfilOrderAction = seaportActions.find(
       (action) => action.type === 'exchange',
     );
 
@@ -466,7 +464,7 @@ export class Seaport {
       orderStart: Date;
       orderExpiry: Date;
     }[],
-  ): Promise<OrderUseCase<CreateBulkOrdersAction>> {
+  ): CreateBulkOrdersReturnType {
     const seaportLib = this.getSeaportLib();
 
     return seaportLib.createBulkOrders(
@@ -511,7 +509,7 @@ export class Seaport {
     allowPartialFills: boolean,
     orderStart: Date,
     orderExpiry: Date,
-  ): Promise<OrderUseCase<CreateOrderAction>> {
+  ): CreateOrderReturnType {
     const seaportLib = this.getSeaportLib();
 
     return seaportLib.createOrder(

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -8,7 +8,7 @@ import type {
   InputCriteria,
   OrderComponents,
   OrderUseCase,
-} from '@opensea/seaport-js/lib/types';
+} from '@opensea/seaport-js/src/types';
 import { providers } from 'ethers';
 import { mapOrderFromOpenApiOrder } from '../openapi/mapper';
 import { Order as OpenApiOrder } from '../openapi/sdk';

--- a/packages/orderbook/src/seaport/seaport.ts
+++ b/packages/orderbook/src/seaport/seaport.ts
@@ -34,10 +34,12 @@ import { mapImmutableOrderToSeaportOrderComponents } from './map-to-seaport-orde
 import { SeaportLibFactory } from './seaport-lib-factory';
 import { prepareTransaction } from './transaction';
 import {
-  ApprovalAction, ConsiderationInputItem,
+  ApprovalAction,
+  ConsiderationInputItem,
   CreateBulkOrdersAction,
   CreateBulkOrdersReturnType,
-  CreateInputItem, CreateOrderAction,
+  CreateInputItem,
+  CreateOrderAction,
   CreateOrderReturnType,
   FulfillmentOrderDetails,
   InputCriteria,

--- a/packages/orderbook/src/seaport/transaction.ts
+++ b/packages/orderbook/src/seaport/transaction.ts
@@ -1,6 +1,6 @@
-import type { TransactionMethods } from '@opensea/seaport-js/src/utils/usecase';
 import { PopulatedTransaction, BigNumber } from 'ethers';
 import { TransactionBuilder } from '../types';
+import { TransactionMethods } from './types';
 
 // Add 20% more gas than estimate to prevent out of gas errors
 // This can always be overwritten by the user signing the transaction

--- a/packages/orderbook/src/seaport/transaction.ts
+++ b/packages/orderbook/src/seaport/transaction.ts
@@ -1,4 +1,4 @@
-import type { TransactionMethods } from '@opensea/seaport-js/lib/utils/usecase';
+import type { TransactionMethods } from '@opensea/seaport-js/src/utils/usecase';
 import { PopulatedTransaction, BigNumber } from 'ethers';
 import { TransactionBuilder } from '../types';
 

--- a/packages/orderbook/src/seaport/types.ts
+++ b/packages/orderbook/src/seaport/types.ts
@@ -1,6 +1,10 @@
 import { Seaport as SeaportLib } from '@opensea/seaport-js';
 import { ItemType } from './constants';
 
+// Importing types from seaport-js using a relative path (e.g. @opensea/seaport-js/lib/constants)
+// can cause issues for consumers of the SDK, e.g: https://github.com/immutable/ts-immutable-sdk/issues/2472.
+// To avoid this issue, we've extracted some of the accessible types below, and duplicated others.
+
 type ElementType<T> = T extends (infer U)[] ? U : never;
 
 export type DefaultReturnType<R> = R extends Array<any> ? R[0] : R;

--- a/packages/orderbook/src/seaport/types.ts
+++ b/packages/orderbook/src/seaport/types.ts
@@ -1,6 +1,11 @@
 import { Seaport as SeaportLib } from '@opensea/seaport-js';
+import { ItemType } from './constants';
 
-export type OrderComponents = Parameters<SeaportLib['signOrder'][0]>;
+type ElementType<T> = T extends (infer U)[] ? U : never;
+
+export type DefaultReturnType<R> = R extends Array<any> ? R[0] : R;
+
+export type OrderComponents = Parameters<SeaportLib['signOrder']>[0];
 
 export type OrderParameters = Omit<OrderComponents, 'counter'>;
 
@@ -10,22 +15,51 @@ export type ConsiderationItem = OrderParameters['consideration'][0];
 
 export type FulfillmentOrderDetails = Parameters<SeaportLib['fulfillOrders']>[0]['fulfillOrderDetails'][0];
 
+export type OrderWithCounter = Parameters<SeaportLib['fulfillOrder']>[0]['order'];
+
 export type CreateOrderInput = Parameters<SeaportLib['createOrder']>[0];
 
 export type ConsiderationInputItem = CreateOrderInput['consideration'][0];
 
 export type CreateInputItem = CreateOrderInput['offer'][0];
 
-export type InputCriteria = Parameters<SeaportLib['fulfillOrder']>[0]['offerCriteria'][0];
+export type InputCriteria = ElementType<Parameters<SeaportLib['fulfillOrder']>[0]['offerCriteria']>;
 
-export type TipInputItem = Parameters<SeaportLib['fulfillOrder']>[0]['tips'][0];
+export type TipInputItem = ElementType<Parameters<SeaportLib['fulfillOrder']>[0]['tips']>;
 
-export type CreateBulkOrdersReturnType = ReturnType<SeaportLib['createBulkOrders']>;
+export type CreateBulkOrdersReturnType = Awaited<ReturnType<SeaportLib['createBulkOrders']>>;
 
-export type CreateOrderReturnType = ReturnType<SeaportLib['createOrder']>;
+export type CreateOrderReturnType = Awaited<ReturnType<SeaportLib['createOrder']>>;
 
-export type ApprovalAction = CreateOrderReturnType['actions'][0];
+export type TransactionMethods<T = unknown> = {
+  buildTransaction: (overrides?: any) => Promise<any>;
+  staticCall: (overrides?: any) => Promise<DefaultReturnType<T>>;
+  estimateGas: (overrides?: any) => Promise<bigint>;
+  transact: (overrides?: any) => Promise<any>;
+};
 
-export type CreateBulkOrdersAction = CreateBulkOrdersReturnType['actions'][0];
+export type CreateOrderAction = {
+  type: 'create';
+  getMessageToSign: () => Promise<string>;
+  createOrder: () => Promise<OrderWithCounter>;
+};
 
-export type CreateOrderAction = CreateOrderReturnType['actions'][0];
+export type ApprovalAction = {
+  type: 'approval';
+  token: string;
+  identifierOrCriteria: string;
+  itemType: ItemType;
+  operator: string;
+  transactionMethods: TransactionMethods;
+};
+
+export type ExchangeAction<T = unknown> = {
+  type: 'exchange';
+  transactionMethods: TransactionMethods<T>;
+};
+
+export type CreateBulkOrdersAction = {
+  type: 'createBulk';
+  getMessageToSign: () => Promise<string>;
+  createBulkOrders: () => Promise<OrderWithCounter[]>;
+};

--- a/packages/orderbook/src/seaport/types.ts
+++ b/packages/orderbook/src/seaport/types.ts
@@ -1,0 +1,31 @@
+import { Seaport as SeaportLib } from '@opensea/seaport-js';
+
+export type OrderComponents = Parameters<SeaportLib['signOrder'][0]>;
+
+export type OrderParameters = Omit<OrderComponents, 'counter'>;
+
+export type OfferItem = OrderParameters['offer'][0];
+
+export type ConsiderationItem = OrderParameters['consideration'][0];
+
+export type FulfillmentOrderDetails = Parameters<SeaportLib['fulfillOrders']>[0]['fulfillOrderDetails'][0];
+
+export type CreateOrderInput = Parameters<SeaportLib['createOrder']>[0];
+
+export type ConsiderationInputItem = CreateOrderInput['consideration'][0];
+
+export type CreateInputItem = CreateOrderInput['offer'][0];
+
+export type InputCriteria = Parameters<SeaportLib['fulfillOrder']>[0]['offerCriteria'][0];
+
+export type TipInputItem = Parameters<SeaportLib['fulfillOrder']>[0]['tips'][0];
+
+export type CreateBulkOrdersReturnType = ReturnType<SeaportLib['createBulkOrders']>;
+
+export type CreateOrderReturnType = ReturnType<SeaportLib['createOrder']>;
+
+export type ApprovalAction = CreateOrderReturnType['actions'][0];
+
+export type CreateBulkOrdersAction = CreateBulkOrdersReturnType['actions'][0];
+
+export type CreateOrderAction = CreateOrderReturnType['actions'][0];

--- a/packages/orderbook/src/types.ts
+++ b/packages/orderbook/src/types.ts
@@ -1,5 +1,5 @@
-import type { OrderComponents } from '@opensea/seaport-js/src/types';
 import { PopulatedTransaction, TypedDataDomain, TypedDataField } from 'ethers';
+import type { OrderComponents } from './seaport/types';
 import { Fee as OpenapiFee, OrdersService, OrderStatus } from './openapi/sdk';
 
 // Strictly re-export only the OrderStatusName enum from the openapi types

--- a/packages/orderbook/src/types.ts
+++ b/packages/orderbook/src/types.ts
@@ -1,4 +1,4 @@
-import type { OrderComponents } from '@opensea/seaport-js/lib/types';
+import type { OrderComponents } from '@opensea/seaport-js/src/types';
 import { PopulatedTransaction, TypedDataDomain, TypedDataField } from 'ethers';
 import { Fee as OpenapiFee, OrdersService, OrderStatus } from './openapi/sdk';
 

--- a/packages/orderbook/src/utils.ts
+++ b/packages/orderbook/src/utils.ts
@@ -1,4 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function exhaustiveSwitch(param: never): never {
+export function exhaustiveSwitch(param: unknown): never {
   throw new Error('Unreachable');
 }


### PR DESCRIPTION
# Summary
This PR resolves an issue with Seaport imports when `@imtbl/orderbook` has been imported in an ESM environment, e.g: [here](https://github.com/immutable/ts-immutable-sdk/issues/2472). Note that this issue does not appear to occur in _all_ ESM environments. Rather than importing types from a relative path within seaport-js, we're now pulling out & re-exporting the types that are easily accessible, and duplicating the types that are less-easily accessible and less likely to cause issues with Typescript.

Related PR [here](https://github.com/immutable/ts-immutable-sdk/pull/384).

# Detail and impact of the change
## Changed
- Orderbook: Updated seaport-js imports to resolve an issue in ESM environments 