### PR TITLE
feat: Fetch purchase price details from the Primary Sales API

### DIFF
--- a/packages/checkout/widgets-lib/src/lib/primary-sales.ts
+++ b/packages/checkout/widgets-lib/src/lib/primary-sales.ts
@@ -119,6 +119,12 @@ export type OrderQuote = {
   totalAmount: Record<string, OrderQuotePricing>;
 };
 
+export type OrderQuoteResponse = {
+  quote: OrderQuote;
+  currency: OrderQuoteCurrency;
+  totalCurrencyAmount: number;
+};
+
 export enum SignPaymentTypes {
   CRYPTO = 'crypto',
   FIAT = 'fiat',
@@ -189,10 +195,8 @@ export const PRIMARY_SALES_API_BASE_URL = {
 };
 
 export type UseQuoteOrderParams = {
-  items: SaleItem[];
   environmentId: string;
   environment: Environment;
-  provider: Web3Provider | undefined;
   preferredCurrency?: string;
 };
 

--- a/packages/checkout/widgets-lib/src/widgets/purchase/PurchaseWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/purchase/PurchaseWidget.tsx
@@ -23,6 +23,7 @@ import { useTokens } from '../../lib/squid/hooks/useTokens';
 import { useProvidersContext } from '../../context/providers-context/ProvidersContext';
 import { fetchChains } from '../../lib/squid/functions/fetchChains';
 import { useQuoteOrder } from '../../lib/hooks/useQuoteOrder';
+import { CryptoFiatProvider } from '../../context/crypto-fiat-context/CryptoFiatProvider';
 
 export type PurchaseWidgetInputs = PurchaseWidgetParams & {
   config: StrongCheckoutWidgetsConfig;
@@ -157,41 +158,43 @@ export default function PurchaseWidget({
   return (
     <ViewContext.Provider value={viewReducerValues}>
       <PurchaseContext.Provider value={purchaseReducerValues}>
-        <Stack sx={{ pos: 'relative' }}>
-          <CloudImage
-            use={(
-              <img
-                src={getRemoteImage(
-                  config.environment,
-                  `/add-tokens-bg-texture-${colorMode}.webp`,
-                )}
-                alt="background texture"
-              />
-            )}
-            sx={{
-              pos: 'absolute',
-              h: '100%',
-              w: '100%',
-              objectFit: 'cover',
-              objectPosition: 'center',
-            }}
-          />
-          {viewState.view.type === PurchaseWidgetViews.PURCHASE && (
-            <Purchase
-              checkout={checkout}
-              environmentId={environmentId!}
-              showBackButton={showBackButton}
-              onCloseButtonClick={() => sendPurchaseCloseEvent(eventTarget)}
-              onBackButtonClick={() => {
-                orchestrationEvents.sendRequestGoBackEvent(
-                  eventTarget,
-                  IMTBLWidgetEvents.IMTBL_PURCHASE_WIDGET_EVENT,
-                  {},
-                );
+        <CryptoFiatProvider environment={checkout.config.environment}>
+          <Stack sx={{ pos: 'relative' }}>
+            <CloudImage
+              use={(
+                <img
+                  src={getRemoteImage(
+                    config.environment,
+                    `/add-tokens-bg-texture-${colorMode}.webp`,
+                  )}
+                  alt="background texture"
+                />
+              )}
+              sx={{
+                pos: 'absolute',
+                h: '100%',
+                w: '100%',
+                objectFit: 'cover',
+                objectPosition: 'center',
               }}
             />
-          )}
-        </Stack>
+            {viewState.view.type === PurchaseWidgetViews.PURCHASE && (
+              <Purchase
+                checkout={checkout}
+                environmentId={environmentId!}
+                showBackButton={showBackButton}
+                onCloseButtonClick={() => sendPurchaseCloseEvent(eventTarget)}
+                onBackButtonClick={() => {
+                  orchestrationEvents.sendRequestGoBackEvent(
+                    eventTarget,
+                    IMTBLWidgetEvents.IMTBL_PURCHASE_WIDGET_EVENT,
+                    {},
+                  );
+                }}
+              />
+            )}
+          </Stack>
+        </CryptoFiatProvider>
       </PurchaseContext.Provider>
     </ViewContext.Provider>
   );

--- a/packages/checkout/widgets-lib/src/widgets/purchase/components/PurchaseItemHero.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/purchase/components/PurchaseItemHero.tsx
@@ -1,5 +1,11 @@
-import { Sticker, Pile, FramedImage } from '@biom3/react';
+import {
+  Sticker, Pile, FramedImage, Heading, Body, Stack,
+} from '@biom3/react';
 import { PurchaseItem } from '@imtbl/checkout-sdk';
+import { useContext, useEffect, useState } from 'react';
+import { CryptoFiatContext } from '../../../context/crypto-fiat-context/CryptoFiatContext';
+import { PurchaseContext } from '../context/PurchaseContext';
+import { calculateCryptoToFiat } from '../../../lib/utils';
 
 interface StickerDisplayProps {
   items: PurchaseItem[];
@@ -11,40 +17,90 @@ export function PurchaseItemHero({ items, totalQty }: StickerDisplayProps) {
     return null;
   }
 
+  const { purchaseState: { quote } } = useContext(PurchaseContext);
+  const { cryptoFiatState: { conversions } } = useContext(CryptoFiatContext);
+
+  const [detailsLoading, setDetailsLoading] = useState(true);
+  const [fiatPrice, setFiatPrice] = useState<string | undefined>(undefined);
+
+  const item = items[0];
+
+  useEffect(() => {
+    if (!quote?.totalCurrencyAmount || !conversions) return;
+
+    const fiatPriceConversion = calculateCryptoToFiat(
+      String(quote.totalCurrencyAmount),
+      quote.currency.name,
+      conversions,
+    );
+
+    setFiatPrice(fiatPriceConversion);
+    setDetailsLoading(false);
+  }, [quote, conversions]);
+
   return (
-    totalQty > 1 ? (
-      <Sticker position={{ x: 'right', y: 'bottomInside' }}>
-        <Pile>
-          <FramedImage
-            use={(
-              <img
-                src={items[0].image}
-                alt={items[0].name}
-              />
-            )}
-            sx={{
-              w: 'base.spacing.x30',
-              h: 'base.spacing.x30',
-            }}
-            emphasized
-          />
-        </Pile>
-        <Sticker.Badge badgeContent={`x${totalQty}`} variant="light" />
-      </Sticker>
-    ) : (
-      <FramedImage
-        use={(
-          <img
-            src={items[0].image}
-            alt={items[0].name}
-          />
-        )}
-        sx={{
-          w: 'base.spacing.x30',
-          h: 'base.spacing.x30',
-        }}
-        emphasized
-      />
-    )
+    <Stack sx={{ gap: '0', alignItems: 'center' }}>
+      {totalQty > 1 ? (
+        <Sticker position={{ x: 'right', y: 'bottomInside' }}>
+          <Pile>
+            <FramedImage
+              use={(
+                <img
+                  src={items[0].image}
+                  alt={items[0].name}
+                />
+              )}
+              sx={{
+                w: 'base.spacing.x33',
+                h: 'base.spacing.x33',
+                mb: 'base.spacing.x4',
+              }}
+              emphasized
+            />
+          </Pile>
+          <Sticker.Badge badgeContent={`x${totalQty}`} variant="light" />
+        </Sticker>
+      ) : (
+        <FramedImage
+          use={(
+            <img
+              src={items[0].image}
+              alt={items[0].name}
+            />
+          )}
+          sx={{
+            w: 'base.spacing.x33',
+            h: 'base.spacing.x33',
+            mb: 'base.spacing.x4',
+          }}
+        />
+      )}
+
+      <Body size="large">
+        {item.name}
+      </Body>
+      {detailsLoading ? (
+        <>
+          <Heading size="small" shimmer={1} />
+          <Body size="xSmall" shimmer={1} />
+        </>
+      ) : (
+        <>
+          {fiatPrice && (
+            <Heading size="small">
+              USD $
+              {fiatPrice}
+            </Heading>
+          )}
+          {quote?.totalCurrencyAmount && (
+            <Body size="xSmall">
+              {quote.currency.name}
+              {' '}
+              {quote.totalCurrencyAmount}
+            </Body>
+          )}
+        </>
+      )}
+    </Stack>
   );
 }

--- a/packages/checkout/widgets-lib/src/widgets/purchase/context/PurchaseContext.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/purchase/context/PurchaseContext.tsx
@@ -2,6 +2,7 @@ import { Squid } from '@0xsquid/sdk';
 import { PurchaseItem } from '@imtbl/checkout-sdk';
 import { createContext } from 'react';
 import { Chain, Token } from '../../../lib/squid/types';
+import { OrderQuoteResponse } from '../../../lib/primary-sales';
 
 export interface PurchaseState {
   squid: {
@@ -10,6 +11,7 @@ export interface PurchaseState {
     tokens: Token[] | null;
   };
   items: PurchaseItem[];
+  quote: OrderQuoteResponse | null;
 }
 
 export const initialPurchaseState: PurchaseState = {
@@ -19,6 +21,7 @@ export const initialPurchaseState: PurchaseState = {
     tokens: null,
   },
   items: [],
+  quote: null,
 };
 
 export interface PurchaseContextState {
@@ -34,13 +37,15 @@ type ActionPayload =
   | SetSquid
   | SetSquidChains
   | SetSquidTokens
-  | SetItems;
+  | SetItems
+  | SetQuote;
 
 export enum PurchaseActions {
   SET_SQUID = 'SET_SQUID',
   SET_SQUID_CHAINS = 'SET_SQUID_CHAINS',
   SET_SQUID_TOKENS = 'SET_SQUID_TOKENS',
   SET_ITEMS = 'SET_ITEMS',
+  SET_QUOTE = 'SET_QUOTE',
 }
 
 export interface SetSquid {
@@ -61,6 +66,11 @@ export interface SetSquidTokens {
 export interface SetItems {
   type: PurchaseActions.SET_ITEMS;
   items: PurchaseItem[];
+}
+
+export interface SetQuote {
+  type: PurchaseActions.SET_QUOTE;
+  quote: OrderQuoteResponse;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -106,6 +116,11 @@ export const purchaseReducer: Reducer<PurchaseState, PurchaseAction> = (
       return {
         ...state,
         items: action.payload.items,
+      };
+    case PurchaseActions.SET_QUOTE:
+      return {
+        ...state,
+        quote: action.payload.quote,
       };
     default:
       return state;

--- a/packages/checkout/widgets-lib/src/widgets/purchase/views/Purchase.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/purchase/views/Purchase.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { Stack, ButtCon } from '@biom3/react';
 import { Checkout, PurchaseItem } from '@imtbl/checkout-sdk';
 import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
@@ -20,13 +20,23 @@ export function Purchase({
   showBackButton,
   onBackButtonClick,
 }: PurchaseProps) {
-  const { purchaseState: { items } } = useContext(PurchaseContext);
+  const { purchaseState: { items, quote } } = useContext(PurchaseContext);
 
-  // eslint-disable-next-line no-console
-  console.log({
-    checkout,
-    environmentId,
-  });
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log({
+      checkout,
+      environmentId,
+    });
+  }, [checkout, environmentId]);
+
+  useEffect(() => {
+    if (!quote) return;
+    // eslint-disable-next-line no-console
+    console.log('Order quote fetched', {
+      quote,
+    });
+  }, [quote]);
 
   const shouldShowBackButton = showBackButton && onBackButtonClick;
 

--- a/packages/checkout/widgets-lib/src/widgets/purchase/views/Purchase.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/purchase/views/Purchase.tsx
@@ -4,6 +4,7 @@ import { Checkout, PurchaseItem } from '@imtbl/checkout-sdk';
 import { SimpleLayout } from '../../../components/SimpleLayout/SimpleLayout';
 import { PurchaseContext } from '../context/PurchaseContext';
 import { PurchaseItemHero } from '../components/PurchaseItemHero';
+import { CryptoFiatActions, CryptoFiatContext } from '../../../context/crypto-fiat-context/CryptoFiatContext';
 
 interface PurchaseProps {
   checkout: Checkout;
@@ -22,6 +23,8 @@ export function Purchase({
 }: PurchaseProps) {
   const { purchaseState: { items, quote } } = useContext(PurchaseContext);
 
+  const { cryptoFiatDispatch } = useContext(CryptoFiatContext);
+
   useEffect(() => {
     // eslint-disable-next-line no-console
     console.log({
@@ -35,6 +38,17 @@ export function Purchase({
     // eslint-disable-next-line no-console
     console.log('Order quote fetched', {
       quote,
+    });
+
+    const tokenSymbols = Object
+      .values(quote.quote.totalAmount)
+      .map((price) => price.currency);
+
+    cryptoFiatDispatch({
+      payload: {
+        type: CryptoFiatActions.SET_TOKEN_SYMBOLS,
+        tokenSymbols,
+      },
     });
   }, [quote]);
 


### PR DESCRIPTION
# Summary

We're now fetching the final purchase details from the backend, converting any amounts to fiat, and displaying them in the Hero component.

<img width="349" alt="image" src="https://github.com/user-attachments/assets/b449a810-bc26-42ed-91f8-ac111a089485" />

