### PR TITLE
fix: marking IMX as token valid for native bridge

### DIFF
--- a/packages/checkout/sdk/src/config/tokensFetcher.ts
+++ b/packages/checkout/sdk/src/config/tokensFetcher.ts
@@ -128,7 +128,7 @@ export class TokensFetcher {
         decimals: 18,
         name: 'IMX',
         symbol: 'IMX',
-        bridge: null,
+        bridge: 'native',
       });
     });
 


### PR DESCRIPTION
# Summary
- IMX currently not showing up in the bridge widget: Small fix to add it as native and therefor supported in the bridge
<img width="355" alt="Screenshot 2025-01-31 at 7 35 27 AM" src="https://github.com/user-attachments/assets/2c3e3da1-ff4f-4fb5-a3c8-d862b6856238" />


# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
