### PR TITLE
chore: Implement geoblock for swaps on Commerce widget

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/swap/GeoblockLoader.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/GeoblockLoader.tsx
@@ -9,7 +9,7 @@ import { useHandover } from '../../lib/hooks/useHandover';
 type GeoblockLoaderParams = {
   widget: React.ReactNode;
   serviceUnavailableView: React.ReactNode;
-  checkout: Checkout,
+  checkout?: Checkout,
 };
 
 export function GeoblockLoader({
@@ -23,6 +23,8 @@ export function GeoblockLoader({
   const [available, setAvailable] = useState(false);
 
   useEffect(() => {
+    if (!checkout) return;
+
     (async () => {
       try {
         showLoader({ text: t('views.LOADING_VIEW.text') });

--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidgetRoot.tsx
@@ -4,7 +4,6 @@ import {
   IMTBLWidgetEvents,
   SwapDirection,
   SwapWidgetParams,
-  WalletProviderName,
   WidgetConfiguration,
   WidgetProperties,
   WidgetTheme,
@@ -13,18 +12,13 @@ import {
 import { Base } from '../BaseWidgetRoot';
 import { ConnectLoader, ConnectLoaderParams } from '../../components/ConnectLoader/ConnectLoader';
 import { getL2ChainId } from '../../lib';
-import { isPassportProvider } from '../../lib/provider';
-import { ServiceUnavailableToRegionErrorView } from '../../views/error/ServiceUnavailableToRegionErrorView';
-import { ServiceType } from '../../views/error/serviceTypes';
 import { isValidAddress, isValidAmount, isValidWalletProvider } from '../../lib/validations/widgetValidators';
 import { ThemeProvider } from '../../components/ThemeProvider/ThemeProvider';
 import { CustomAnalyticsProvider } from '../../context/analytics-provider/CustomAnalyticsProvider';
 import { LoadingView } from '../../views/loading/LoadingView';
 import { HandoverProvider } from '../../context/handover-context/HandoverProvider';
-import { topUpBridgeOption, topUpOnRampOption } from './helpers';
 import { sendSwapWidgetCloseEvent } from './SwapWidgetEvents';
 import i18n from '../../i18n';
-import { GeoblockLoader } from './GeoblockLoader';
 
 const SwapWidget = React.lazy(() => import('./SwapWidget'));
 
@@ -79,27 +73,6 @@ export class Swap extends Base<WidgetType.SWAP> {
     return validatedParams;
   }
 
-  private isNotPassport = !isPassportProvider(this.web3Provider)
-    || this.parameters?.walletProviderName !== WalletProviderName.PASSPORT;
-
-  private topUpOptions(): { textKey: string; action: () => void }[] | undefined {
-    const optionsArray: { textKey: string; action: () => void }[] = [];
-
-    const isOnramp = topUpOnRampOption(this.strongConfig().isOnRampEnabled);
-    if (isOnramp) {
-      optionsArray.push({ ...isOnramp });
-    }
-    const isBridge = topUpBridgeOption(
-      this.strongConfig().isBridgeEnabled,
-      this.isNotPassport,
-    );
-    if (isBridge) {
-      optionsArray.push({ ...isBridge });
-    }
-
-    return optionsArray;
-  }
-
   protected render() {
     if (!this.reactRoot) return;
 
@@ -114,65 +87,29 @@ export class Swap extends Base<WidgetType.SWAP> {
       allowedChains: [getL2ChainId(this.checkout!.config)],
     };
 
-    const topUpOptions = this.topUpOptions();
-
     this.reactRoot!.render(
       <React.StrictMode>
         <CustomAnalyticsProvider checkout={this.checkout}>
           <ThemeProvider id="swap-container" config={this.strongConfig()}>
             <HandoverProvider>
-              <GeoblockLoader
-                checkout={this.checkout}
-                widget={
-                (
-                  <ConnectLoader
-                    params={connectLoaderParams}
-                    widgetConfig={this.strongConfig()}
-                    closeEvent={() => sendSwapWidgetCloseEvent(window)}
-                  >
-                    <Suspense fallback={<LoadingView loadingText={t('views.LOADING_VIEW.text')} />}>
-                      <SwapWidget
-                        fromTokenAddress={this.parameters.fromTokenAddress}
-                        toTokenAddress={this.parameters.toTokenAddress}
-                        amount={this.parameters.amount}
-                        config={this.strongConfig()}
-                        autoProceed={this.parameters.autoProceed}
-                        direction={this.parameters.direction ?? SwapDirection.FROM}
-                        showBackButton={this.parameters.showBackButton}
-                      />
-                    </Suspense>
-                  </ConnectLoader>
-                )
-              }
-                serviceUnavailableView={
-                (
-                  <ServiceUnavailableToRegionErrorView
-                    service={ServiceType.SWAP}
-                    onCloseClick={() => sendSwapWidgetCloseEvent(window)}
-                    primaryActionText={
-                      topUpOptions && topUpOptions?.length > 0
-                        ? t(topUpOptions[0].textKey)
-                        : undefined
-                    }
-                    onPrimaryButtonClick={
-                      topUpOptions && topUpOptions?.length > 0
-                        ? topUpOptions[0].action
-                        : undefined
-                    }
-                    secondaryActionText={
-                      topUpOptions?.length === 2
-                        ? t(topUpOptions[1].textKey)
-                        : undefined
-                    }
-                    onSecondaryButtonClick={
-                      topUpOptions?.length === 2
-                        ? topUpOptions[1].action
-                        : undefined
-                    }
+              <ConnectLoader
+                params={connectLoaderParams}
+                widgetConfig={this.strongConfig()}
+                closeEvent={() => sendSwapWidgetCloseEvent(window)}
+              >
+                <Suspense fallback={<LoadingView loadingText={t('views.LOADING_VIEW.text')} />}>
+                  <SwapWidget
+                    fromTokenAddress={this.parameters.fromTokenAddress}
+                    toTokenAddress={this.parameters.toTokenAddress}
+                    amount={this.parameters.amount}
+                    config={this.strongConfig()}
+                    autoProceed={this.parameters.autoProceed}
+                    direction={this.parameters.direction ?? SwapDirection.FROM}
+                    showBackButton={this.parameters.showBackButton}
+                    walletProviderName={this.parameters.walletProviderName}
                   />
-                )
-              }
-              />
+                </Suspense>
+              </ConnectLoader>
             </HandoverProvider>
           </ThemeProvider>
         </CustomAnalyticsProvider>


### PR DESCRIPTION
# Summary

The geo-block check was being skipped by the Commerce widget. By bringing the wrapper into `SwapWidget` rather than `SwapWidgetRoot`, the check is now included when using the Commerce widget.