### PR TITLE
feat: GFI-82: Allow USDC Swap Hops

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -215,6 +215,24 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     network,
   ]);
 
+  const openUnableToSwapDrawer = useCallback((error: any) => {
+    setShowNotEnoughImxDrawer(false);
+    setShowUnableToSwapDrawer(true);
+    track({
+      userJourney: UserJourney.SWAP,
+      screen: 'SwapCoins',
+      control: 'UnableToSwapDrawer',
+      controlType: 'Button',
+      extras: {
+        fromToken,
+        toToken,
+        fromAmount,
+        toAmount,
+        error: 'message' in error ? error.message : error,
+      },
+    });
+  }, [track, fromToken, toToken, fromAmount, toAmount]);
+
   const tokensOptionsTo = useMemo(() => allowedTokens
     .map(
       (token) => ({
@@ -329,8 +347,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
         console.error('Error fetching quote.', error);
 
         resetQuote();
-        setShowNotEnoughImxDrawer(false);
-        setShowUnableToSwapDrawer(true);
+        openUnableToSwapDrawer(error);
       }
     }
 
@@ -406,8 +423,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     } catch (error: any) {
       if (!error.cancelled) {
         resetQuote();
-        setShowNotEnoughImxDrawer(false);
-        setShowUnableToSwapDrawer(true);
+        openUnableToSwapDrawer(error);
       }
     }
 
@@ -542,6 +558,18 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     setFromToken(selected.token);
     setFromBalance(selected.formattedBalance);
     setFromTokenError('');
+
+    track({
+      userJourney: UserJourney.SWAP,
+      screen: 'SwapCoins',
+      control: 'SelectFrom',
+      controlType: 'Select',
+      extras: {
+        fromBalance: selected.formattedBalance,
+        fromToken: selected.token,
+        fromAmount,
+      },
+    });
   }, [toToken]);
 
   const onFromTextInputFocus = () => {
@@ -559,6 +587,18 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
       setLoading(true);
     }
     setFromAmount(value);
+
+    track({
+      userJourney: UserJourney.SWAP,
+      screen: 'SwapCoins',
+      control: 'InputFrom',
+      controlType: 'TextInput',
+      extras: {
+        fromBalance,
+        fromToken,
+        fromAmount: value,
+      },
+    });
   };
 
   const textInputMaxButtonClick = () => {
@@ -602,6 +642,17 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
 
     setToToken(selected);
     setToTokenError('');
+
+    track({
+      userJourney: UserJourney.SWAP,
+      screen: 'SwapCoins',
+      control: 'SelectTo',
+      controlType: 'Select',
+      extras: {
+        toToken: selected,
+        toAmount,
+      },
+    });
   }, [fromToken]);
 
   const onToTextInputFocus = () => {
@@ -620,6 +671,17 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
       setLoading(true);
     }
     setToAmount(value);
+
+    track({
+      userJourney: UserJourney.SWAP,
+      screen: 'SwapCoins',
+      control: 'InputTo',
+      controlType: 'TextInput',
+      extras: {
+        toToken,
+        toAmount: value,
+      },
+    });
   };
 
   const openNotEnoughImxDrawer = () => {

--- a/packages/internal/dex/sdk/src/constants/tokens/immutable-mainnet.ts
+++ b/packages/internal/dex/sdk/src/constants/tokens/immutable-mainnet.ts
@@ -27,7 +27,17 @@ export const ETH_IMMUTABLE_MAINNET: ERC20 = {
   type: 'erc20',
 };
 
+export const USDC_IMMUTABLE_MAINNET: ERC20 = {
+  chainId: IMMUTABLE_MAINNET_CHAIN_ID,
+  address: '0x3B2d8A1931736Fc321C24864BceEe981B11c3c57',
+  decimals: 6,
+  symbol: 'USDC',
+  name: 'USDC',
+  type: 'erc20',
+};
+
 export const IMMUTABLE_MAINNET_COMMON_ROUTING_TOKENS: ERC20[] = [
   WIMX_IMMUTABLE_MAINNET,
   ETH_IMMUTABLE_MAINNET,
+  USDC_IMMUTABLE_MAINNET,
 ];

--- a/packages/internal/dex/sdk/src/constants/tokens/immutable-mainnet.ts
+++ b/packages/internal/dex/sdk/src/constants/tokens/immutable-mainnet.ts
@@ -29,10 +29,19 @@ export const ETH_IMMUTABLE_MAINNET: ERC20 = {
 
 export const USDC_IMMUTABLE_MAINNET: ERC20 = {
   chainId: IMMUTABLE_MAINNET_CHAIN_ID,
-  address: '0x3B2d8A1931736Fc321C24864BceEe981B11c3c57',
+  address: '0x6de8aCC0D406837030CE4dd28e7c08C5a96a30d2',
   decimals: 6,
   symbol: 'USDC',
   name: 'USDC',
+  type: 'erc20',
+};
+
+export const USDT_IMMUTABLE_MAINNET: ERC20 = {
+  chainId: IMMUTABLE_MAINNET_CHAIN_ID,
+  address: '0x68bcc7F1190AF20e7b572BCfb431c3Ac10A936Ab',
+  decimals: 6,
+  symbol: 'USDT',
+  name: 'USDT',
   type: 'erc20',
 };
 
@@ -40,4 +49,5 @@ export const IMMUTABLE_MAINNET_COMMON_ROUTING_TOKENS: ERC20[] = [
   WIMX_IMMUTABLE_MAINNET,
   ETH_IMMUTABLE_MAINNET,
   USDC_IMMUTABLE_MAINNET,
+  USDT_IMMUTABLE_MAINNET,
 ];


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [x] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Add USDC to "common routing tokens" allowing it to be considered as a hop for swaps.

Further justification for this is that we recommend games set up a USDC LP for their token: https://docs.immutable.com/guides/zkevm/game-currencies/liquidity-pools/#set-up-your-liquidity-pool-with-quickswap

Also added USDT as some tokens only have USDT pools e.g. https://quickswap.exchange/#/analytics/v3/token/0x699797abcdc2e20165fE4bAC5efbAa652490E6E2

Ran some tests locally and adding two more common routing tokens only increased the quoting time by about 50ms.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
