### PR TITLE
GFI-87: Increase max swap hops to 3

### DIFF
--- a/packages/internal/dex/sdk/src/constants/router.ts
+++ b/packages/internal/dex/sdk/src/constants/router.ts
@@ -4,8 +4,8 @@ export const DEFAULT_SLIPPAGE = 0.1;
 // 15 minutes from the time the transaction was prepared
 export const DEFAULT_DEADLINE_SECONDS: number = 60 * 15;
 
-// most swaps will be able to resolve with 2 hops
-export const DEFAULT_MAX_HOPS: number = 2;
+// most swaps will be able to resolve with 3 hops
+export const DEFAULT_MAX_HOPS: number = 3;
 
 // after 10 hops, it is very unlikely a route will be available
 export const MAX_MAX_HOPS: number = 10;

--- a/packages/internal/dex/sdk/src/lib/router.ts
+++ b/packages/internal/dex/sdk/src/lib/router.ts
@@ -7,6 +7,7 @@ import { erc20ToUniswapToken, poolEquals, uniswapTokenToERC20 } from './utils';
 import { getQuotesForRoutes, QuoteResult } from './getQuotesForRoutes';
 import { fetchValidPools } from './poolUtils/fetchValidPools';
 import { ERC20Pair } from './poolUtils/generateERC20Pairs';
+import { DEFAULT_MAX_HOPS } from '../constants/router';
 import type { Multicall } from '../contracts/types';
 
 export type RoutingContracts = {
@@ -32,7 +33,7 @@ export class Router {
     amountSpecified: CoinAmount<ERC20>,
     otherToken: ERC20,
     tradeType: TradeType,
-    maxHops: number = 2,
+    maxHops: number = DEFAULT_MAX_HOPS,
   ): Promise<QuoteResult> {
     const [tokenIn, tokenOut] = this.determineERC20InAndERC20Out(tradeType, amountSpecified, otherToken);
 


### PR DESCRIPTION
### Hi👋, please prefix this PR's title with:
<!-- This will give consistant Release changelog to the public -->
- [ ] `breaking-change:` if you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities.
- [ ] `feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`.

# Summary

Increasing the max number of pools used in a swap to 3. This will allow swaps between IMX and VDT (for example) where the pools necessary are

IMX / USDC
USDC / USDT
USDT / VDT

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
