### PR TITLE
build(checkout): GFI-96: Track select token clicks

### DIFF
--- a/packages/checkout/widgets-lib/src/components/FormComponents/SelectForm/SelectForm.tsx
+++ b/packages/checkout/widgets-lib/src/components/FormComponents/SelectForm/SelectForm.tsx
@@ -1,15 +1,17 @@
 import {
   Select, Box, OptionKey,
 } from '@biom3/react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Environment } from '@imtbl/config';
 import { WidgetTheme } from '@imtbl/checkout-sdk';
 import { TokenImage } from '../../TokenImage/TokenImage';
 import { FormControlWrapper } from '../FormControlWrapper/FormControlWrapper';
 import { CoinSelector } from '../../CoinSelector/CoinSelector';
 import { CoinSelectorOptionProps } from '../../CoinSelector/CoinSelectorOption';
+import { useAnalytics, UserJourney } from '../../../context/analytics-provider/SegmentAnalyticsProvider';
 
 interface SelectFormProps {
+  control: string;
   testId: string;
   options: CoinSelectorOptionProps[];
   optionsLoading?: boolean;
@@ -26,6 +28,7 @@ interface SelectFormProps {
 }
 
 export function SelectForm({
+  control,
   testId,
   options,
   optionsLoading,
@@ -40,6 +43,7 @@ export function SelectForm({
   environment = Environment.PRODUCTION,
   theme = WidgetTheme.DARK,
 }: SelectFormProps) {
+  const { track } = useAnalytics();
   const [coinSelectorOpen, setCoinSelectorOpen] = useState<boolean>(false);
   const coinSelectorOptions = useMemo(() => options.map((option) => ({
     ...option,
@@ -57,7 +61,18 @@ export function SelectForm({
     return selectedOption;
   };
 
-  const filteredOption = options?.find((o) => o.id === selectedOption) as CoinSelectorOptionProps ?? selectedOption;
+  const filteredOption = options.find((o) => o.id === selectedOption) as CoinSelectorOptionProps ?? selectedOption;
+
+  const openCoinSelector = useCallback(() => {
+    setCoinSelectorOpen(true);
+    track({
+      userJourney: UserJourney.SWAP,
+      screen: 'SwapCoins',
+      control,
+      controlType: 'Select',
+      action: 'Opened',
+    });
+  }, [setCoinSelectorOpen, track]);
 
   return (
     <Box>
@@ -80,7 +95,7 @@ export function SelectForm({
           testId={`${testId}-select`}
           size="large"
           defaultLabel="Select token"
-          targetClickOveride={() => setCoinSelectorOpen(true)}
+          targetClickOveride={openCoinSelector}
           selectedOption={getSelectedOption()}
           sx={{ minw: '170px' }}
         >

--- a/packages/checkout/widgets-lib/src/components/FormComponents/SelectForm/SelectForm.tsx
+++ b/packages/checkout/widgets-lib/src/components/FormComponents/SelectForm/SelectForm.tsx
@@ -11,7 +11,7 @@ import { CoinSelectorOptionProps } from '../../CoinSelector/CoinSelectorOption';
 import { useAnalytics, UserJourney } from '../../../context/analytics-provider/SegmentAnalyticsProvider';
 
 interface SelectFormProps {
-  control: string;
+
   testId: string;
   options: CoinSelectorOptionProps[];
   optionsLoading?: boolean;
@@ -23,12 +23,14 @@ interface SelectFormProps {
   onSelectChange: (value: string) => void;
   coinSelectorHeading: string;
   defaultTokenImage: string;
+  userJourney: UserJourney;
+  screen: string;
+  control: string;
   environment?: Environment;
   theme?: WidgetTheme,
 }
 
 export function SelectForm({
-  control,
   testId,
   options,
   optionsLoading,
@@ -40,6 +42,9 @@ export function SelectForm({
   selectedOption,
   coinSelectorHeading,
   defaultTokenImage,
+  userJourney,
+  screen,
+  control,
   environment = Environment.PRODUCTION,
   theme = WidgetTheme.DARK,
 }: SelectFormProps) {
@@ -66,8 +71,8 @@ export function SelectForm({
   const openCoinSelector = useCallback(() => {
     setCoinSelectorOpen(true);
     track({
-      userJourney: UserJourney.SWAP,
-      screen: 'SwapCoins',
+      userJourney,
+      screen,
       control,
       controlType: 'Select',
       action: 'Opened',

--- a/packages/checkout/widgets-lib/src/components/FormComponents/SelectForm/SelectForm.tsx
+++ b/packages/checkout/widgets-lib/src/components/FormComponents/SelectForm/SelectForm.tsx
@@ -11,7 +11,6 @@ import { CoinSelectorOptionProps } from '../../CoinSelector/CoinSelectorOption';
 import { useAnalytics, UserJourney } from '../../../context/analytics-provider/SegmentAnalyticsProvider';
 
 interface SelectFormProps {
-
   testId: string;
   options: CoinSelectorOptionProps[];
   optionsLoading?: boolean;

--- a/packages/checkout/widgets-lib/src/components/FormComponents/SelectInput/SelectInput.tsx
+++ b/packages/checkout/widgets-lib/src/components/FormComponents/SelectInput/SelectInput.tsx
@@ -9,9 +9,10 @@ import {
 import { SelectForm } from '../SelectForm/SelectForm';
 import { InputMode, TextInputForm, TextInputType } from '../TextInputForm/TextInputForm';
 import { CoinSelectorOptionProps } from '../../CoinSelector/CoinSelectorOption';
+import { UserJourney } from '../../../context/analytics-provider/SegmentAnalyticsProvider';
 
 interface SelectInputProps {
-  control: string;
+
   testId: string;
   options: CoinSelectorOptionProps[];
   selectTextAlign?: 'left' | 'right';
@@ -35,12 +36,14 @@ interface SelectInputProps {
   onSelectChange: (value: OptionKey) => void;
   selectedOption?: OptionKey;
   defaultTokenImage: string;
+  userJourney: UserJourney;
+  screen: string;
+  control: string;
   environment?: Environment;
   theme?: WidgetTheme;
 }
 
 export function SelectInput({
-  control,
   testId,
   options,
   textInputValue,
@@ -64,6 +67,9 @@ export function SelectInput({
   selectedOption,
   coinSelectorHeading,
   defaultTokenImage,
+  userJourney,
+  screen,
+  control,
   environment,
   theme,
 }: SelectInputProps) {
@@ -71,7 +77,6 @@ export function SelectInput({
     <Box sx={selectInputBoxStyle}>
       <Box sx={selectStyle}>
         <SelectForm
-          control={control}
           testId={`${testId}-select-form`}
           options={options}
           subtext={selectSubtext}
@@ -82,6 +87,9 @@ export function SelectInput({
           selectedOption={selectedOption}
           coinSelectorHeading={coinSelectorHeading}
           defaultTokenImage={defaultTokenImage}
+          control={control}
+          userJourney={userJourney}
+          screen={screen}
           environment={environment}
           theme={theme}
         />

--- a/packages/checkout/widgets-lib/src/components/FormComponents/SelectInput/SelectInput.tsx
+++ b/packages/checkout/widgets-lib/src/components/FormComponents/SelectInput/SelectInput.tsx
@@ -11,6 +11,7 @@ import { InputMode, TextInputForm, TextInputType } from '../TextInputForm/TextIn
 import { CoinSelectorOptionProps } from '../../CoinSelector/CoinSelectorOption';
 
 interface SelectInputProps {
+  control: string;
   testId: string;
   options: CoinSelectorOptionProps[];
   selectTextAlign?: 'left' | 'right';
@@ -39,6 +40,7 @@ interface SelectInputProps {
 }
 
 export function SelectInput({
+  control,
   testId,
   options,
   textInputValue,
@@ -69,6 +71,7 @@ export function SelectInput({
     <Box sx={selectInputBoxStyle}>
       <Box sx={selectStyle}>
         <SelectForm
+          control={control}
           testId={`${testId}-select-form`}
           options={options}
           subtext={selectSubtext}

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeForm.tsx
@@ -326,6 +326,9 @@ export function BridgeForm(props: BridgeFormProps) {
         {(!defaultTokenAddress || !isTokenBalancesLoading) && (
           <Box sx={formInputsContainerStyles}>
             <SelectForm
+              userJourney={UserJourney.BRIDGE}
+              screen="TokenAmount"
+              control="FromToken"
               testId="bridge-token"
               options={tokensOptions}
               optionsLoading={isTokenBalancesLoading}

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -888,7 +888,6 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
               {t('views.SWAP.swapForm.from.label')}
             </Heading>
             <SelectInput
-              control="FromToken"
               testId="fromTokenInputs"
               options={tokensOptionsFrom}
               selectSubtext={
@@ -921,6 +920,9 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
                 : undefined}
               coinSelectorHeading={t('views.SWAP.swapForm.from.selectorTitle')}
               defaultTokenImage={defaultTokenImage}
+              control="FromToken"
+              userJourney={UserJourney.SWAP}
+              screen="SwapCoins"
               environment={checkout?.config.environment}
               theme={theme}
             />
@@ -953,7 +955,6 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
               )}
             </Box>
             <SelectInput
-              control="ToToken"
               testId="toTokenInputs"
               options={tokensOptionsTo}
               selectTextAlign="left"
@@ -973,6 +974,9 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
                 : undefined}
               coinSelectorHeading={t('views.SWAP.swapForm.to.selectorTitle')}
               defaultTokenImage={defaultTokenImage}
+              control="ToToken"
+              userJourney={UserJourney.SWAP}
+              screen="SwapCoins"
               environment={checkout?.config.environment}
               theme={theme}
             />

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -888,6 +888,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
               {t('views.SWAP.swapForm.from.label')}
             </Heading>
             <SelectInput
+              control="FromToken"
               testId="fromTokenInputs"
               options={tokensOptionsFrom}
               selectSubtext={
@@ -952,6 +953,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
               )}
             </Box>
             <SelectInput
+              control="ToToken"
               testId="toTokenInputs"
               options={tokensOptionsTo}
               selectTextAlign="left"


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [x] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary

We track when the user chooses a token - event for that is checkoutSwapSwapCoins_SelectFromSelect and checkoutSwapSwapCoins_SelectToSelect, but we don't track the interaction before that which is opening the select menu. This PR tracks that.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
