### PR TITLE
build(checkout): Track spending approval separate from swap approval

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/swap/views/ApproveERC20Onboarding.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/ApproveERC20Onboarding.tsx
@@ -52,12 +52,12 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
   useEffect(() => {
     page({
       userJourney: UserJourney.SWAP,
-      screen: 'ApproveERC20',
+      screen: noApprovalTransaction ? 'ApproveSwap' : 'ApproveSpending',
       extras: {
         swapFormInfo: data.swapFormInfo,
       },
     });
-  }, []);
+  }, [noApprovalTransaction]);
 
   // Get symbol from swap info for approve amount text
   const fromToken = useMemo(

--- a/packages/checkout/widgets-lib/src/widgets/swap/views/ApproveERC20Onboarding.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/views/ApproveERC20Onboarding.tsx
@@ -27,6 +27,10 @@ import { isPassportProvider } from '../../../lib/provider';
 export interface ApproveERC20Props {
   data: ApproveERC20SwapData;
 }
+
+const APPROVE_SPENDING = 'ApproveSpending';
+const APPROVE_SWAP = 'ApproveSwap';
+
 export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
   const { t } = useTranslation();
   const { swapState: { allowedTokens } } = useContext(SwapContext);
@@ -52,12 +56,12 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
   useEffect(() => {
     page({
       userJourney: UserJourney.SWAP,
-      screen: noApprovalTransaction ? 'ApproveSwap' : 'ApproveSpending',
+      screen: noApprovalTransaction ? APPROVE_SWAP : APPROVE_SPENDING,
       extras: {
         swapFormInfo: data.swapFormInfo,
       },
     });
-  }, [noApprovalTransaction]);
+  }, []);
 
   // Get symbol from swap info for approve amount text
   const fromToken = useMemo(
@@ -147,8 +151,8 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
     if (loading) return;
     track({
       userJourney: UserJourney.SWAP,
-      screen: 'ApproveERC20',
-      control: 'ApproveSpending',
+      screen: APPROVE_SPENDING,
+      control: APPROVE_SPENDING,
       controlType: 'Button',
       extras: {
         autoProceed: data.autoProceed,
@@ -251,8 +255,8 @@ export function ApproveERC20Onboarding({ data }: ApproveERC20Props) {
     if (loading) return;
     track({
       userJourney: UserJourney.SWAP,
-      screen: 'ApproveERC20',
-      control: 'ApproveSwap',
+      screen: APPROVE_SWAP,
+      control: APPROVE_SWAP,
       controlType: 'Button',
       extras: {
         autoProceed: data.autoProceed,


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [x] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary

Currently we track these two screens with the same event, making it difficult to represent the user flow accurately in a funnel.

![image](https://github.com/user-attachments/assets/821ea0f3-5567-4a90-a3d5-c36a6453d928)
![image](https://github.com/user-attachments/assets/1beab62d-0e25-4289-9b2c-0dddd58a462d)

Use different events for each.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
