### PR TITLE
fix(passport): Fix login redirect uri

### DIFF
--- a/packages/passport/sdk-sample-app/.env.production
+++ b/packages/passport/sdk-sample-app/.env.production
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_ENV=prod
 NEXT_PUBLIC_POPUP_REDIRECT_URI=https://passport.immutable.com/sdk-sample-app/login/callback
-NEXT_PUBLIC_REDIRECT_URI=http://passport.immutable.com/sdk-sample-app/login/redirect-callback
+NEXT_PUBLIC_REDIRECT_URI=https://passport.immutable.com/sdk-sample-app/login/redirect-callback
 NEXT_PUBLIC_LOGOUT_REDIRECT_URI=https://passport.immutable.com/sdk-sample-app
 # Logout modes: redirect, silent
 NEXT_PUBLIC_LOGOUT_MODE=silent


### PR DESCRIPTION
Fix the login redirect uri because we've specified the redirect URL as http in production .env file, but we're allowed https in Auth0