### PR TITLE
chore(passport): Check isLoggedIn before calling loginWithOIDC

### DIFF
--- a/packages/passport/sdk/src/magic/magicAdapter.test.ts
+++ b/packages/passport/sdk/src/magic/magicAdapter.test.ts
@@ -6,6 +6,7 @@ import { PassportError, PassportErrorType } from '../errors/passportError';
 import { MagicProviderProxyFactory } from './magicProviderProxyFactory';
 
 const loginWithOIDCMock:jest.MockedFunction<(args: LoginWithOpenIdParams) => Promise<void>> = jest.fn();
+const isLoggedInMock:jest.MockedFunction<() => Promise<boolean>> = jest.fn();
 
 const rpcProvider = {};
 
@@ -36,6 +37,7 @@ describe('MagicWallet', () => {
       },
       user: {
         logout: logoutMock,
+        isLoggedIn: isLoggedInMock,
       },
       rpcProvider,
     }));
@@ -85,6 +87,7 @@ describe('MagicWallet', () => {
 
   describe('login', () => {
     it('should call loginWithOIDC and initialise the provider with the correct arguments', async () => {
+      isLoggedInMock.mockImplementation(() => Promise.resolve(false));
       const magicAdapter = new MagicAdapter(config, magicProviderProxyFactory);
       const magicProvider = await magicAdapter.login(idToken);
 
@@ -97,6 +100,22 @@ describe('MagicWallet', () => {
         jwt: idToken,
         providerId,
       });
+
+      expect(magicProviderProxyFactory.createProxy).toHaveBeenCalled();
+      expect(magicProvider).toEqual(rpcProvider);
+    });
+
+    it('should not call loginWithOIDC if isLoggedIn is true', async () => {
+      isLoggedInMock.mockImplementation(() => Promise.resolve(true));
+      const magicAdapter = new MagicAdapter(config, magicProviderProxyFactory);
+      const magicProvider = await magicAdapter.login(idToken);
+
+      expect(Magic).toHaveBeenCalledWith(apiKey, {
+        network: 'mainnet',
+        extensions: [new OpenIdExtension()],
+      });
+
+      expect(loginWithOIDCMock).toBeCalledTimes(0);
 
       expect(magicProviderProxyFactory.createProxy).toHaveBeenCalled();
       expect(magicProvider).toEqual(rpcProvider);

--- a/packages/passport/sdk/src/magic/magicAdapter.ts
+++ b/packages/passport/sdk/src/magic/magicAdapter.ts
@@ -51,10 +51,13 @@ export default class MagicAdapter {
         const magicClient = await this.magicClient;
         flow.addEvent('endMagicClientInit');
 
-        await magicClient.openid.loginWithOIDC({
-          jwt: idToken,
-          providerId: this.config.magicProviderId,
-        });
+        const isUserLoggedIn = await magicClient.user.isLoggedIn();
+        if (!isUserLoggedIn) {
+          await magicClient.openid.loginWithOIDC({
+            jwt: idToken,
+            providerId: this.config.magicProviderId,
+          });
+        }
         flow.addEvent('endLoginWithOIDC');
 
         trackDuration(


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

- Check isLoggedIn before calling loginWithOIDC to prevent unnecessary calls to the Magic OIDC endpoint

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
