### PR TITLE
fix(passport): Fix location.href in redirect-callback to envs that use the base_path configuration

### DIFF
--- a/packages/passport/sdk-sample-app/src/pages/login/redirect-callback.ts
+++ b/packages/passport/sdk-sample-app/src/pages/login/redirect-callback.ts
@@ -15,7 +15,8 @@ export default function HandleCallback() {
 
     const handleCallback = async () => {
       await passportClient.loginCallback();
-      window.location.href = window.location.origin;
+      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+      window.location.href = `${window.location.origin}/${basePath}`;
     };
 
     handleCallback().catch(console.error);


### PR DESCRIPTION
Add rule to validate if application is using base_path configuration before forwarding using location.href in login redirect-callback.