### PR TITLE
fix(passport): Fix location.href to redirect callback

### DIFF
--- a/packages/passport/sdk-sample-app/src/pages/login/redirect-callback.ts
+++ b/packages/passport/sdk-sample-app/src/pages/login/redirect-callback.ts
@@ -16,7 +16,7 @@ export default function HandleCallback() {
     const handleCallback = async () => {
       await passportClient.loginCallback();
       const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-      window.location.href = `${window.location.origin}/${basePath}`;
+      window.location.href = window.location.origin + basePath;
     };
 
     handleCallback().catch(console.error);


### PR DESCRIPTION
Fix location.href to redirect callback to remove unappropriated `/`.
