### PR TITLE
fix(passport): Use correct ethers v6 error type

### DIFF
--- a/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
@@ -163,9 +163,9 @@ describe('getNonce', () => {
   });
 
   describe('when an error is thrown', () => {
-    describe('and the error is a call_exception', () => {
+    describe('and the error is BAD_DATA', () => {
       it('should return 0', async () => {
-        const error = { code: 'CALL_EXCEPTION' } as CallExceptionError;
+        const error = { code: 'BAD_DATA' } as CallExceptionError;
 
         nonceMock.mockRejectedValue(error);
 
@@ -175,10 +175,10 @@ describe('getNonce', () => {
       });
     });
 
-    describe('and the error is NOT a call_exception', () => {
+    describe('and the error is NOT BAD_DATA', () => {
       it('should throw the error', async () => {
         const error = new Error('call revert exception');
-        Object.defineProperty(error, 'code', { value: 'NETWORK_ERROR' satisfies ErrorCode });
+        Object.defineProperty(error, 'code', { value: 'CALL_EXCEPTION' satisfies ErrorCode });
         nonceMock.mockRejectedValue(error);
 
         await expect(() => getNonce(rpcProvider, walletAddress)).rejects.toThrow(error);

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.ts
@@ -3,8 +3,9 @@ import { v1 as sequenceCoreV1 } from '@0xsequence/core';
 import { trackDuration } from '@imtbl/metrics';
 import {
   BigNumberish, Contract, getBytes, hashMessage,
-  Interface, isCallException, keccak256, Signer, solidityPacked, ZeroAddress,
+  Interface, keccak256, Signer, solidityPacked, ZeroAddress,
   TypedDataEncoder, JsonRpcProvider, AbiCoder,
+  isError,
 } from 'ethers';
 import { MetaTransaction, MetaTransactionNormalised, TypedDataPayload } from './types';
 
@@ -93,8 +94,8 @@ export const getNonce = async (
       return encodeNonce(space, result);
     }
   } catch (error) {
-    if (isCallException(error)) {
-      // The most likely reason for a CALL_EXCEPTION is that the smart contract wallet
+    if (isError(error, 'BAD_DATA')) {
+      // The most likely reason for a BAD_DATA error is that the smart contract wallet
       // has not been deployed yet, so we should default to a nonce of 0.
       return BigInt(0);
     }


### PR DESCRIPTION
# Summary

Ethers V6 has changed the error type which is thrown when the Passport smart contract is not yet deployed and a readNonce call is made.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
* Fixed an issue preventing new users from having their Passport smart contract wallet deployed

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
