### PR TITLE
fix(passport): ID-3274: Handle nonce error

### DIFF
--- a/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.test.ts
@@ -1,5 +1,5 @@
 import {
-  Contract, Wallet, JsonRpcProvider, ErrorCode, CallExceptionError,
+  Contract, Wallet, JsonRpcProvider, ErrorCode,
 } from 'ethers';
 import { TypedDataPayload } from './types';
 import {
@@ -165,7 +165,7 @@ describe('getNonce', () => {
   describe('when an error is thrown', () => {
     describe('and the error is BAD_DATA', () => {
       it('should return 0', async () => {
-        const error = { code: 'BAD_DATA' } as CallExceptionError;
+        const error = { code: 'UNKNOWN_ERROR', error: { code: 'BAD_DATA' } };
 
         nonceMock.mockRejectedValue(error);
 

--- a/packages/passport/sdk/src/zkEvm/walletHelpers.ts
+++ b/packages/passport/sdk/src/zkEvm/walletHelpers.ts
@@ -94,7 +94,7 @@ export const getNonce = async (
       return encodeNonce(space, result);
     }
   } catch (error) {
-    if (isError(error, 'BAD_DATA')) {
+    if (isError(error, 'UNKNOWN_ERROR') && isError(error.error, 'BAD_DATA')) {
       // The most likely reason for a BAD_DATA error is that the smart contract wallet
       // has not been deployed yet, so we should default to a nonce of 0.
       return BigInt(0);


### PR DESCRIPTION
# Summary

Handles a BAD_DATA response inside a UNKNOWN_ERROR error.

Related PR: https://github.com/immutable/ts-immutable-sdk/pull/2561

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
