### PR TITLE
FIX: DVR-236 | Pipeline changes to replace sdk reference instead of pushing

### DIFF
--- a/.github/scripts/check-docs-deployed.sh
+++ b/.github/scripts/check-docs-deployed.sh
@@ -8,10 +8,10 @@ then
   echo "VERSION is not set"
   exit 1
 fi
-
+MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
 # this command will send a GET request to the docs site, the -s option silences the output,
 # the -o option redirects the output to /dev/null, and the -w option formats the output to only return the HTTP status code
-HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://docs.immutable.com/sdk-references/ts-immutable-sdk/$VERSION/)
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://docs.immutable.com/sdk-references/ts-immutable-sdk/v$MAJOR_VERSION/)
 
 if [ "$HTTP_STATUS" -ne 200 ]; then
   echo "SDK reference docs for v$VERSION are not deployed. Check Netlify for the build status. https://app.netlify.com/sites/imx-docs-prod/deploys"

--- a/.github/scripts/check-docs-deployed.sh
+++ b/.github/scripts/check-docs-deployed.sh
@@ -8,7 +8,7 @@ then
   echo "VERSION is not set"
   exit 1
 fi
-MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
+MAJOR_VERSION=$(echo $VERSION | sed -E 's/^(prelease-)?([0-9]+)\..*/\2/')
 # this command will send a GET request to the docs site, the -s option silences the output,
 # the -o option redirects the output to /dev/null, and the -w option formats the output to only return the HTTP status code
 HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://docs.immutable.com/sdk-references/ts-immutable-sdk/v$MAJOR_VERSION/)

--- a/.github/scripts/check-docs-version.sh
+++ b/.github/scripts/check-docs-version.sh
@@ -15,14 +15,11 @@ then
   exit 1
 fi
 
-# check a docs folder with the same version exists in $CLONE_DIR
-if [ -d "$CLONE_DIR/api-docs/sdk-references/ts-immutable-sdk/$VERSION" ]; then
-  echo "There is already a docs folder for v$VERSION. Please create a separate PR to update the SDK reference docs for v$VERSION."
-  exit 1
-fi
+# Extract major version only
+MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
 
-# check the version contains `alpha` string
-if echo "$VERSION" | grep -q "alpha"; then
-  echo "Skipping docs generation for alpha version"
-  exit 1
-fi
+echo "Checking if docs folder for v$VERSION / v$MAJOR_VERSION exists"
+
+# Remove any check for existing folders - we want to overwrite
+
+echo "Will generate docs for v$VERSION in the v$MAJOR_VERSION folder"

--- a/.github/scripts/push-docs.sh
+++ b/.github/scripts/push-docs.sh
@@ -56,7 +56,7 @@ if git status | grep -q "Changes to be committed"
 then
   git commit --message "SDK reference docs update from https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
   echo "Pushing git commit"
-  git push -u origin DVR-236-fix-ts-sdk-version-pipeline
+  git push -u origin main
 
   # Without this sleep, the checks on the imx-docs repo fail
   # but pass on a re-run from within Netlify

--- a/.github/scripts/push-docs.sh
+++ b/.github/scripts/push-docs.sh
@@ -15,8 +15,8 @@ then
   exit 1
 fi
 
-# Extract major version only
-MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
+# Extract major version only - handle both regular and prelease tags
+MAJOR_VERSION=$(echo $VERSION | sed -E 's/^(prelease-)?([0-9]+)\..*/\2/')
 # Use v{MAJOR} format for the folder
 INPUT_SOURCE_FOLDER="./docs/."
 INPUT_DESTINATION_REPO="immutable/docs"

--- a/.github/scripts/push-docs.sh
+++ b/.github/scripts/push-docs.sh
@@ -15,12 +15,13 @@ then
   exit 1
 fi
 
-# Do not remove the trailing period!!!
-# https://dev.to/ackshaey/macos-vs-linux-the-cp-command-will-trip-you-up-2p00
+# Extract major version only
+MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
+# Use v{MAJOR} format for the folder
 INPUT_SOURCE_FOLDER="./docs/."
 INPUT_DESTINATION_REPO="immutable/docs"
 INPUT_DESTINATION_HEAD_BRANCH="ts-immutable-sdk-docs-$VERSION"
-INPUT_DESTINATION_FOLDER="$CLONE_DIR/api-docs/sdk-references/ts-immutable-sdk/$VERSION"
+INPUT_DESTINATION_FOLDER="$CLONE_DIR/api-docs/sdk-references/ts-immutable-sdk/v$MAJOR_VERSION"
 
 if [ -z "$INPUT_PULL_REQUEST_REVIEWERS" ]
 then
@@ -30,6 +31,12 @@ else
 fi
 
 echo "Copying contents to git repo"
+# Clear existing vX folder if it exists
+if [ -d "$INPUT_DESTINATION_FOLDER" ]; then
+  echo "Cleaning existing v$MAJOR_VERSION folder..."
+  rm -rf "$INPUT_DESTINATION_FOLDER"/*
+fi
+
 mkdir -p $INPUT_DESTINATION_FOLDER
 
 if [ -d "$INPUT_DESTINATION_FOLDER" ]; then
@@ -49,7 +56,7 @@ if git status | grep -q "Changes to be committed"
 then
   git commit --message "SDK reference docs update from https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
   echo "Pushing git commit"
-  git push -u origin main
+  git push -u origin DVR-236-fix-ts-sdk-version-pipeline
 
   # Without this sleep, the checks on the imx-docs repo fail
   # but pass on a re-run from within Netlify

--- a/.github/scripts/update-docs-link.sh
+++ b/.github/scripts/update-docs-link.sh
@@ -15,24 +15,26 @@ then
   exit 1
 fi
 
+# Extract major version for folder paths
+MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
+
 (
   cd $CLONE_DIR;
   FILE=src/components/UnifiedSDKLink/index.tsx
   if [ "$(uname)" == "Darwin" ]; then
       # On Mac OS, sed requires an empty string as an argument to -i to avoid creating a backup file
-      sed -i '' -E "s/SDK_VERSION = '.*'/SDK_VERSION = '$VERSION'/g;" $FILE
+      sed -i '' -E "s/SDK_VERSION = '.*'/SDK_VERSION = 'v$MAJOR_VERSION'/g;" $FILE
   else
-      sed -i -E "s/SDK_VERSION = '.*'/SDK_VERSION = '$VERSION'/g;" $FILE
+      sed -i -E "s/SDK_VERSION = '.*'/SDK_VERSION = 'v$MAJOR_VERSION'/g;" $FILE
   fi
 
   FILE2=sidebars/sidebars-docs.js
   if [ "$(uname)" == "Darwin" ]; then
       # On Mac OS, sed requires an empty string as an argument to -i to avoid creating a backup file
-      sed -i '' -E "s/SDK_VERSION = '.*'/SDK_VERSION = '$VERSION'/g;" $FILE2
+      sed -i '' -E "s/SDK_VERSION = '.*'/SDK_VERSION = 'v$MAJOR_VERSION'/g;" $FILE2
   else
-      sed -i -E "s/SDK_VERSION = '.*'/SDK_VERSION = '$VERSION'/g;" $FILE2
+      sed -i -E "s/SDK_VERSION = '.*'/SDK_VERSION = 'v$MAJOR_VERSION'/g;" $FILE2
   fi
-
 
   major=$(echo $VERSION | awk '{ 
     split($0, a, ".");

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -54,9 +54,9 @@ jobs:
         run: |
           echo "Is Alpha Version: ${{ env.IS_ALPHA }}"
 
-      - name: Check Public Release Branch
-        if: github.ref != 'refs/heads/main'
-        run: failure("SDK reference docs should be only published from main branch, current branch ${{ github.ref }}")
+      # - name: Check Public Release Branch
+      #   if: github.ref != 'refs/heads/main'
+      #   run: failure("SDK reference docs should be only published from main branch, current branch ${{ github.ref }}")
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Check if SDK version is alpha
     runs-on: ubuntu-latest
     outputs:
-      is_alpha: ${{ steps.alpha_check.outputs.is_alpha }}
+      is_alpha: 'false'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
     branches:
-      - DVR-236-fix-ts-sdk-version-pipeline
+      - main
   workflow_dispatch:
 
 concurrency:
@@ -18,7 +18,7 @@ jobs:
     name: Check if SDK version is alpha
     runs-on: ubuntu-latest
     outputs:
-      is_alpha: 'false'
+      is_alpha: ${{ steps.alpha_check.outputs.is_alpha }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -28,15 +28,15 @@ jobs:
       - name: Check alpha version
         id: alpha_check
         run: |
-          # VERSION=$(git describe --tags --abbrev=0)
-          # if echo "$VERSION" | grep -q "alpha"; then
-          #   echo "Skipping docs generation for alpha version"
-          #   echo "is_alpha=true" >> $GITHUB_OUTPUT
-          #   exit 0
-          # else
-          #   echo "Generating docs for non-alpha version"
-          #   echo "is_alpha=false" >> $GITHUB_OUTPUT
-          # fi
+          VERSION=$(git describe --tags --abbrev=0)
+          if echo "$VERSION" | grep -q "alpha"; then
+            echo "Skipping docs generation for alpha version"
+            echo "is_alpha=true" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "Generating docs for non-alpha version"
+            echo "is_alpha=false" >> $GITHUB_OUTPUT
+          fi
         shell: bash
 
   PublishDocs:
@@ -54,9 +54,9 @@ jobs:
         run: |
           echo "Is Alpha Version: ${{ env.IS_ALPHA }}"
 
-      # - name: Check Public Release Branch
-      #   if: github.ref != 'refs/heads/main'
-      #   run: failure("SDK reference docs should be only published from main branch, current branch ${{ github.ref }}")
+      - name: Check Public Release Branch
+        if: github.ref != 'refs/heads/main'
+        run: failure("SDK reference docs should be only published from main branch, current branch ${{ github.ref }}")
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -69,7 +69,7 @@ jobs:
           repository: immutable/docs
           token: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
           path: imx-docs
-          ref: DVR-236-fix-ts-sdk-version-pipeline
+          ref: main
 
       - name: Setup environment variables
         run: |

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
     branches:
-      - main
+      - DVR-236-fix-ts-sdk-version-pipeline
   workflow_dispatch:
 
 concurrency:
@@ -69,7 +69,7 @@ jobs:
           repository: immutable/docs
           token: ${{ secrets.TS_IMMUTABLE_SDK_GITHUB_TOKEN }}
           path: imx-docs
-          ref: main
+          ref: DVR-236-fix-ts-sdk-version-pipeline
 
       - name: Setup environment variables
         run: |

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -28,15 +28,15 @@ jobs:
       - name: Check alpha version
         id: alpha_check
         run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          if echo "$VERSION" | grep -q "alpha"; then
-            echo "Skipping docs generation for alpha version"
-            echo "is_alpha=true" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Generating docs for non-alpha version"
-            echo "is_alpha=false" >> $GITHUB_OUTPUT
-          fi
+          # VERSION=$(git describe --tags --abbrev=0)
+          # if echo "$VERSION" | grep -q "alpha"; then
+          #   echo "Skipping docs generation for alpha version"
+          #   echo "is_alpha=true" >> $GITHUB_OUTPUT
+          #   exit 0
+          # else
+          #   echo "Generating docs for non-alpha version"
+          #   echo "is_alpha=false" >> $GITHUB_OUTPUT
+          # fi
         shell: bash
 
   PublishDocs:


### PR DESCRIPTION
## Description

Changed the pipeline to replace existing SDK reference instead of pushing new releases. 

This will make the Docs Site's SDK-reference less clunky and will only contain the latest version of v2 and v1 instead of all versions.

NOTE: This is not done and some more changes needs to be done(remove hard codes, changing target branch to main, and commented out jobs)

JIRA: https://immutable.atlassian.net/browse/DVR-325