### PR TITLE
fix(passport): prevent eth_requestAccounts from being called on Magic RPC

### DIFF
--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -151,6 +151,8 @@ export class Passport {
     return withMetricsAsync(() => this.passportImxProviderFactory.getProvider(), 'connectImx', false);
   }
 
+  private zkEvmProvider: ZkEvmProvider;
+
   /**
    * Connects to EVM and optionally announces the provider.
    * @param {Object} options - Configuration options
@@ -163,7 +165,8 @@ export class Passport {
     announceProvider: true,
   }): Promise<Provider> {
     return withMetricsAsync(async () => {
-      const provider = new ZkEvmProvider({
+      if (this.zkEvmProvider) return this.zkEvmProvider;
+      this.zkEvmProvider = new ZkEvmProvider({
         passportEventEmitter: this.passportEventEmitter,
         authManager: this.authManager,
         magicAdapter: this.magicAdapter,

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -151,8 +151,6 @@ export class Passport {
     return withMetricsAsync(() => this.passportImxProviderFactory.getProvider(), 'connectImx', false);
   }
 
-  private zkEvmProvider: ZkEvmProvider;
-
   /**
    * Connects to EVM and optionally announces the provider.
    * @param {Object} options - Configuration options
@@ -165,8 +163,7 @@ export class Passport {
     announceProvider: true,
   }): Promise<Provider> {
     return withMetricsAsync(async () => {
-      if (this.zkEvmProvider) return this.zkEvmProvider;
-      this.zkEvmProvider = new ZkEvmProvider({
+      const provider = new ZkEvmProvider({
         passportEventEmitter: this.passportEventEmitter,
         authManager: this.authManager,
         magicAdapter: this.magicAdapter,

--- a/packages/passport/sdk/src/magic/magicProviderProxyFactory.test.ts
+++ b/packages/passport/sdk/src/magic/magicProviderProxyFactory.test.ts
@@ -107,5 +107,17 @@ describe('MagicProviderProxyFactory', () => {
 
       await expect(proxy.request!(params)).rejects.toThrow('ProviderProxy: Test error');
     });
+
+    it('should convert eth_requestAccounts to eth_accounts to avoid Magic overlay', async () => {
+      const proxy = factory.createProxy(mockMagicClient);
+      const params = { method: 'eth_requestAccounts' };
+      (mockMagicClient.user.isLoggedIn as jest.Mock).mockResolvedValue(true);
+
+      await proxy.request!(params);
+
+      expect(mockMagicClient.user.isLoggedIn).toHaveBeenCalled();
+      expect(mockRpcProvider.request).toHaveBeenCalledWith({ method: 'eth_accounts' });
+      expect(mockRpcProvider.request).not.toHaveBeenCalledWith(params);
+    });
   });
 });

--- a/packages/passport/sdk/src/magic/magicProviderProxyFactory.ts
+++ b/packages/passport/sdk/src/magic/magicProviderProxyFactory.ts
@@ -8,7 +8,15 @@ const shouldCheckMagicSession = (args: any[]): boolean => (
   && typeof args[0] === 'object'
     && 'method' in args[0]
     && typeof args[0].method === 'string'
-    && ['personal_sign', 'eth_accounts'].includes(args[0].method)
+    && ['personal_sign', 'eth_accounts', 'eth_requestAccounts'].includes(args[0].method)
+);
+
+const isEthRequestAccountsCall = (args: any[]): boolean => (
+  args?.length > 0
+  && typeof args[0] === 'object'
+  && 'method' in args[0]
+  && typeof args[0].method === 'string'
+  && args[0].method === 'eth_requestAccounts'
 );
 
 /**
@@ -46,6 +54,12 @@ export class MagicProviderProxyFactory {
                     jwt: idToken,
                     providerId: this.config.magicProviderId,
                   });
+                }
+
+                if (isEthRequestAccountsCall(args)) {
+                  // @ts-ignore - Calling eth_requestAccounts on the Magic RPC provider displays an overlay, so this
+                  // should be avoided - call eth_accounts instead.
+                  return target.request!({ method: 'eth_accounts' });
                 }
               }
 


### PR DESCRIPTION
# Summary
fixes an issue where calling `eth_requestAccounts` triggers the Magic login UI overlay

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
