### PR TITLE
fix(checkout): Fix network switching bug in bridge

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletAndNetworkSelector.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/WalletAndNetworkSelector.tsx
@@ -207,7 +207,10 @@ export function WalletAndNetworkSelector() {
       if (event.providerDetail.info.rdns === WalletProviderRdns.METAMASK) {
         changeAccount = true;
       }
-      const wrappedBrowserProvider = new WrappedBrowserProvider(event.provider);
+
+      // Pass 'any' here so that if the user switches networks, they are still prompted to switch
+      // to the chosen network at the end of the bridging process.
+      const wrappedBrowserProvider = new WrappedBrowserProvider(event.provider, 'any');
       const connectedProvider = await connectToProvider(checkout, wrappedBrowserProvider, changeAccount);
 
       await handleFromWalletConnectionSuccess(connectedProvider);


### PR DESCRIPTION
# Summary

To replicate:

1. Go to https://checkout-playground.sandbox.immutable.com/ethereum-bridge/
2. Choose Metamask as the source wallet
3. Change your chain in Metamask to something else
4. Try to go ahead with the bridge
5. On the Switch to Sepolia step, nothing will happen and an error will be logged.

In Ethers v6, if the user changes networks, the BrowserProvider should be recreated. That's the ideal solution. However a workaround is to pass "any" for the network when creating the provider and this will also allow the network to be switched without error.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
