### PR TITLE
chore(passport): ID-3354: Revert "chore(passport): Check isLoggedIn before calling loginWithOIDC"

### DIFF
--- a/packages/passport/sdk/src/magic/magicAdapter.test.ts
+++ b/packages/passport/sdk/src/magic/magicAdapter.test.ts
@@ -6,7 +6,6 @@ import { PassportError, PassportErrorType } from '../errors/passportError';
 import { MagicProviderProxyFactory } from './magicProviderProxyFactory';
 
 const loginWithOIDCMock:jest.MockedFunction<(args: LoginWithOpenIdParams) => Promise<void>> = jest.fn();
-const isLoggedInMock:jest.MockedFunction<() => Promise<boolean>> = jest.fn();
 
 const rpcProvider = {};
 
@@ -37,7 +36,6 @@ describe('MagicWallet', () => {
       },
       user: {
         logout: logoutMock,
-        isLoggedIn: isLoggedInMock,
       },
       rpcProvider,
     }));
@@ -87,7 +85,6 @@ describe('MagicWallet', () => {
 
   describe('login', () => {
     it('should call loginWithOIDC and initialise the provider with the correct arguments', async () => {
-      isLoggedInMock.mockImplementation(() => Promise.resolve(false));
       const magicAdapter = new MagicAdapter(config, magicProviderProxyFactory);
       const magicProvider = await magicAdapter.login(idToken);
 
@@ -100,22 +97,6 @@ describe('MagicWallet', () => {
         jwt: idToken,
         providerId,
       });
-
-      expect(magicProviderProxyFactory.createProxy).toHaveBeenCalled();
-      expect(magicProvider).toEqual(rpcProvider);
-    });
-
-    it('should not call loginWithOIDC if isLoggedIn is true', async () => {
-      isLoggedInMock.mockImplementation(() => Promise.resolve(true));
-      const magicAdapter = new MagicAdapter(config, magicProviderProxyFactory);
-      const magicProvider = await magicAdapter.login(idToken);
-
-      expect(Magic).toHaveBeenCalledWith(apiKey, {
-        network: 'mainnet',
-        extensions: [new OpenIdExtension()],
-      });
-
-      expect(loginWithOIDCMock).toBeCalledTimes(0);
 
       expect(magicProviderProxyFactory.createProxy).toHaveBeenCalled();
       expect(magicProvider).toEqual(rpcProvider);

--- a/packages/passport/sdk/src/magic/magicAdapter.ts
+++ b/packages/passport/sdk/src/magic/magicAdapter.ts
@@ -51,13 +51,10 @@ export default class MagicAdapter {
         const magicClient = await this.magicClient;
         flow.addEvent('endMagicClientInit');
 
-        const isUserLoggedIn = await magicClient.user.isLoggedIn();
-        if (!isUserLoggedIn) {
-          await magicClient.openid.loginWithOIDC({
-            jwt: idToken,
-            providerId: this.config.magicProviderId,
-          });
-        }
+        await magicClient.openid.loginWithOIDC({
+          jwt: idToken,
+          providerId: this.config.magicProviderId,
+        });
         flow.addEvent('endLoginWithOIDC');
 
         trackDuration(


### PR DESCRIPTION
Reverts immutable/ts-immutable-sdk#2533

This revert exercise is the first step in the ongoing investigation to support the case where Passport allows multiple user accounts to be used across different Passport clients within the same browser instance.

This will result in increased number of calls to `loginWithOIDC` but will resolve the situation where users end up with an `Authorisation Error` when attempting to transact with a Passport wallet.

[NR chart](https://onenr.io/0BR6oLnE0jO) showing uptick in error rate in the last 30 days

![Screenshot 2025-03-20 at 12 07 41](https://github.com/user-attachments/assets/98492f57-45c1-4cc8-9845-60fc43707d2e)
