### PR TITLE
fix(immutable-x): Enforce utf8 encoding when deriving starkex key pair

### DIFF
--- a/packages/x-client/src/utils/stark/starkCurve.ts
+++ b/packages/x-client/src/utils/stark/starkCurve.ts
@@ -6,7 +6,7 @@ import * as encUtils from 'enc-utils';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import BN from 'bn.js';
 import { hdkey } from '@ethereumjs/wallet';
-import { Signature, Signer } from 'ethers';
+import { Signature, Signer, toUtf8Bytes } from 'ethers';
 import { createStarkSigner } from './starkSigner';
 import * as legacy from './legacy/crypto';
 import { getStarkPublicKeyFromImx } from './getStarkPublicKeyFromImx';
@@ -286,7 +286,7 @@ export async function generateLegacyStarkPrivateKey(
   signer: Signer,
 ): Promise<string> {
   const address = (await signer.getAddress()).toLowerCase();
-  const signature = await signer.signMessage(legacy.DEFAULT_SIGNATURE_MESSAGE);
+  const signature = await signer.signMessage(toUtf8Bytes(legacy.DEFAULT_SIGNATURE_MESSAGE));
   const seed = Signature.from(signature).s;
   const path = legacy.getAccountPath(
     legacy.DEFAULT_ACCOUNT_LAYER,

--- a/packages/x-provider/src/imx-wallet/imxWallet.ts
+++ b/packages/x-provider/src/imx-wallet/imxWallet.ts
@@ -1,5 +1,5 @@
 import { Environment } from '@imtbl/config';
-import { BrowserProvider } from 'ethers';
+import { BrowserProvider, toUtf8Bytes } from 'ethers';
 import {
   ConnectRequest,
   ConnectResponse,
@@ -25,7 +25,7 @@ export async function connect(
 ): Promise<ImxSigner> {
   const l1Signer = await l1Provider.getSigner();
   const address = await l1Signer.getAddress();
-  const signature = await l1Signer.signMessage(DEFAULT_CONNECTION_MESSAGE);
+  const signature = await l1Signer.signMessage(toUtf8Bytes(DEFAULT_CONNECTION_MESSAGE));
   const iframe = await getOrSetupIFrame(env);
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
# Summary
Fixed signature discrepancies between ethers.js v5 and v6 when signing messages containing special characters, ensuring consistent behaviour across versions when deriving starkex key pair.

## Changed
Explicitly encode the message using `ethers.toUtf8Bytes()` before passing it to signMessage() to ensure consistent UTF-8 encoding in both ethers.js v5 and v6.

## Fixed
Fixed issue where signing a message with non-ASCII characters (e.g., curly apostrophes) might produce different signatures between ethers.js v5 and v6 due to implicit encoding differences.
