### PR TITLE
Add console.logs for debugging issues during starkex gen

### DIFF
--- a/packages/internal/toolkit/src/crypto.ts
+++ b/packages/internal/toolkit/src/crypto.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js';
 import * as encUtils from 'enc-utils';
-import { Signer } from 'ethers';
+import { Signer, toUtf8Bytes } from 'ethers';
 
 type SignatureOptions = {
   r: BN;
@@ -42,7 +42,9 @@ export async function signRaw(
   payload: string,
   signer: Signer,
 ): Promise<string> {
-  const signature = deserializeSignature(await signer.signMessage(payload));
+  console.log('signRaw.payload', { payload });
+  console.log('signRaw.toUtf8Bytes', { toUtf8Bytes: toUtf8Bytes(payload).toString() });
+  const signature = deserializeSignature(await signer.signMessage(toUtf8Bytes(payload)));
   return serializeEthSignature(signature);
 }
 

--- a/packages/x-provider/src/imx-wallet/ImxSigner.ts
+++ b/packages/x-provider/src/imx-wallet/ImxSigner.ts
@@ -1,4 +1,5 @@
 import { StarkSigner } from '@imtbl/x-client';
+import { toUtf8Bytes } from 'ethers';
 import {
   COMMUNICATION_TYPE,
   ResponseEventType,
@@ -28,6 +29,9 @@ export class ImxSigner implements StarkSigner {
   }
 
   public signMessage(rawMessage: string): Promise<string> {
+    console.log('signMessage.rawMessage', { rawMessage });
+    console.log('signMessage.toUtf8Bytes.toString()', { toUtf8Bytes: toUtf8Bytes(rawMessage).toString() });
+
     return new Promise((resolve, reject) => {
       const listener = (event: MessageEvent) => {
         messageResponseListener<SignMessageResponse>(

--- a/packages/x-provider/src/imx-wallet/imxWallet.ts
+++ b/packages/x-provider/src/imx-wallet/imxWallet.ts
@@ -1,5 +1,10 @@
 import { Environment } from '@imtbl/config';
-import { BrowserProvider, toUtf8Bytes } from 'ethers';
+import {
+  BrowserProvider,
+  getBytes,
+  toUtf8Bytes,
+  toUtf8String,
+} from 'ethers';
 import {
   ConnectRequest,
   ConnectResponse,
@@ -25,6 +30,13 @@ export async function connect(
 ): Promise<ImxSigner> {
   const l1Signer = await l1Provider.getSigner();
   const address = await l1Signer.getAddress();
+
+  console.log('DEFAULT_CONNECTION_MESSAGE', { message: DEFAULT_CONNECTION_MESSAGE });
+  console.log('toUtf8Bytes.toString()', { toUtf8Bytes: toUtf8Bytes(DEFAULT_CONNECTION_MESSAGE).toString() });
+
+  console.log('toUtf8String 1', { toUtf8String: toUtf8String(toUtf8Bytes(DEFAULT_CONNECTION_MESSAGE)) });
+  console.log('toUtf8String 2', { toUtf8String: toUtf8String(getBytes(toUtf8Bytes(DEFAULT_CONNECTION_MESSAGE))) });
+
   const signature = await l1Signer.signMessage(toUtf8Bytes(DEFAULT_CONNECTION_MESSAGE));
   const iframe = await getOrSetupIFrame(env);
 

--- a/packages/x-provider/src/l1-providers/metaMaskWrapper.ts
+++ b/packages/x-provider/src/l1-providers/metaMaskWrapper.ts
@@ -27,9 +27,15 @@ export class MetaMaskIMXProvider extends GenericIMXProvider {
           metaMaskProvider,
           config.baseConfig.environment,
         );
+
+        const signer = await metaMaskProvider.getSigner();
+
+        console.log('metaMaskProvider.getSigner().getAddress()', await signer.getAddress());
+        console.log('imxSigner.getAddress()', this.imxSigner.getAddress());
+
         return new MetaMaskIMXProvider(
           config,
-          await metaMaskProvider.getSigner(),
+          signer,
           this.imxSigner,
         );
       },


### PR DESCRIPTION
# Summary
Added logging to debug Stark key generation and message signing issues, particularly focusing on UTF-8 encoding of messages. This is for alpha release only and contains no sensitive information.

# Detail and impact of the change

## Changed
- Modified `signRaw` function to use `toUtf8Bytes` for message signing
- Added logging for payload and UTF-8 bytes in message signing process
- Added logging for raw messages and UTF-8 bytes in `ImxSigner`
- Added logging for connection messages and UTF-8 encoding in `imxWallet`
- Added logging for signer addresses in `metaMaskWrapper`

# Anything else worth calling out?
- The changes focus on debugging the Stark signature verification failures by adding comprehensive logging around message encoding and signing
- Added logging for both the raw messages and their UTF-8 encoded versions to help identify any encoding mismatches
- Added address logging to help track potential signer mismatches between MetaMask and IMX signers
- The changes are primarily diagnostic and don't modify the core functionality, making them safe to deploy
- All logging is alpha-only and will be removed before production release
- No private keys or sensitive data are logged
- Only public addresses and encoded message data are logged for debugging purposes

This PR should help identify the root cause of the Stark signature verification failures by providing visibility into the message encoding and signing process. The logging is intended for alpha testing only and will be removed before any production release.