### PR TITLE
fix(checkout): Show correct swap fees

### DIFF
--- a/packages/checkout/widgets-lib/package.json
+++ b/packages/checkout/widgets-lib/package.json
@@ -54,6 +54,7 @@
     "@segment/analytics-next": "^1.53.2",
     "@svgr/webpack": "^8.0.1",
     "@swc/core": "^1.3.36",
+    "@swc/jest": "^0.2.37",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/packages/checkout/widgets-lib/src/lib/utils.test.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.test.ts
@@ -39,6 +39,7 @@ describe('utils', () => {
           }],
         },
       } as any;
+
       const feesInFiat = calculateFeesFiat(
         quoteWithSecondaryFees,
         fromToken,
@@ -46,12 +47,14 @@ describe('utils', () => {
         conversions,
         gasFeeInIMX.toString(),
       );
+
       expect(feesInFiat).toBe(0.00767904); // secondaryFeeInGOG * conversions.get('gog'));
     });
 
     it('includes the USD equivalent of the gas fees', () => {
       const gasFeeInIMX = 0.123;
       const quoteWithoutSecondaryFees = { quote: { fees: [] } } as any;
+
       const feesInFiat = calculateFeesFiat(
         quoteWithoutSecondaryFees,
         fromToken,
@@ -59,7 +62,30 @@ describe('utils', () => {
         conversions,
         gasFeeInIMX.toString(),
       );
+
       expect(feesInFiat).toBe(0.0792243); // gasFeeInIMX * conversions.get('imx'));
+    });
+
+    it('includes both types of fees when present', () => {
+      const gasFeeInIMX = 0.123;
+      const secondaryFeeInGOG = 0.456;
+      const quoteWithSecondaryFees = {
+        quote: {
+          fees: [{
+            amount: { value: parseUnits(secondaryFeeInGOG.toString(), 18) },
+          }],
+        },
+      } as any;
+
+      const feesInFiat = calculateFeesFiat(
+        quoteWithSecondaryFees,
+        fromToken,
+        gasFeeToken,
+        conversions,
+        gasFeeInIMX.toString(),
+      );
+
+      expect(feesInFiat).toBe(0.08690334); // both values above summed.
     });
   });
 

--- a/packages/checkout/widgets-lib/src/lib/utils.test.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.test.ts
@@ -30,17 +30,36 @@ const conversions = new Map<string, number>([['imx', 0.6441], ['gog', 0.01684]])
 describe('utils', () => {
   describe('calculateFeesFiat', () => {
     it('includes the USD equivalent of the secondary fees', () => {
-      const quoteWithSecondaryFees = { quote: { fees: [{ amount: { value: parseUnits('0.123', 18) } }] } } as any;
-      const gasFeeValue = '0';
-      const feesInFiat = calculateFeesFiat(quoteWithSecondaryFees, fromToken, gasFeeToken, conversions, gasFeeValue);
-      expect(feesInFiat).toBe(0.00207132);
+      const gasFeeInIMX = 0;
+      const secondaryFeeInGOG = 0.456;
+      const quoteWithSecondaryFees = {
+        quote: {
+          fees: [{
+            amount: { value: parseUnits(secondaryFeeInGOG.toString(), 18) },
+          }],
+        },
+      } as any;
+      const feesInFiat = calculateFeesFiat(
+        quoteWithSecondaryFees,
+        fromToken,
+        gasFeeToken,
+        conversions,
+        gasFeeInIMX.toString(),
+      );
+      expect(feesInFiat).toBe(0.00767904); // secondaryFeeInGOG * conversions.get('gog'));
     });
 
     it('includes the USD equivalent of the gas fees', () => {
+      const gasFeeInIMX = 0.123;
       const quoteWithoutSecondaryFees = { quote: { fees: [] } } as any;
-      const gasFeeValue = '0.123';
-      const feesInFiat = calculateFeesFiat(quoteWithoutSecondaryFees, fromToken, gasFeeToken, conversions, gasFeeValue);
-      expect(feesInFiat).toBe(0.0792243);
+      const feesInFiat = calculateFeesFiat(
+        quoteWithoutSecondaryFees,
+        fromToken,
+        gasFeeToken,
+        conversions,
+        gasFeeInIMX.toString(),
+      );
+      expect(feesInFiat).toBe(0.0792243); // gasFeeInIMX * conversions.get('imx'));
     });
   });
 

--- a/packages/checkout/widgets-lib/src/lib/utils.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.ts
@@ -1,9 +1,9 @@
 import {
-  ChainId, CheckoutConfiguration, GetBalanceResult, NetworkInfo, WidgetTheme,
+  ChainId, CheckoutConfiguration, GetBalanceResult, NetworkInfo, TokenInfo, WidgetTheme,
   WrappedBrowserProvider,
 } from '@imtbl/checkout-sdk';
 import { Environment } from '@imtbl/config';
-import { Contract } from 'ethers';
+import { Contract, formatUnits } from 'ethers';
 import { getL1ChainId, getL2ChainId } from './networkUtils';
 import {
   CHECKOUT_CDN_BASE_URL,
@@ -86,6 +86,15 @@ export const calculateCryptoToFiat = (
   const parsedAmount = parseFloat(amount);
   if (parseFloat(amount) === 0 || Number.isNaN(parsedAmount)) return zeroString;
   return formatFiatString(parsedAmount * conversion, maxDecimals);
+};
+
+export const calculateCryptoToFiatBigInt = (
+  amount: bigint,
+  token: TokenInfo,
+  conversions: Map<string, number>,
+) => {
+  const formattedAmount = formatUnits(amount, token.decimals);
+  return calculateCryptoToFiat(formattedAmount, token.symbol, conversions, '0.00', 10);
 };
 
 export const formatZeroAmount = (

--- a/packages/checkout/widgets-lib/src/lib/utils.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.ts
@@ -81,7 +81,10 @@ export const calculateCryptoToFiat = (
 
   const name = tokenSymbolNameOverrides[symbol.toLowerCase()] || symbol.toLowerCase();
   const conversion = conversions.get(name);
-  if (!conversion) return zeroString;
+  if (!conversion) {
+    console.log('no conversion', name);
+    return zeroString;
+  }
 
   const parsedAmount = parseFloat(amount);
   if (parseFloat(amount) === 0 || Number.isNaN(parsedAmount)) return zeroString;

--- a/packages/checkout/widgets-lib/src/lib/utils.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.ts
@@ -81,10 +81,7 @@ export const calculateCryptoToFiat = (
 
   const name = tokenSymbolNameOverrides[symbol.toLowerCase()] || symbol.toLowerCase();
   const conversion = conversions.get(name);
-  if (!conversion) {
-    console.log('no conversion', name);
-    return zeroString;
-  }
+  if (!conversion) return zeroString;
 
   const parsedAmount = parseFloat(amount);
   if (parseFloat(amount) === 0 || Number.isNaN(parsedAmount)) return zeroString;

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/Fees.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/Fees.tsx
@@ -16,8 +16,8 @@ interface FeesProps {
   gasFeeToken?: TokenInfo;
   feeFiatValue: number | null;
   fees: FormattedFee[];
-  onFeesClick?: () => void;
-  loading?: boolean;
+  onFeesClick: () => void;
+  loading: boolean;
   sx?: SxProps;
 }
 
@@ -26,6 +26,8 @@ export function Fees({
 }: FeesProps) {
   const [showFeeBreakdown, setShowFeeBreakdown] = useState(false);
   const { t } = useTranslation();
+
+  if (!loading && !feeFiatValue) return null;
 
   const viewFees = () => {
     setShowFeeBreakdown(true);

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/Fees.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/Fees.tsx
@@ -1,0 +1,94 @@
+import {
+  Accordion,
+  Body,
+  Box,
+  PriceDisplay, ShimmerBox,
+  SxProps,
+} from '@biom3/react';
+import { TokenInfo } from '@imtbl/checkout-sdk';
+import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
+import { gasAmountAccordionStyles, gasAmountHeadingStyles } from '../../../components/Fees/FeeStyles';
+import { FormattedFee } from '../functions/swapFees';
+import { FeesBreakdown } from '../../../components/FeesBreakdown/FeesBreakdown';
+
+interface FeesProps {
+  gasFeeToken?: TokenInfo;
+  feeFiatValue: number | null;
+  fees: FormattedFee[];
+  onFeesClick?: () => void;
+  loading?: boolean;
+  sx?: SxProps;
+}
+
+export function Fees({
+  gasFeeToken, feeFiatValue, fees, onFeesClick, loading, sx,
+}: FeesProps) {
+  const [showFeeBreakdown, setShowFeeBreakdown] = useState(false);
+  const { t } = useTranslation();
+  if (!loading) return null;
+
+  const gasTokenSymbol = gasFeeToken?.symbol;
+
+  const viewFees = () => {
+    setShowFeeBreakdown(true);
+    onFeesClick?.();
+  };
+
+  return (
+    <>
+      <Accordion
+        targetClickOveride={viewFees}
+        sx={{ ...gasAmountAccordionStyles, paddingBottom: 'base.spacing.x2', ...sx }}
+      >
+        <Accordion.TargetLeftSlot>
+          <Body size="medium" sx={gasAmountHeadingStyles}>
+            {t('drawers.feesBreakdown.heading')}
+          </Body>
+        </Accordion.TargetLeftSlot>
+        <Accordion.TargetRightSlot>
+          {loading && (
+            <Box sx={{ width: '218px', position: 'relative' }}>
+              <Box
+                sx={{
+                  display: 'block',
+                  position: 'absolute',
+                  top: '-15px',
+                  width: '100%',
+                  height: '68px',
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  WebkitMaskPosition: 'right center',
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  WebkitMaskRepeat: 'no-repeat',
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  WebkitMaskSize: 'contain',
+                  // eslint-disable-next-line @typescript-eslint/naming-convention,max-len
+                  WebkitMaskImage: 'url(\'data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" width="196" height="96"><path d="M182.85 55.2Q181.65 54 180 54h-56q-1.7 0-2.85 1.2Q120 56.35 120 58v4q0 1.7 1.15 2.85Q122.3 66 124 66h56q1.65 0 2.85-1.15Q184 63.7 184 62v-4q0-1.65-1.15-2.8m0-22Q181.65 32 180 32H68q-1.7 0-2.85 1.2Q64 34.35 64 36v8q0 1.7 1.15 2.85Q66.3 48 68 48h112q1.65 0 2.85-1.15Q184 45.7 184 44v-8q0-1.65-1.15-2.8Z" id="a"/></svg>\')',
+                }}
+                rc={<span />}
+              >
+                <ShimmerBox
+                  rc={<span />}
+                />
+              </Box>
+            </Box>
+          )}
+          {!loading && (
+            <PriceDisplay
+              testId="fees-gas-fee__priceDisplay"
+              fiatAmount={`≈ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${feeFiatValue}`}
+              price=""
+            />
+          )}
+        </Accordion.TargetRightSlot>
+      </Accordion>
+      <FeesBreakdown
+        tokenSymbol={gasTokenSymbol ?? ''}
+        fees={fees}
+        visible={showFeeBreakdown}
+        loading={loading}
+        onCloseDrawer={() => setShowFeeBreakdown(false)}
+      />
+    </>
+  );
+}

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/Fees.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/Fees.tsx
@@ -8,7 +8,7 @@ import {
 import { TokenInfo } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
-import { gasAmountAccordionStyles, gasAmountHeadingStyles } from '../../../components/Fees/FeeStyles';
+import { gasAmountAccordionStyles } from '../../../components/Fees/FeeStyles';
 import { FormattedFee } from '../functions/swapFees';
 import { FeesBreakdown } from '../../../components/FeesBreakdown/FeesBreakdown';
 
@@ -41,7 +41,7 @@ export function Fees({
         sx={{ ...gasAmountAccordionStyles, paddingBottom: 'base.spacing.x2', ...sx }}
       >
         <Accordion.TargetLeftSlot>
-          <Body size="medium" sx={gasAmountHeadingStyles}>
+          <Body size="medium">
             {t('drawers.feesBreakdown.heading')}
           </Body>
         </Accordion.TargetLeftSlot>
@@ -75,8 +75,8 @@ export function Fees({
           {!loading && (
             <PriceDisplay
               testId="fees-gas-fee__priceDisplay"
-              fiatAmount={`≈ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${feeFiatValue}`}
-              price=""
+              price={`≈ ${t('drawers.feesBreakdown.fees.fiatPricePrefix')}${feeFiatValue}`}
+              sx={{ mt: 'base.spacing.x1' }}
             />
           )}
         </Accordion.TargetRightSlot>

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/Fees.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/Fees.tsx
@@ -26,9 +26,6 @@ export function Fees({
 }: FeesProps) {
   const [showFeeBreakdown, setShowFeeBreakdown] = useState(false);
   const { t } = useTranslation();
-  if (!loading) return null;
-
-  const gasTokenSymbol = gasFeeToken?.symbol;
 
   const viewFees = () => {
     setShowFeeBreakdown(true);
@@ -83,7 +80,7 @@ export function Fees({
         </Accordion.TargetRightSlot>
       </Accordion>
       <FeesBreakdown
-        tokenSymbol={gasTokenSymbol ?? ''}
+        tokenSymbol={gasFeeToken?.symbol ?? ''}
         fees={fees}
         visible={showFeeBreakdown}
         loading={loading}

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -127,13 +127,14 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
   const [gasFeeToken, setGasFeeToken] = useState<TokenInfo | undefined>(undefined);
 
   const feeFiatValue = useMemo(() => {
-    console.log({ gasFeeToken, quote, fromToken });
     if (!gasFeeToken || !quote || !fromToken) return null;
 
     const gasFeeEstimateFiat = calculateCryptoToFiat(
       gasFeeValue,
       gasFeeToken.symbol,
       cryptoFiatState.conversions,
+      '0.00',
+      10,
     );
 
     const secondaryFeesTotal = quote.quote.fees?.reduce((acc, fee) => acc + fee.amount.value, 0n);
@@ -143,8 +144,9 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
       cryptoFiatState.conversions,
     );
 
-    return Number(gasFeeEstimateFiat) + Number(secondaryFeesFiat);
-  }, [quote, cryptoFiatState.conversions]);
+    const res = Number(gasFeeEstimateFiat) + Number(secondaryFeesFiat);
+    return res;
+  }, [quote, cryptoFiatState.conversions, gasFeeToken, gasFeeValue, fromToken]);
 
   const [tokensOptionsFrom, setTokensOptionsForm] = useState<CoinSelectorOptionProps[]>([]);
   const formattedFees = useMemo(

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -18,7 +18,8 @@ import { amountInputValidation as textInputValidator } from '../../../lib/valida
 import { SwapContext } from '../context/SwapContext';
 import { CryptoFiatActions, CryptoFiatContext } from '../../../context/crypto-fiat-context/CryptoFiatContext';
 import {
-  calculateCryptoToFiat, formatZeroAmount, getDefaultTokenImage, isNativeToken, tokenValueFormat,
+  calculateCryptoToFiat, calculateCryptoToFiatBigInt, formatZeroAmount,
+  getDefaultTokenImage, isNativeToken, tokenValueFormat,
 } from '../../../lib/utils';
 import {
   DEFAULT_TOKEN_DECIMALS,
@@ -35,7 +36,6 @@ import {
   validateToAmount,
   validateToToken,
 } from '../functions/SwapValidator';
-import { Fees } from '../../../components/Fees/Fees';
 import { SwapButton } from './SwapButton';
 import { SwapFormData } from './swapFormTypes';
 import { CoinSelectorOptionProps } from '../../../components/CoinSelector/CoinSelectorOption';
@@ -53,6 +53,7 @@ import { processQuoteToken } from '../functions/processQuoteToken';
 import { formatQuoteConversionRate } from '../functions/swapConversionRate';
 import { PrefilledSwapForm, SwapWidgetViews } from '../../../context/view-context/SwapViewContextTypes';
 import { TransactionRejected } from '../../../components/TransactionRejected/TransactionRejected';
+import { Fees } from './Fees';
 
 enum SwapDirection {
   FROM = 'FROM',
@@ -124,7 +125,27 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
   const [quoteError, setQuoteError] = useState<string>('');
   const [gasFeeValue, setGasFeeValue] = useState<string>('');
   const [gasFeeToken, setGasFeeToken] = useState<TokenInfo | undefined>(undefined);
-  const [gasFeeFiatValue, setGasFeeFiatValue] = useState<string>('');
+
+  const feeFiatValue = useMemo(() => {
+    console.log({ gasFeeToken, quote, fromToken });
+    if (!gasFeeToken || !quote || !fromToken) return null;
+
+    const gasFeeEstimateFiat = calculateCryptoToFiat(
+      gasFeeValue,
+      gasFeeToken.symbol,
+      cryptoFiatState.conversions,
+    );
+
+    const secondaryFeesTotal = quote.quote.fees?.reduce((acc, fee) => acc + fee.amount.value, 0n);
+    const secondaryFeesFiat = calculateCryptoToFiatBigInt(
+      secondaryFeesTotal,
+      fromToken,
+      cryptoFiatState.conversions,
+    );
+
+    return Number(gasFeeEstimateFiat) + Number(secondaryFeesFiat);
+  }, [quote, cryptoFiatState.conversions]);
+
   const [tokensOptionsFrom, setTokensOptionsForm] = useState<CoinSelectorOptionProps[]>([]);
   const formattedFees = useMemo(
     () => (quote ? formatSwapFees(quote, cryptoFiatState, t) : []),
@@ -269,7 +290,6 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     }
     setConversionAmount('');
     setConversionToken(null);
-    setGasFeeFiatValue('');
     setQuote(null);
   };
 
@@ -323,11 +343,6 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
         address: gasToken?.address,
         icon: gasToken?.icon,
       });
-      setGasFeeFiatValue(calculateCryptoToFiat(
-        gasFee,
-        gasToken?.symbol || '',
-        cryptoFiatState.conversions,
-      ));
 
       setToAmount(
         formatZeroAmount(
@@ -404,12 +419,6 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
         address: gasToken?.address,
         icon: gasToken?.icon,
       });
-
-      setGasFeeFiatValue(calculateCryptoToFiat(
-        gasFee,
-        gasToken?.symbol || '',
-        cryptoFiatState.conversions,
-      ));
 
       setFromAmount(
         formatZeroAmount(
@@ -1063,9 +1072,8 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
         </Box>
         {!isPassportProvider(provider) && (
         <Fees
-          gasFeeFiatValue={gasFeeFiatValue}
+          feeFiatValue={feeFiatValue}
           gasFeeToken={gasFeeToken}
-          gasFeeValue={gasFeeValue}
           fees={formattedFees}
           onFeesClick={() => {
             track({

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -144,8 +144,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
       cryptoFiatState.conversions,
     );
 
-    const res = Number(gasFeeEstimateFiat) + Number(secondaryFeesFiat);
-    return res;
+    return Number(gasFeeEstimateFiat) + Number(secondaryFeesFiat);
   }, [quote, cryptoFiatState.conversions, gasFeeToken, gasFeeValue, fromToken]);
 
   const [tokensOptionsFrom, setTokensOptionsForm] = useState<CoinSelectorOptionProps[]>([]);
@@ -1072,7 +1071,6 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
             />
           </Box>
         </Box>
-        {!isPassportProvider(provider) && (
         <Fees
           feeFiatValue={feeFiatValue}
           gasFeeToken={gasFeeToken}
@@ -1090,7 +1088,6 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
           }}
           loading={loading}
         />
-        )}
       </Box>
       {quoteError && (
         <Box sx={{

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -18,7 +18,7 @@ import { amountInputValidation as textInputValidator } from '../../../lib/valida
 import { SwapContext } from '../context/SwapContext';
 import { CryptoFiatActions, CryptoFiatContext } from '../../../context/crypto-fiat-context/CryptoFiatContext';
 import {
-  calculateCryptoToFiat, calculateCryptoToFiatBigInt, formatZeroAmount,
+  calculateCryptoToFiat, calculateFeesFiat, formatZeroAmount,
   getDefaultTokenImage, isNativeToken, tokenValueFormat,
 } from '../../../lib/utils';
 import {
@@ -128,23 +128,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
 
   const feeFiatValue = useMemo(() => {
     if (!gasFeeToken || !quote || !fromToken) return null;
-
-    const gasFeeEstimateFiat = calculateCryptoToFiat(
-      gasFeeValue,
-      gasFeeToken.symbol,
-      cryptoFiatState.conversions,
-      '0.00',
-      10,
-    );
-
-    const secondaryFeesTotal = quote.quote.fees?.reduce((acc, fee) => acc + fee.amount.value, 0n);
-    const secondaryFeesFiat = calculateCryptoToFiatBigInt(
-      secondaryFeesTotal,
-      fromToken,
-      cryptoFiatState.conversions,
-    );
-
-    return Number(gasFeeEstimateFiat) + Number(secondaryFeesFiat);
+    return calculateFeesFiat(quote, fromToken, gasFeeToken, cryptoFiatState.conversions, gasFeeValue);
   }, [quote, cryptoFiatState.conversions, gasFeeToken, gasFeeValue, fromToken]);
 
   const [tokensOptionsFrom, setTokensOptionsForm] = useState<CoinSelectorOptionProps[]>([]);

--- a/packages/checkout/widgets-sample-app/src/utils/passport.ts
+++ b/packages/checkout/widgets-sample-app/src/utils/passport.ts
@@ -3,7 +3,7 @@ import { Environment } from "@imtbl/config";
 
 export const passport = new Passport({
   baseConfig: {
-    environment: Environment.PRODUCTION,
+    environment: Environment.SANDBOX,
   },
   clientId: "gYT9Cj8xE7to2mWp4ztBTxBlXCTzAebU",
   redirectUri: "http://localhost:3000/login",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1321,6 +1321,9 @@ importers:
       '@swc/core':
         specifier: ^1.3.36
         version: 1.9.3(@swc/helpers@0.5.13)
+      '@swc/jest':
+        specifier: ^0.2.37
+        version: 0.2.37(@swc/core@1.9.3(@swc/helpers@0.5.13))
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.17.0


### PR DESCRIPTION
# Summary

Two bugs on the swaps widget relating to fees.

* For Passport, no fees were being shown at all
* For EOA, the secondary fees were excluded from the total.

Now:

EOA:

![image](https://github.com/user-attachments/assets/420907b5-eae9-479c-8031-b1c418c13d65)
![image](https://github.com/user-attachments/assets/54d953bc-e307-40c5-a7f2-4762f610df7d)

Passport:

![image](https://github.com/user-attachments/assets/010da099-3bb7-4e7d-b63c-6f7ee97ef0ec)
![image](https://github.com/user-attachments/assets/fefbfa42-9198-4fd4-9a45-8cb3870b084c)

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
