### PR TITLE
fix(checkout): Allow all decimals for max transfer

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/transfer/TransferForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/transfer/TransferForm.tsx
@@ -6,7 +6,6 @@ import {
   Dispatch, SetStateAction, useContext, useMemo, useCallback,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CoinSelectorOptionProps } from '../../components/CoinSelector/CoinSelectorOption';
 import { SelectInput } from '../../components/FormComponents/SelectInput/SelectInput';
 import { TextInputForm } from '../../components/FormComponents/TextInputForm/TextInputForm';
 import { HeaderNavigation } from '../../components/Header/HeaderNavigation';
@@ -44,13 +43,14 @@ export function TransferForm({
 
   const tokenOptions = useMemo(
     () =>
-      viewState.allowedBalances.map<CoinSelectorOptionProps>(
+      viewState.allowedBalances.map(
         (tokenBalance) => ({
           id: getOptionKey(tokenBalance.token),
           name: tokenBalance.token.name,
           symbol: tokenBalance.token.symbol,
           defaultTokenImage: tokenBalance.token.icon || 'TODO',
           balance: {
+            fullBalance: tokenBalance.formattedBalance,
             formattedAmount: tokenValueFormat(tokenBalance.formattedBalance),
             formattedFiatAmount: getFiatAmount(cryptoFiatState, tokenBalance),
           },
@@ -104,12 +104,12 @@ export function TransferForm({
       userJourney: UserJourney.TRANSFER,
       control: 'Max',
       controlType: 'Button',
-      extras: { token: token.id, amount: token.balance.formattedAmount },
+      extras: { token: token.id, amount: token.balance.fullBalance },
     });
 
     setViewState((s) => {
       if (!token.balance) throw new Error('Token balance not found');
-      return { ...s, amount: token.balance.formattedAmount };
+      return { ...s, amount: token.balance.fullBalance };
     });
   }, [tokenOptions, token]);
 

--- a/packages/checkout/widgets-lib/src/widgets/transfer/TransferWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/transfer/TransferWidget.tsx
@@ -81,23 +81,11 @@ function TransferWidgetInner(props: TransferWidgetInputs) {
     };
 
     x();
-  }, [checkout]);
+  }, [checkout, provider, cryptoFiatDispatch, props.amount, props.tokenAddress, props.toAddress, viewState.type]);
 
   const resetForm = useCallback(() => {
-    if (viewState.type === 'INITIALISING') return;
-
-    setViewState({
-      type: 'FORM',
-      allowedBalances: viewState.allowedBalances,
-      checkout: viewState.checkout,
-      provider: viewState.provider,
-      amount: '',
-      amountError: '',
-      tokenAddress: '',
-      toAddress: '',
-      toAddressError: '',
-    });
-  }, [checkout, provider, viewState]);
+    setViewState({ type: 'INITIALISING' });
+  }, []);
 
   const onSend = useCallback(async () => {
     if (viewState.type !== 'FORM') throw new Error('Unexpected state');


### PR DESCRIPTION
# Summary

Two changes:

1. When clicking "max" - it puts in the full amount so that dust is not left in the wallet.
2. Once transfer completes, the balances are refreshed so that they reflect the transfer that just happened.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
