### PR TITLE
fix(bridge): Fix failing dynamic gas estimates

### DIFF
--- a/packages/internal/bridge/sdk/src/constants/bridges.ts
+++ b/packages/internal/bridge/sdk/src/constants/bridges.ts
@@ -52,7 +52,7 @@ export const SLOT_PREFIX_CONTRACT_CALL_APPROVED = '0x07b0d4304f82012bd3b70b1d531
 /**
  * @constant {string} SLOT_POS_CONTRACT_CALL_APPROVED - The position of the storage slot to store contract call approved mapping.
  */
-export const SLOT_POS_CONTRACT_CALL_APPROVED = 4;
+export const SLOT_POS_CONTRACT_CALL_APPROVED = '0x0000000000000000000000000000000000000000000000000000000000000004';
 
 /**
  * @typedef {Object} childWIMXs - Child Wrapped IMX address for the testnet & mainnet.

--- a/packages/internal/bridge/sdk/src/tokenBridge.ts
+++ b/packages/internal/bridge/sdk/src/tokenBridge.ts
@@ -4,7 +4,6 @@ import axios, { AxiosResponse } from 'axios';
 import {
   concat,
   Contract, getAddress, keccak256, Provider, toBeHex, toQuantity, TransactionRequest,
-  zeroPadValue,
   AbiCoder,
   ZeroAddress,
 } from 'ethers';
@@ -885,7 +884,7 @@ export class TokenBridge {
     const commandHash = keccak256(command);
     const gatewayCallApprovedSlot = keccak256(concat([
       commandHash,
-      toBeHex(zeroPadValue(toBeHex(SLOT_POS_CONTRACT_CALL_APPROVED), 32)),
+      SLOT_POS_CONTRACT_CALL_APPROVED,
     ]));
 
     // Encode execute data


### PR DESCRIPTION
## Fixed
PR #2137 introduced a change that caused the storage slot encoding for Axelar’s commandId mapping to be truncated (represented as 0x4) instead of using the fully padded hex representation from prior versions. This resulted in incorrect state overrides during dynamic gas estimation, ultimately leading to underpriced gas estimates and stuck withdrawal transactions. This PR resolves the issue by restoring the full-length hex encoding.