### PR TITLE
chore(checkout): Add pair info to price surge event

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
@@ -353,6 +353,7 @@ export default function SwapWidget({
                 page({
                   userJourney: UserJourney.SWAP,
                   screen: 'PriceSurge',
+                  extras: viewState.view.data,
                 });
                 sendSwapRejectedEvent(eventTarget, 'Price surge');
               }}


### PR DESCRIPTION
# Summary

Adds the pair (token addresses) to the price surge event for data tracking.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
