### PR TITLE
fix(passport): no window opener

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -15,7 +15,7 @@ runs:
       with:
         node-version-file: ".nvmrc"
         registry-url: https://registry.npmjs.org/
-        cache: "pnpm"
+        # cache: "pnpm"
 
     - name: install dependencies
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -19,4 +19,4 @@ runs:
 
     - name: install dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm install

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,8 +41,36 @@ jobs:
       - name: setup
         uses: ./.github/actions/setup
 
+      - name: Inspect oidc-client-ts dependency
+        shell: bash
+        run: |
+          echo "Looking for oidc-client-ts in node_modules..."
+          if [ -d "node_modules/oidc-client-ts" ]; then
+            echo "Found oidc-client-ts in root node_modules."
+            TARGET_OIDC_PATH="node_modules/oidc-client-ts"
+          elif [ -d "packages/passport/sdk/node_modules/oidc-client-ts" ]; then
+            echo "Found oidc-client-ts in packages/passport/sdk/node_modules."
+            TARGET_OIDC_PATH="packages/passport/sdk/node_modules/oidc-client-ts"
+          elif [ -d "node_modules/.pnpm/github.com+nattb8+oidc-client-ts@980de802dbb1cd28e8738b7293e8fc64d9783456/node_modules/oidc-client-ts" ]; then
+            # Path for pnpm when fetching from git, the hash might change, adjust if needed
+            echo "Found oidc-client-ts in pnpm store-like path."
+            TARGET_OIDC_PATH="node_modules/.pnpm/github.com+nattb8+oidc-client-ts@980de802dbb1cd28e8738b7293e8fc64d9783456/node_modules/oidc-client-ts"
+          else
+            echo "ERROR: oidc-client-ts not found in expected locations. Listing common node_modules structures:"
+            ls -R node_modules/.pnpm | head -n 50
+            exit 1
+          fi
+          echo "--- Listing contents of $TARGET_OIDC_PATH ---"
+          ls -R $TARGET_OIDC_PATH
+          echo "--- Contents of $TARGET_OIDC_PATH/package.json ---"
+          cat $TARGET_OIDC_PATH/package.json
+          echo "--- Contents of $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts (first 50 lines) ---"
+          head -n 50 $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts || echo "File $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts not found"
+          echo "--- Grepping for UserManager in $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts ---"
+          grep -i "UserManager" $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts || echo "UserManager not found in $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts"
+
       - name: Build, Lint & Test
-        run: pnpm --if-present nx affected -t build,lint,test 
+        run: pnpm --if-present nx affected -t build,lint,test
 
   build-lint-test-examples:
     name: Build, Lint & Test Examples

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -69,6 +69,9 @@ jobs:
           echo "--- Grepping for UserManager in $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts ---"
           grep -i "UserManager" $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts || echo "UserManager not found in $TARGET_OIDC_PATH/dist/types/oidc-client-ts.d.ts"
 
+      - name: Reset Nx Cache
+        run: pnpm nx reset
+
       - name: Build, Lint & Test
         run: pnpm --if-present nx affected -t build,lint,test
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "packageManager": "pnpm@9.12.0",
   "pnpm": {
     "overrides": {
-      "oidc-client-ts": "git+https://github.com/authts/oidc-client-ts.git#main"
+      "oidc-client-ts": "git+https://github.com/nattb8/oidc-client-ts.git#main"
     }
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
     "*.{js,jsx,ts,tsx}": "eslint"
   },
   "packageManager": "pnpm@9.12.0",
+  "pnpm": {
+    "overrides": {
+      "oidc-client-ts": "git+https://github.com/authts/oidc-client-ts.git#main"
+    }
+  },
   "private": true,
   "repository": "immutable/ts-immutable-sdk.git",
   "resolutions": {

--- a/packages/passport/sdk/package.json
+++ b/packages/passport/sdk/package.json
@@ -79,7 +79,7 @@
   "scripts": {
     "build": "pnpm transpile && pnpm typegen",
     "transpile": "tsup src/index.ts --config ../../../tsup.config.js",
-    "typegen": "tsc --customConditions default --emitDeclarationOnly --outDir dist/types",
+    "typegen": "tsc --customConditions default --emitDeclarationOnly --outDir dist/types --traceResolution",
     "pack:root": "pnpm pack --pack-destination $(dirname $(pnpm root -w))",
     "lint": "eslint ./src --ext .ts,.jsx,.tsx --max-warnings=0",
     "test": "jest",

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -132,7 +132,7 @@ describe('AuthManager', () => {
         authority: config.authenticationDomain,
         client_id: config.oidcConfiguration.clientId,
         extraQueryParams: {},
-        mergeClaims: true,
+        mergeClaimsStrategy: { array: 'merge' },
         automaticSilentRenew: false,
         metadata: {
           authorization_endpoint: `${config.authenticationDomain}/authorize`,

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -72,7 +72,7 @@ const getAuthConfiguration = (config: PassportConfiguration): UserManagerSetting
       userinfo_endpoint: `${authenticationDomain}/userinfo`,
       end_session_endpoint: endSessionEndpoint.toString(),
     },
-    mergeClaims: true,
+    mergeClaimsStrategy: { array: 'merge' }, // Based on this migration guide https://github.com/authts/oidc-client-ts/blob/4519663add35b41bb257b40737a7bf1ab5b813e9/docs/migration.md?plain=1#L16
     automaticSilentRenew: false, // Disabled until https://github.com/authts/oidc-client-ts/issues/430 has been resolved
     scope: oidcConfiguration.scope,
     userStore,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1934,7 +1934,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -2169,7 +2169,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2467,7 +2467,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -13403,8 +13403,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456:
-    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456}
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0:
+    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0}
     version: 3.2.1
     engines: {node: '>=18'}
 
@@ -20263,7 +20263,7 @@ snapshots:
       jwt-decode: 3.1.2
       localforage: 1.10.0
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -20307,7 +20307,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20349,7 +20349,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -33622,7 +33622,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456:
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/2fa83268258f7b9375b590a991eb1697a1162ad0:
     dependencies:
       jwt-decode: 4.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@openzeppelin/contracts@3.4.2-solc-0.7': 3.4.2
   elliptic: ^6.6.1
   responselike: ^2.0.0
-  oidc-client-ts: git+https://github.com/authts/oidc-client-ts.git#main
+  oidc-client-ts: git+https://github.com/nattb8/oidc-client-ts.git#main
 
 importers:
 
@@ -1933,8 +1933,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: git+https://github.com/authts/oidc-client-ts.git#main
-        version: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
+        specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -2168,8 +2168,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: git+https://github.com/authts/oidc-client-ts.git#main
-        version: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
+        specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2466,8 +2466,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: git+https://github.com/authts/oidc-client-ts.git#main
-        version: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
+        specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -13403,8 +13403,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-client-ts@https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9:
-    resolution: {tarball: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9}
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898:
+    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898}
     version: 3.2.1
     engines: {node: '>=18'}
 
@@ -20263,7 +20263,7 @@ snapshots:
       jwt-decode: 3.1.2
       localforage: 1.10.0
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -20307,7 +20307,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20349,7 +20349,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -33622,7 +33622,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-client-ts@https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9:
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898:
     dependencies:
       jwt-decode: 4.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@openzeppelin/contracts@3.4.2-solc-0.7': 3.4.2
   elliptic: ^6.6.1
   responselike: ^2.0.0
+  oidc-client-ts: git+https://github.com/authts/oidc-client-ts.git#main
 
 importers:
 
@@ -1932,8 +1933,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: git+https://github.com/authts/oidc-client-ts.git#main
+        version: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -2167,8 +2168,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: git+https://github.com/authts/oidc-client-ts.git#main
+        version: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2465,8 +2466,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: git+https://github.com/authts/oidc-client-ts.git#main
+        version: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -12370,6 +12371,10 @@ packages:
   jwt-decode@3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
 
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
+
   jwt-encode@1.0.1:
     resolution: {integrity: sha512-QrGiNhynbAYyFdbC1GbjborzenSFs5Ga+2nE0uBokGXsH11xrgd1AX55HR7P+wGQyyZOn6LUO5iKlh74dlhBkA==}
 
@@ -13398,9 +13403,10 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-client-ts@2.4.0:
-    resolution: {integrity: sha512-WijhkTrlXK2VvgGoakWJiBdfIsVGz6CFzgjNNqZU1hPKV2kyeEaJgLs7RwuiSp2WhLfWBQuLvr2SxVlZnk3N1w==}
-    engines: {node: '>=12.13.0'}
+  oidc-client-ts@https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9:
+    resolution: {tarball: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9}
+    version: 3.2.1
+    engines: {node: '>=18'}
 
   on-exit-leak-free@0.2.0:
     resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
@@ -20257,7 +20263,7 @@ snapshots:
       jwt-decode: 3.1.2
       localforage: 1.10.0
       magic-sdk: 29.0.5
-      oidc-client-ts: 2.4.0
+      oidc-client-ts: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -20301,7 +20307,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: 2.4.0
+      oidc-client-ts: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20343,7 +20349,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: 2.4.0
+      oidc-client-ts: https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -32277,6 +32283,8 @@ snapshots:
 
   jwt-decode@3.1.2: {}
 
+  jwt-decode@4.0.0: {}
+
   jwt-encode@1.0.1:
     dependencies:
       ts.cryptojs256: 1.0.1
@@ -33614,10 +33622,9 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-client-ts@2.4.0:
+  oidc-client-ts@https://codeload.github.com/authts/oidc-client-ts/tar.gz/4519663add35b41bb257b40737a7bf1ab5b813e9:
     dependencies:
-      crypto-js: 4.2.0
-      jwt-decode: 3.1.2
+      jwt-decode: 4.0.0
 
   on-exit-leak-free@0.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1934,7 +1934,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -2169,7 +2169,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2467,7 +2467,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -13403,8 +13403,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898:
-    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898}
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f:
+    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f}
     version: 3.2.1
     engines: {node: '>=18'}
 
@@ -20263,7 +20263,7 @@ snapshots:
       jwt-decode: 3.1.2
       localforage: 1.10.0
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -20307,7 +20307,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20349,7 +20349,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -33622,7 +33622,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b985e40a6747df463e965f70493e4aef639f6898:
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f:
     dependencies:
       jwt-decode: 4.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1934,7 +1934,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -2169,7 +2169,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2467,7 +2467,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -13403,8 +13403,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a:
-    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a}
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456:
+    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456}
     version: 3.2.1
     engines: {node: '>=18'}
 
@@ -20263,7 +20263,7 @@ snapshots:
       jwt-decode: 3.1.2
       localforage: 1.10.0
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -20307,7 +20307,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20349,7 +20349,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -33622,7 +33622,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a:
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/980de802dbb1cd28e8738b7293e8fc64d9783456:
     dependencies:
       jwt-decode: 4.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1934,7 +1934,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -2169,7 +2169,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2467,7 +2467,7 @@ importers:
         version: 29.0.5
       oidc-client-ts:
         specifier: git+https://github.com/nattb8/oidc-client-ts.git#main
-        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
+        version: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -13403,8 +13403,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f:
-    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f}
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a:
+    resolution: {tarball: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a}
     version: 3.2.1
     engines: {node: '>=18'}
 
@@ -20263,7 +20263,7 @@ snapshots:
       jwt-decode: 3.1.2
       localforage: 1.10.0
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -20307,7 +20307,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20349,7 +20349,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f
+      oidc-client-ts: https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -33622,7 +33622,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/b84931a9996dcf00e173002a189b1ff2055e884f:
+  oidc-client-ts@https://codeload.github.com/nattb8/oidc-client-ts/tar.gz/a63cb0351e5e1d95260cfe9762c3b816498bc11a:
     dependencies:
       jwt-decode: 4.0.0
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "nodenext",
     "allowJs": false,
     "removeComments": false,
     "strict": true,


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Context

[ID-3722](https://immutable.atlassian.net/browse/ID-3722)

Facebook login in Play is currently broken - users get stuck on the "Welcome, you're logged in" page and aren't redirected back to the app. This doesn't affect Google, Apple, or email login. The issue has been reproduced in the Passport sample app and is caused by a `No window.opener. Can't complete notification.` error during the callback.

A fix has been merged into the `main` branch of `oidc-client-ts`, but it hasn't been included in an official release. Since their release schedule is irregular, we’re applying a temporary workaround to unblock affected teams.

# Detail and impact of the change

## Changed
Temporarily updated our TS SDK to depend on the `main` branch of `oidc-client-ts` to include the fix.

# Anything else worth calling out?
This will be published as an alpha release to unblock teams affected by the Facebook login issue.
Once `oidc-client-ts` publishes an official release with the fix, we'll update our dependency accordingly and release a stable SDK version.


[ID-3722]: https://immutable.atlassian.net/browse/ID-3722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ