### PR TITLE
fix(passport): no window opener

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
     "*.{js,jsx,ts,tsx}": "eslint"
   },
   "packageManager": "pnpm@9.12.0",
+  "pnpm": {
+    "overrides": {
+      "oidc-client-ts": "v3.3.0-rc.0"
+    }
+  },
   "private": true,
   "repository": "immutable/ts-immutable-sdk.git",
   "resolutions": {

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -132,7 +132,7 @@ describe('AuthManager', () => {
         authority: config.authenticationDomain,
         client_id: config.oidcConfiguration.clientId,
         extraQueryParams: {},
-        mergeClaims: true,
+        mergeClaimsStrategy: { array: 'merge' },
         automaticSilentRenew: false,
         metadata: {
           authorization_endpoint: `${config.authenticationDomain}/authorize`,

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -72,7 +72,7 @@ const getAuthConfiguration = (config: PassportConfiguration): UserManagerSetting
       userinfo_endpoint: `${authenticationDomain}/userinfo`,
       end_session_endpoint: endSessionEndpoint.toString(),
     },
-    mergeClaims: true,
+    mergeClaimsStrategy: { array: 'merge' },
     automaticSilentRenew: false, // Disabled until https://github.com/authts/oidc-client-ts/issues/430 has been resolved
     scope: oidcConfiguration.scope,
     userStore,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@openzeppelin/contracts@3.4.2-solc-0.7': 3.4.2
   elliptic: ^6.6.1
   responselike: ^2.0.0
+  oidc-client-ts: v3.3.0-rc.0
 
 importers:
 
@@ -1932,8 +1933,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: v3.3.0-rc.0
+        version: 3.3.0-rc.0
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -2167,8 +2168,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: v3.3.0-rc.0
+        version: 3.3.0-rc.0
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2465,8 +2466,8 @@ importers:
         specifier: ^29.0.5
         version: 29.0.5
       oidc-client-ts:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: v3.3.0-rc.0
+        version: 3.3.0-rc.0
     devDependencies:
       '@swc/core':
         specifier: ^1.3.36
@@ -12370,6 +12371,10 @@ packages:
   jwt-decode@3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
 
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
+
   jwt-encode@1.0.1:
     resolution: {integrity: sha512-QrGiNhynbAYyFdbC1GbjborzenSFs5Ga+2nE0uBokGXsH11xrgd1AX55HR7P+wGQyyZOn6LUO5iKlh74dlhBkA==}
 
@@ -13398,9 +13403,9 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-client-ts@2.4.0:
-    resolution: {integrity: sha512-WijhkTrlXK2VvgGoakWJiBdfIsVGz6CFzgjNNqZU1hPKV2kyeEaJgLs7RwuiSp2WhLfWBQuLvr2SxVlZnk3N1w==}
-    engines: {node: '>=12.13.0'}
+  oidc-client-ts@3.3.0-rc.0:
+    resolution: {integrity: sha512-tnCmwX6DnGmuhoCQdzKm52rHTYtuIZQfauttVIQ8xxXW0T9s+e5THRnxnMf1uX2B/NjizmXN7oHdCerx9yhW0Q==}
+    engines: {node: '>=18'}
 
   on-exit-leak-free@0.2.0:
     resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
@@ -20257,7 +20262,7 @@ snapshots:
       jwt-decode: 3.1.2
       localforage: 1.10.0
       magic-sdk: 29.0.5
-      oidc-client-ts: 2.4.0
+      oidc-client-ts: 3.3.0-rc.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -20301,7 +20306,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: 2.4.0
+      oidc-client-ts: 3.3.0-rc.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20343,7 +20348,7 @@ snapshots:
       enc-utils: 3.0.0
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       magic-sdk: 29.0.5
-      oidc-client-ts: 2.4.0
+      oidc-client-ts: 3.3.0-rc.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -32277,6 +32282,8 @@ snapshots:
 
   jwt-decode@3.1.2: {}
 
+  jwt-decode@4.0.0: {}
+
   jwt-encode@1.0.1:
     dependencies:
       ts.cryptojs256: 1.0.1
@@ -33614,10 +33621,9 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-client-ts@2.4.0:
+  oidc-client-ts@3.3.0-rc.0:
     dependencies:
-      crypto-js: 4.2.0
-      jwt-decode: 3.1.2
+      jwt-decode: 4.0.0
 
   on-exit-leak-free@0.2.0: {}
 


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Context

[ID-3722](https://immutable.atlassian.net/browse/ID-3722)

Facebook login in Play is currently broken - users get stuck on the "Welcome, you're logged in" page and aren't redirected back to the app. This doesn't affect Google, Apple, or email login. The issue has been reproduced in the Passport sample app and is caused by a `No window.opener. Can't complete notification.` error during the callback.

A fix has been merged into the `main` branch of `oidc-client-ts`, but it hasn't been included in an official release. Since their release schedule is irregular, we’re applying a temporary workaround to unblock affected teams.

# Detail and impact of the change

## Changed
Temporarily updated our TS SDK to depend on the `main` branch of `oidc-client-ts` to include the fix.

# Anything else worth calling out?
This will be published as an alpha release to unblock teams affected by the Facebook login issue.
Once `oidc-client-ts` publishes an official release with the fix, we'll update our dependency accordingly and release a stable SDK version.


[ID-3722]: https://immutable.atlassian.net/browse/ID-3722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ