### PR TITLE
fix(checkout): commerce widget error

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/immutable-commerce/hooks/useWidgetEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/immutable-commerce/hooks/useWidgetEvents.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import {
   IMTBLWidgetEvents,
+  ConnectEventType,
   OrchestrationEvent,
   OrchestrationEventType,
   RequestOnrampEvent,
@@ -88,6 +89,14 @@ export function useWidgetEvents(
 
       if (isOrchestrationEvent(customEvent)) {
         handleOrchestrationEvent(customEvent);
+        return;
+      }
+
+      // ignore walletconnect provider updated event on CONNECT
+      // we are not sure why this event is being emitted on connect and it is not possible to map it to a CommerceEventDetail
+      // there is no harm in ignoring it as the provider is available to the consumer on success event and it is currently not consumed anywhere
+      const isConnectProviderUpdatedEvent = customEvent.detail.type === ConnectEventType.WALLETCONNECT_PROVIDER_UPDATED;
+      if (isConnectProviderUpdatedEvent) {
         return;
       }
 

--- a/packages/checkout/widgets-lib/src/widgets/immutable-commerce/hooks/useWidgetEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/immutable-commerce/hooks/useWidgetEvents.ts
@@ -93,8 +93,8 @@ export function useWidgetEvents(
       }
 
       // ignore walletconnect provider updated event on CONNECT
-      // we are not sure why this event is being emitted on connect and it is not possible to map it to a CommerceEventDetail
-      // there is no harm in ignoring it as the provider is available to the consumer on success event and it is currently not consumed anywhere
+      // as that is not really consumed and the provider is available to the consumer on success event
+      // GFI-596
       const isConnectProviderUpdatedEvent = customEvent.detail.type === ConnectEventType.WALLETCONNECT_PROVIDER_UPDATED;
       if (isConnectProviderUpdatedEvent) {
         return;


### PR DESCRIPTION
# Summary
The `WALLETCONNECT_PROVIDER_UPDATED` event was not being mapped to a commerce connect event throwing an error for an unknown type. This event was not comsumed so dropped this event for commerce widget and the updated provider is available via success event.