### PR TITLE
feat(passport): ID-3764 Debounce login

### DIFF
--- a/packages/passport/sdk/src/Passport.test.ts
+++ b/packages/passport/sdk/src/Passport.test.ts
@@ -652,9 +652,11 @@ describe('Passport', () => {
       authLoginMock.mockRejectedValue(error);
 
       // Make multiple concurrent login calls that will fail
-      const loginPromise1 = passport.login();
-      const loginPromise2 = passport.login();
-      const loginPromise3 = passport.login();
+      const [loginPromise1, loginPromise2, loginPromise3] = [
+        passport.login(),
+        passport.login(),
+        passport.login(),
+      ];
 
       // All promises should be the same reference
       expect(loginPromise1).toEqual(loginPromise2);
@@ -662,7 +664,7 @@ describe('Passport', () => {
 
       // All should reject with the same error
       try {
-        await Promise.all([loginPromise1, loginPromise2, loginPromise3])
+        await Promise.all([loginPromise1, loginPromise2, loginPromise3]);
       } catch (e: unknown) {
         expect(e).toEqual(error);
         // AuthManager.login should only be called once despite multiple login calls

--- a/packages/passport/sdk/src/Passport.test.ts
+++ b/packages/passport/sdk/src/Passport.test.ts
@@ -594,8 +594,8 @@ describe('Passport', () => {
       const loginPromise3 = passport.login();
 
       // All promises should be the same reference
-      expect(loginPromise1).toBe(loginPromise2);
-      expect(loginPromise2).toBe(loginPromise3);
+      expect(loginPromise1).toEqual(loginPromise2);
+      expect(loginPromise2).toEqual(loginPromise3);
 
       // Wait for all to complete
       const [result1, result2, result3] = await Promise.all([
@@ -657,14 +657,17 @@ describe('Passport', () => {
       const loginPromise3 = passport.login();
 
       // All promises should be the same reference
-      expect(loginPromise1).toBe(loginPromise2);
-      expect(loginPromise2).toBe(loginPromise3);
+      expect(loginPromise1).toEqual(loginPromise2);
+      expect(loginPromise2).toEqual(loginPromise3);
 
       // All should reject with the same error
-      await expect(Promise.all([loginPromise1, loginPromise2, loginPromise3])).rejects.toThrow(error);
-
-      // AuthManager.login should only be called once despite multiple login calls
-      expect(authLoginMock).toBeCalledTimes(1);
+      try {
+        await Promise.all([loginPromise1, loginPromise2, loginPromise3])
+      } catch (e: unknown) {
+        expect(e).toEqual(error);
+        // AuthManager.login should only be called once despite multiple login calls
+        expect(authLoginMock).toBeCalledTimes(1);
+      }
     });
   });
 

--- a/packages/passport/sdk/src/Passport.test.ts
+++ b/packages/passport/sdk/src/Passport.test.ts
@@ -583,6 +583,89 @@ describe('Passport', () => {
       expect(getUserMock).toBeCalledTimes(1);
       expect(authLoginMock).toBeCalledTimes(1);
     });
+
+    it('should debounce concurrent login calls and return the same result', async () => {
+      getUserMock.mockReturnValue(null);
+      authLoginMock.mockReturnValue(mockUserImx);
+
+      // Make multiple concurrent login calls
+      const loginPromise1 = passport.login();
+      const loginPromise2 = passport.login();
+      const loginPromise3 = passport.login();
+
+      // All promises should be the same reference
+      expect(loginPromise1).toBe(loginPromise2);
+      expect(loginPromise2).toBe(loginPromise3);
+
+      // Wait for all to complete
+      const [result1, result2, result3] = await Promise.all([
+        loginPromise1,
+        loginPromise2,
+        loginPromise3,
+      ]);
+
+      // All results should be the same
+      expect(result1).toEqual(mockUserImx.profile);
+      expect(result2).toEqual(mockUserImx.profile);
+      expect(result3).toEqual(mockUserImx.profile);
+
+      // AuthManager.login should only be called once despite multiple login calls
+      expect(authLoginMock).toBeCalledTimes(1);
+    });
+
+    it('should reset login promise after successful completion and allow new login calls', async () => {
+      getUserMock.mockReturnValue(null);
+      authLoginMock.mockReturnValue(mockUserImx);
+
+      // First login call
+      const firstLoginResult = await passport.login();
+      expect(firstLoginResult).toEqual(mockUserImx.profile);
+
+      // Second login call after first completes should create a new login process
+      const secondLoginResult = await passport.login();
+      expect(secondLoginResult).toEqual(mockUserImx.profile);
+
+      // AuthManager.login should be called twice (once for each login)
+      expect(authLoginMock).toBeCalledTimes(2);
+    });
+
+    it('should reset login promise after failed completion and allow new login calls', async () => {
+      const error = new Error('Login failed');
+      getUserMock.mockReturnValue(null);
+      authLoginMock.mockRejectedValue(error);
+
+      // First login call should fail
+      await expect(passport.login()).rejects.toThrow(error);
+
+      // Second login call after first fails should create a new login process
+      authLoginMock.mockReturnValue(mockUserImx);
+      const secondLoginResult = await passport.login();
+      expect(secondLoginResult).toEqual(mockUserImx.profile);
+
+      // AuthManager.login should be called twice (once for failed, once for successful)
+      expect(authLoginMock).toBeCalledTimes(2);
+    });
+
+    it('should debounce concurrent login calls even when they fail', async () => {
+      const error = new Error('Login failed');
+      getUserMock.mockReturnValue(null);
+      authLoginMock.mockRejectedValue(error);
+
+      // Make multiple concurrent login calls that will fail
+      const loginPromise1 = passport.login();
+      const loginPromise2 = passport.login();
+      const loginPromise3 = passport.login();
+
+      // All promises should be the same reference
+      expect(loginPromise1).toBe(loginPromise2);
+      expect(loginPromise2).toBe(loginPromise3);
+
+      // All should reject with the same error
+      await expect(Promise.all([loginPromise1, loginPromise2, loginPromise3])).rejects.toThrow(error);
+
+      // AuthManager.login should only be called once despite multiple login calls
+      expect(authLoginMock).toBeCalledTimes(1);
+    });
   });
 
   describe('linkExternalWallet', () => {


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
# Summary
Calling the `login` method twice can result in a `No matching state found in storage` error once the user authenticates. This PR solves this issue by adding debounce logic to the `login` method.

# Detail and impact of the change
## Changed
- Passport: Improved how we handle multiple calls to the login method