### PR TITLE
fix(passport): [ID-3766] cache register user promise

### DIFF
--- a/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
+++ b/packages/passport/sdk/src/zkEvm/zkEvmProvider.ts
@@ -280,12 +280,9 @@ export class ZkEvmProvider implements Provider {
             try {
               userZkEvmEthAddress = await this.#userRegistrationPromise;
               flow.addEvent('endUserRegistration');
-              // Clear the cache after successful registration so future calls get fresh user data
+            } finally {
+              // Clear the cache on success or error
               this.#clearUserRegistrationCache();
-            } catch (error) {
-              // Clear the cached promise on error so it can be retried
-              this.#clearUserRegistrationCache();
-              throw error;
             }
           } else {
             userZkEvmEthAddress = user.zkEvm.ethAddress;


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary

[ID-3677](https://immutable.atlassian.net/browse/ID-3766)

Cache user registration promise to prevent SDK sending multiple user registration requests due to app re-rendering.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->


[ID-3677]: https://immutable.atlassian.net/browse/ID-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ