### PR TITLE
chore(passport): improve passport post to relayer error message

### DIFF
--- a/packages/passport/sdk/src/zkEvm/relayerClient.test.ts
+++ b/packages/passport/sdk/src/zkEvm/relayerClient.test.ts
@@ -44,6 +44,8 @@ describe('relayerClient', () => {
       const data = '0x123';
 
       (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ result: transactionHash })),
         json: () => ({
           result: transactionHash,
         }),
@@ -69,6 +71,36 @@ describe('relayerClient', () => {
         }],
       });
     });
+
+    it('throws HTTP error for non-ok response', async () => {
+      const to = '0xd64b0d2d72bb1b3f18046b8a7fc6c9ee6bccd287';
+      const data = '0x123';
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: () => Promise.resolve('{"error":"invalid_token"}'),
+      });
+
+      await expect(relayerClient.ethSendTransaction(to, data)).rejects.toThrow(
+        'Relayer HTTP error: 401. Content: "{"error":"invalid_token"}"',
+      );
+    });
+
+    it('throws JSON parse error for invalid response', async () => {
+      const to = '0xd64b0d2d72bb1b3f18046b8a7fc6c9ee6bccd287';
+      const data = '0x123';
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('invalid json'),
+      });
+
+      await expect(relayerClient.ethSendTransaction(to, data)).rejects.toThrow(
+        'Relayer JSON parse error: Unexpected token \'i\', "invalid json" is not valid JSON. Content: "invalid json"',
+      );
+    });
   });
 
   describe('imGetTransactionByHash', () => {
@@ -82,6 +114,8 @@ describe('relayerClient', () => {
       };
 
       (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ result: relayerTransaction })),
         json: () => ({
           result: relayerTransaction,
         }),
@@ -118,6 +152,8 @@ describe('relayerClient', () => {
       }];
 
       (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ result: feeOptions })),
         json: () => ({
           result: feeOptions,
         }),
@@ -152,6 +188,8 @@ describe('relayerClient', () => {
       const relayerSignature = '0x123';
 
       (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ result: relayerSignature })),
         json: () => ({
           result: relayerSignature,
         }),
@@ -186,6 +224,8 @@ describe('relayerClient', () => {
       const relayerSignature = '0x123';
 
       (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ result: relayerSignature })),
         json: () => ({
           result: relayerSignature,
         }),


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Improved JSON parsing error message in `postToRelayer` to address `SyntaxError: Unexpected end of JSON`.


[ID-3834](https://immutable.atlassian.net/browse/ID-3834?atlOrigin=eyJpIjoiMzUwN2UzNTY2ZTU3NDc3NWIzOTNjOTMwZThmMDRiZWUiLCJwIjoiaiJ9)

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->


[ID-3834]: https://immutable.atlassian.net/browse/ID-3834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ