### PR TITLE
feat(passport, gamebridge): add support for direct login methods (google, apple, facebook) in ts sdk and game bridge

### DIFF
--- a/packages/game-bridge/src/index.ts
+++ b/packages/game-bridge/src/index.ts
@@ -349,7 +349,9 @@ window.callFunction = async (jsonData: string) => {
         break;
       }
       case PASSPORT_FUNCTIONS.getPKCEAuthUrl: {
-        const url = await getPassportClient().loginWithPKCEFlow();
+        const request = data ? JSON.parse(data) : {};
+        const directLoginMethod = request?.directLoginMethod;
+        const url = await getPassportClient().loginWithPKCEFlow(directLoginMethod);
         trackDuration(moduleName, 'performedGetPkceAuthUrl', mt(markStart));
         callbackToGame({
           responseFor: fxName,

--- a/packages/game-bridge/src/index.ts
+++ b/packages/game-bridge/src/index.ts
@@ -233,7 +233,6 @@ window.callFunction = async (jsonData: string) => {
               scope,
               crossSdkBridgeEnabled: true,
               logoutMode,
-              extraQueryParams: request.extraQueryParams,
               overrides: {
                 authenticationDomain: 'https://auth.dev.immutable.com',
                 magicPublishableApiKey: 'pk_live_4058236363130CA9', // Public key
@@ -269,7 +268,6 @@ window.callFunction = async (jsonData: string) => {
               crossSdkBridgeEnabled: true,
               jsonRpcReferrer: 'http://imtblgamesdk.local',
               logoutMode,
-              extraQueryParams: request.extraQueryParams,
             };
           }
 

--- a/packages/passport/sdk-sample-app/src/components/PassportMethods.tsx
+++ b/packages/passport/sdk-sample-app/src/components/PassportMethods.tsx
@@ -11,8 +11,14 @@ function PassportMethods() {
   const { isLoading } = useStatusProvider();
   const {
     logout,
-    login,
     popupRedirect,
+    popupRedirectGoogle,
+    popupRedirectApple,
+    popupRedirectFacebook,
+    login,
+    loginGoogle,
+    loginApple,
+    loginFacebook,
     getIdToken,
     getAccessToken,
     getUserInfo,
@@ -52,9 +58,45 @@ function PassportMethods() {
         </WorkflowButton>
         <WorkflowButton
           disabled={isLoading}
+          onClick={popupRedirectGoogle}
+        >
+          Popup Login (Google)
+        </WorkflowButton>
+        <WorkflowButton
+          disabled={isLoading}
+          onClick={popupRedirectApple}
+        >
+          Popup Login (Apple)
+        </WorkflowButton>
+        <WorkflowButton
+          disabled={isLoading}
+          onClick={popupRedirectFacebook}
+        >
+          Popup Login (Facebook)
+        </WorkflowButton>
+        <WorkflowButton
+          disabled={isLoading}
           onClick={login}
         >
           Login
+        </WorkflowButton>
+        <WorkflowButton
+          disabled={isLoading}
+          onClick={loginGoogle}
+        >
+          Login (Google)
+        </WorkflowButton>
+        <WorkflowButton
+          disabled={isLoading}
+          onClick={loginApple}
+        >
+          Login (Apple)
+        </WorkflowButton>
+        <WorkflowButton
+          disabled={isLoading}
+          onClick={loginFacebook}
+        >
+          Login (Facebook)
         </WorkflowButton>
         <WorkflowButton
           disabled={isLoading}

--- a/packages/passport/sdk-sample-app/src/context/PassportProvider.tsx
+++ b/packages/passport/sdk-sample-app/src/context/PassportProvider.tsx
@@ -21,6 +21,12 @@ const PassportContext = createContext<{
   getUserInfo: () => Promise<UserProfile | undefined>;
   getLinkedAddresses: () => Promise<string[] | undefined>;
   linkWallet: (params: LinkWalletParams) => Promise<LinkedWallet | undefined>;
+  popupRedirectGoogle: () => void;
+  popupRedirectApple: () => void;
+  popupRedirectFacebook: () => void;
+  loginGoogle: () => void;
+  loginApple: () => void;
+  loginFacebook: () => void;
 }>({
       imxProvider: undefined,
       zkEvmProvider: undefined,
@@ -34,6 +40,12 @@ const PassportContext = createContext<{
       getUserInfo: () => Promise.resolve(undefined),
       getLinkedAddresses: () => Promise.resolve(undefined),
       linkWallet: () => Promise.resolve(undefined),
+      popupRedirectGoogle: () => undefined,
+      popupRedirectApple: () => undefined,
+      popupRedirectFacebook: () => undefined,
+      loginGoogle: () => undefined,
+      loginApple: () => undefined,
+      loginFacebook: () => undefined,
     });
 
 export function PassportProvider({
@@ -163,14 +175,109 @@ export function PassportProvider({
     }
   }, [addMessage, passportClient, setIsLoading]);
 
+  // Popup redirect methods (provider-specific)
+  const popupRedirectGoogle = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const userProfile = await passportClient.login({ directLoginMethod: 'google' });
+      addMessage('Popup Login (Google)', userProfile);
+    } catch (err) {
+      addMessage('Popup Login (Google)', err);
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [addMessage, passportClient, setIsLoading]);
+
+  const popupRedirectApple = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const userProfile = await passportClient.login({ directLoginMethod: 'apple' });
+      addMessage('Popup Login (Apple)', userProfile);
+    } catch (err) {
+      addMessage('Popup Login (Apple)', err);
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [addMessage, passportClient, setIsLoading]);
+
+  const popupRedirectFacebook = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const userProfile = await passportClient.login({ directLoginMethod: 'facebook' });
+      addMessage('Popup Login (Facebook)', userProfile);
+    } catch (err) {
+      addMessage('Popup Login (Facebook)', err);
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [addMessage, passportClient, setIsLoading]);
+
+  // Login (redirect) methods
+  const loginGoogle = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const userProfile = await passportClient.login({
+        directLoginMethod: 'google',
+        useRedirectFlow: true,
+      });
+      addMessage('Login (Google)', userProfile);
+    } catch (err) {
+      addMessage('Login (Google)', err);
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [addMessage, passportClient, setIsLoading]);
+
+  const loginApple = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const userProfile = await passportClient.login({
+        directLoginMethod: 'apple',
+        useRedirectFlow: true,
+      });
+      addMessage('Login (Apple)', userProfile);
+    } catch (err) {
+      addMessage('Login (Apple)', err);
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [addMessage, passportClient, setIsLoading]);
+
+  const loginFacebook = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const userProfile = await passportClient.login({
+        directLoginMethod: 'facebook',
+        useRedirectFlow: true,
+      });
+      addMessage('Login (Facebook)', userProfile);
+    } catch (err) {
+      addMessage('Login (Facebook)', err);
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [addMessage, passportClient, setIsLoading]);
+
   const providerValues = useMemo(() => ({
     imxProvider,
     zkEvmProvider,
     connectImx,
     connectZkEvm,
     logout,
-    login,
     popupRedirect,
+    popupRedirectGoogle,
+    popupRedirectApple,
+    popupRedirectFacebook,
+    login,
+    loginGoogle,
+    loginApple,
+    loginFacebook,
     getIdToken,
     getAccessToken,
     getUserInfo,
@@ -182,8 +289,14 @@ export function PassportProvider({
     connectImx,
     connectZkEvm,
     logout,
-    login,
     popupRedirect,
+    popupRedirectGoogle,
+    popupRedirectApple,
+    popupRedirectFacebook,
+    login,
+    loginGoogle,
+    loginApple,
+    loginFacebook,
     getIdToken,
     getAccessToken,
     getUserInfo,
@@ -204,9 +317,15 @@ export function usePassportProvider() {
     zkEvmProvider,
     connectImx,
     connectZkEvm,
-    login,
-    popupRedirect,
     logout,
+    popupRedirect,
+    popupRedirectGoogle,
+    popupRedirectApple,
+    popupRedirectFacebook,
+    login,
+    loginGoogle,
+    loginApple,
+    loginFacebook,
     getIdToken,
     getAccessToken,
     getUserInfo,
@@ -218,9 +337,15 @@ export function usePassportProvider() {
     zkEvmProvider,
     connectImx,
     connectZkEvm,
-    login,
-    popupRedirect,
     logout,
+    popupRedirect,
+    popupRedirectGoogle,
+    popupRedirectApple,
+    popupRedirectFacebook,
+    login,
+    loginGoogle,
+    loginApple,
+    loginFacebook,
     getIdToken,
     getAccessToken,
     getUserInfo,

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -272,10 +272,11 @@ export class Passport {
 
   /**
    * Initiates a PKCE flow login.
+   * @param {DirectLoginMethod} [directLoginMethod] - If provided, directly redirects to the specified login method
    * @returns {string} The authorization URL for the PKCE flow
    */
-  public loginWithPKCEFlow(): Promise<string> {
-    return withMetricsAsync(async () => await this.authManager.getPKCEAuthorizationUrl(), 'loginWithPKCEFlow');
+  public loginWithPKCEFlow(directLoginMethod?: DirectLoginMethod): Promise<string> {
+    return withMetricsAsync(async () => await this.authManager.getPKCEAuthorizationUrl(directLoginMethod), 'loginWithPKCEFlow');
   }
 
   /**

--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -15,6 +15,7 @@ import MagicAdapter from './magic/magicAdapter';
 import { PassportImxProviderFactory } from './starkEx';
 import { PassportConfiguration } from './config';
 import {
+  DirectLoginMethod,
   isUserImx,
   isUserZkEvm,
   LinkedWallet,
@@ -189,6 +190,8 @@ export class Passport {
    * @param {string} [options.anonymousId] - ID used to enrich Passport internal metrics
    * @param {boolean} [options.useSilentLogin] - If true, attempts silent authentication without user interaction.
    *                                            Note: This takes precedence over useCachedSession if both are true
+   * @param {boolean} [options.useRedirectFlow] - If true, uses redirect flow instead of popup flow
+   * @param {DirectLoginMethod} [options.directLoginMethod] - If provided, directly redirects to the specified login method
    * @returns {Promise<UserProfile | null>} A promise that resolves to the user profile if logged in, null otherwise
    * @throws {Error} If retrieving the cached user session fails (except for "Unknown or invalid refresh token" errors)
    *                and useCachedSession is true
@@ -198,6 +201,7 @@ export class Passport {
     anonymousId?: string;
     useSilentLogin?: boolean;
     useRedirectFlow?: boolean;
+    directLoginMethod?: DirectLoginMethod;
   }): Promise<UserProfile | null> {
     // If there's already a login in progress, return that promise
     if (this.#loginPromise) {
@@ -225,9 +229,9 @@ export class Passport {
         user = await this.authManager.forceUserRefresh();
       } else if (!user && !useCachedSession) {
         if (options?.useRedirectFlow) {
-          await this.authManager.loginWithRedirect(options?.anonymousId);
+          await this.authManager.loginWithRedirect(options?.anonymousId, options?.directLoginMethod);
         } else {
-          user = await this.authManager.login(options?.anonymousId);
+          user = await this.authManager.login(options?.anonymousId, options?.directLoginMethod);
         }
       }
 

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -692,4 +692,183 @@ describe('AuthManager', () => {
       });
     });
   });
+
+  describe('getPKCEAuthorizationUrl', () => {
+    beforeEach(() => {
+      // Mock crypto.getRandomValues for PKCE verifier and state generation
+      const mockArrayBuffer = new ArrayBuffer(32);
+      const mockUint8Array = new Uint8Array([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+      ]);
+      Object.defineProperty(window, 'crypto', {
+        value: {
+          getRandomValues: jest.fn().mockReturnValue(mockUint8Array),
+          subtle: {
+            digest: jest.fn().mockResolvedValue(mockArrayBuffer),
+          },
+        },
+        writable: true,
+      });
+
+      // Mock TextEncoder
+      global.TextEncoder = jest.fn().mockImplementation(() => ({
+        encode: jest.fn().mockReturnValue(mockUint8Array),
+      }));
+
+      // Mock btoa function used in base64URLEncode
+      global.btoa = jest.fn().mockReturnValue('bW9ja2VkLWJhc2U2NC1zdHJpbmc=');
+    });
+
+    it('should generate a PKCE authorization URL with required parameters', async () => {
+      const result = await authManager.getPKCEAuthorizationUrl();
+      const url = new URL(result);
+
+      expect(url.hostname).toEqual(authenticationDomain);
+      expect(url.pathname).toEqual('/authorize');
+      expect(url.searchParams.get('response_type')).toEqual('code');
+      expect(url.searchParams.get('code_challenge_method')).toEqual('S256');
+      expect(url.searchParams.get('client_id')).toEqual(clientId);
+      expect(url.searchParams.get('redirect_uri')).toEqual(redirectUri);
+      expect(url.searchParams.get('scope')).toEqual('email profile');
+      expect(url.searchParams.get('code_challenge')).toEqual('bW9ja2VkLWJhc2U2NC1zdHJpbmc');
+      expect(url.searchParams.get('state')).toEqual('bW9ja2VkLWJhc2U2NC1zdHJpbmc');
+    });
+
+    it('should not include direct parameter when directLoginMethod is not provided', async () => {
+      const result = await authManager.getPKCEAuthorizationUrl();
+      const url = new URL(result);
+
+      expect(url.searchParams.get('direct')).toBeNull();
+    });
+
+    it('should include direct parameter when directLoginMethod is provided', async () => {
+      const directLoginMethod = 'apple';
+      const result = await authManager.getPKCEAuthorizationUrl(directLoginMethod);
+      const url = new URL(result);
+
+      expect(url.searchParams.get('direct')).toEqual('apple');
+    });
+
+    it('should include direct parameter for google login method', async () => {
+      const directLoginMethod = 'google';
+      const result = await authManager.getPKCEAuthorizationUrl(directLoginMethod);
+      const url = new URL(result);
+
+      expect(url.searchParams.get('direct')).toEqual('google');
+    });
+
+    it('should include direct parameter for facebook login method', async () => {
+      const directLoginMethod = 'facebook';
+      const result = await authManager.getPKCEAuthorizationUrl(directLoginMethod);
+      const url = new URL(result);
+
+      expect(url.searchParams.get('direct')).toEqual('facebook');
+    });
+
+    it('should include audience parameter when specified in config', async () => {
+      const configWithAudience = getConfig({ audience: 'test-audience' });
+      const am = new AuthManager(configWithAudience);
+
+      const result = await am.getPKCEAuthorizationUrl();
+      const url = new URL(result);
+
+      expect(url.searchParams.get('audience')).toEqual('test-audience');
+    });
+
+    it('should include both direct and audience parameters', async () => {
+      const configWithAudience = getConfig({ audience: 'test-audience' });
+      const am = new AuthManager(configWithAudience);
+
+      const result = await am.getPKCEAuthorizationUrl('apple');
+      const url = new URL(result);
+
+      expect(url.searchParams.get('direct')).toEqual('apple');
+      expect(url.searchParams.get('audience')).toEqual('test-audience');
+    });
+  });
+
+  describe('login with directLoginMethod', () => {
+    it('should pass directLoginMethod to login popup', async () => {
+      mockSigninPopup.mockResolvedValue(mockOidcUser);
+
+      await authManager.login('anonymous-id', 'apple');
+
+      expect(mockSigninPopup).toHaveBeenCalledWith({
+        extraQueryParams: {
+          rid: '',
+          third_party_a_id: 'anonymous-id',
+          direct: 'apple',
+        },
+        popupWindowFeatures: {
+          width: 410,
+          height: 450,
+        },
+        popupWindowTarget: 'passportLoginPrompt',
+      });
+    });
+
+    it('should not include direct parameter when directLoginMethod is not provided', async () => {
+      mockSigninPopup.mockResolvedValue(mockOidcUser);
+
+      await authManager.login('anonymous-id');
+
+      expect(mockSigninPopup).toHaveBeenCalledWith({
+        extraQueryParams: {
+          rid: '',
+          third_party_a_id: 'anonymous-id',
+        },
+        popupWindowFeatures: {
+          width: 410,
+          height: 450,
+        },
+        popupWindowTarget: 'passportLoginPrompt',
+      });
+    });
+  });
+
+  describe('loginWithRedirect with directLoginMethod', () => {
+    let mockSigninRedirect: jest.Mock;
+
+    beforeEach(() => {
+      mockSigninRedirect = jest.fn();
+      (UserManager as jest.Mock).mockReturnValue({
+        signinPopup: mockSigninPopup,
+        signinCallback: mockSigninCallback,
+        signinRedirectCallback: mockSigninRedirectCallback,
+        signoutRedirect: mockSignoutRedirect,
+        signoutSilent: mockSignoutSilent,
+        getUser: mockGetUser,
+        signinSilent: mockSigninSilent,
+        storeUser: mockStoreUser,
+        revokeTokens: mockRevokeTokens,
+        signinRedirect: mockSigninRedirect,
+        clearStaleState: jest.fn(),
+      });
+      authManager = new AuthManager(getConfig());
+    });
+
+    it('should pass directLoginMethod to redirect login', async () => {
+      await authManager.loginWithRedirect('anonymous-id', 'google');
+
+      expect(mockSigninRedirect).toHaveBeenCalledWith({
+        extraQueryParams: {
+          rid: '',
+          third_party_a_id: 'anonymous-id',
+          direct: 'google',
+        },
+      });
+    });
+
+    it('should not include direct parameter when directLoginMethod is not provided', async () => {
+      await authManager.loginWithRedirect('anonymous-id');
+
+      expect(mockSigninRedirect).toHaveBeenCalledWith({
+        extraQueryParams: {
+          rid: '',
+          third_party_a_id: 'anonymous-id',
+        },
+      });
+    });
+  });
 });

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -76,7 +76,6 @@ const getAuthConfiguration = (config: PassportConfiguration): UserManagerSetting
     userStore,
     revokeTokenTypes: ['refresh_token'],
     extraQueryParams: {
-      ...config.extraQueryParams,
       ...(oidcConfiguration.audience ? { audience: oidcConfiguration.audience } : {}),
     },
   };

--- a/packages/passport/sdk/src/config/config.ts
+++ b/packages/passport/sdk/src/config/config.ts
@@ -54,8 +54,6 @@ export class PassportConfiguration {
 
   readonly popupOverlayOptions: PopupOverlayOptions;
 
-  readonly extraQueryParams: Record<string, string>;
-
   constructor({
     baseConfig,
     overrides,
@@ -63,7 +61,6 @@ export class PassportConfiguration {
     jsonRpcReferrer,
     forceScwDeployBeforeMessageSignature,
     popupOverlayOptions,
-    extraQueryParams,
     ...oidcConfiguration
   }: PassportModuleConfiguration) {
     validateConfiguration(oidcConfiguration, [
@@ -78,7 +75,6 @@ export class PassportConfiguration {
       disableGenericPopupOverlay: false,
       disableBlockedPopupOverlay: false,
     };
-    this.extraQueryParams = extraQueryParams || {};
     if (overrides) {
       validateConfiguration(
         overrides,

--- a/packages/passport/sdk/src/types.ts
+++ b/packages/passport/sdk/src/types.ts
@@ -118,11 +118,6 @@ export interface PassportModuleConfiguration
    * to approve a deploy transaction before signing.
    */
   forceScwDeployBeforeMessageSignature?: boolean;
-
-  /**
-   * Extra query params to be sent to the OIDC provider.
-   */
-  extraQueryParams?: Record<string, string>;
 }
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };

--- a/packages/passport/sdk/src/types.ts
+++ b/packages/passport/sdk/src/types.ts
@@ -3,6 +3,13 @@ import { EthSigner, IMXClient, StarkSigner } from '@imtbl/x-client';
 import { ImxApiClients } from '@imtbl/generated-clients';
 import { Flow } from '@imtbl/metrics';
 
+/**
+ * Direct login method identifier
+ * Known providers: 'google', 'apple', 'facebook'
+ * Additional providers may be supported server-side
+ */
+export type DirectLoginMethod = string;
+
 export enum PassportEvents {
   LOGGED_OUT = 'loggedOut',
   LOGGED_IN = 'loggedIn',


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->

- Add support for direct login methods (Google, Apple, Facebook) in TS SDK and Game Bridge. This allow users to skip the standard login page to redirect directly to their preferred authenticated provider
- Remove `extraQueryParams` which was used as a generic way of passing the direct login method. This required re-initialising the passport whenever the login method changed. We now pass the direct login method when login happens

[ID-3818](https://immutable.atlassian.net/browse/ID-3818) [ID-3832](https://immutable.atlassian.net/browse/ID-3832)

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->


[ID-3818]: https://immutable.atlassian.net/browse/ID-3818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ