### PR TITLE
fix(checkout-sdk): Unrecognized chain error handling

### DIFF
--- a/packages/checkout/sdk-sample-app/src/components/CheckConnection.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/CheckConnection.tsx
@@ -18,11 +18,11 @@ export default function CheckConnection(props: CheckConnectionProps) {
 
   async function checkMyConnection() {
     if (!checkout) {
-      console.error('missing checkout, please connect frist');
+      console.error('missing checkout, please connect first');
       return;
     }
     if (!provider) {
-      console.error('missing provider, please connect frist');
+      console.error('missing provider, please connect first');
       return;
     }
 

--- a/packages/checkout/sdk-sample-app/src/components/GetAllBalances.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/GetAllBalances.tsx
@@ -18,11 +18,11 @@ export default function GetAllBalances(props: BalanceProps) {
 
   async function getAllBalances() {
     if (!checkout) {
-      console.error('missing checkout, please connect frist');
+      console.error('missing checkout, please connect first');
       return;
     }
     if (!provider) {
-      console.error('missing provider, please connect frist');
+      console.error('missing provider, please connect first');
       return;
     }
     setError(null);

--- a/packages/checkout/sdk-sample-app/src/components/GetBalance.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/GetBalance.tsx
@@ -24,11 +24,11 @@ export default function GetBalance(props: BalanceProps) {
 
   async function getNativeBalanceClick() {
     if (!checkout) {
-      console.error('missing checkout, please connect frist');
+      console.error('missing checkout, please connect first');
       return;
     }
     if (!provider) {
-      console.error('missing provider, please connect frist');
+      console.error('missing provider, please connect first');
       return;
     }
 
@@ -55,11 +55,11 @@ export default function GetBalance(props: BalanceProps) {
 
   async function getERC20BalanceClick() {
     if (!checkout) {
-      console.error('missing checkout, please connect frist');
+      console.error('missing checkout, please connect first');
       return;
     }
     if (!provider) {
-      console.error('missing provider, please connect frist');
+      console.error('missing provider, please connect first');
       return;
     }
 

--- a/packages/checkout/sdk-sample-app/src/components/SendTransaction.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/SendTransaction.tsx
@@ -43,11 +43,11 @@ export default function SendTransaction(props: SendTransactionProps) {
 
   async function sendTxClick() {
     if (!checkout) {
-      console.error('missing checkout, please connect frist');
+      console.error('missing checkout, please connect first');
       return;
     }
     if (!provider) {
-      console.error('missing provider, please connect frist');
+      console.error('missing provider, please connect first');
       return;
     }
 

--- a/packages/checkout/sdk-sample-app/src/components/SwitchNetwork.tsx
+++ b/packages/checkout/sdk-sample-app/src/components/SwitchNetwork.tsx
@@ -49,11 +49,11 @@ export default function SwitchNetwork(props: SwitchNetworkProps) {
 
   const switchNetwork = useCallback(async(chainId: ChainId) => {
     if (!checkout) {
-      console.error('missing checkout, please connect frist');
+      console.error('missing checkout, please connect first');
       return;
     }
     if (!provider) {
-      console.error('missing provider, please connect frist');
+      console.error('missing provider, please connect first');
       return;
     }
 
@@ -81,11 +81,11 @@ export default function SwitchNetwork(props: SwitchNetworkProps) {
 
   async function getNetworkInfo() {
     if (!checkout) {
-      console.error('missing checkout, please connect frist');
+      console.error('missing checkout, please connect first');
       return;
     }
     if (!provider) {
-      console.error('missing provider, please connect frist');
+      console.error('missing provider, please connect first');
       return;
     }
 

--- a/packages/checkout/sdk-sample-app/src/pages/ConnectWidget.tsx
+++ b/packages/checkout/sdk-sample-app/src/pages/ConnectWidget.tsx
@@ -20,16 +20,7 @@ export default function ConnectWidget() {
   }, [environment]);
   const [provider, setProvider] = useState<WrappedBrowserProvider>();
 
-  function toggleEnvironment() {
-    if (environment === Environment.PRODUCTION) {
-      setEnvironment(Environment.SANDBOX);
-    } else {
-      setEnvironment(Environment.PRODUCTION);
-    }
-  }
-
-  console.log('qwerqewrqwer')
-  console.log(checkout.getInjectedProviders())
+  console.log('injected providers:', checkout.getInjectedProviders())
 
   return (
     <div>

--- a/packages/checkout/sdk/src/network/network.test.ts
+++ b/packages/checkout/sdk/src/network/network.test.ts
@@ -52,6 +52,13 @@ const unrecognisedChainError = {
   },
 };
 
+const anotherUnrecognisedChainError = {
+  error: {
+    message: 'Provider error',
+    code: 4902,
+  },
+};
+
 jest.mock('../api/http', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   HttpClient: jest.fn().mockImplementation(() => ({
@@ -300,6 +307,54 @@ describe('network functions', () => {
           send: jest
             .fn()
             .mockRejectedValueOnce(unrecognisedChainError)
+            .mockResolvedValueOnce({}),
+          ethereumProvider: {
+            isMetaMask: true,
+          },
+          getNetwork: jest.fn().mockResolvedValue(zkevmNetworkInfo),
+        })
+        .mockReturnValueOnce({
+          send: jest.fn().mockResolvedValueOnce({}),
+          ethereumProvider: {
+            isMetaMask: true,
+          },
+          getNetwork: jest.fn().mockResolvedValue(zkevmNetworkInfo),
+        });
+      const { provider } = await createProvider(WalletProviderName.METAMASK);
+
+      await switchWalletNetwork(
+        testCheckoutConfiguration,
+        provider,
+        ChainId.IMTBL_ZKEVM_TESTNET,
+      );
+
+      expect(provider.send).toHaveBeenCalledWith(WalletAction.ADD_NETWORK, [
+        {
+          chainId: testCheckoutConfiguration.networkMap.get(
+            ChainId.IMTBL_ZKEVM_TESTNET,
+          )?.chainIdHex,
+          chainName: testCheckoutConfiguration.networkMap.get(
+            ChainId.IMTBL_ZKEVM_TESTNET,
+          )?.chainName,
+          rpcUrls: testCheckoutConfiguration.networkMap.get(
+            ChainId.IMTBL_ZKEVM_TESTNET,
+          )?.rpcUrls,
+          nativeCurrency: testCheckoutConfiguration.networkMap.get(
+            ChainId.IMTBL_ZKEVM_TESTNET,
+          )?.nativeCurrency,
+          blockExplorerUrls: testCheckoutConfiguration.networkMap.get(
+            ChainId.IMTBL_ZKEVM_TESTNET,
+          )?.blockExplorerUrls,
+        },
+      ]);
+    });
+
+    it('should request the user to add a new network when anotherUnrecognisedChainError is received', async () => {
+      (WrappedBrowserProvider as unknown as jest.Mock)
+        .mockReturnValueOnce({
+          send: jest
+            .fn()
+            .mockRejectedValueOnce(anotherUnrecognisedChainError)
             .mockResolvedValueOnce({}),
           ethereumProvider: {
             isMetaMask: true,

--- a/packages/checkout/sdk/src/network/network.ts
+++ b/packages/checkout/sdk/src/network/network.ts
@@ -136,7 +136,8 @@ export async function getNetworkInfo(
  * You get "Error: could not coalesce error....".
  * This is a workaround to check if the error is an unrecognised chain error.
  * */
-const isUnrecognisedChainError = (err: any) => err.error?.data?.originalError?.code === UNRECOGNISED_CHAIN_ERROR_CODE;
+const isUnrecognisedChainError = (err: any) => err.error?.data?.originalError?.code === UNRECOGNISED_CHAIN_ERROR_CODE
+  || err.error?.code === UNRECOGNISED_CHAIN_ERROR_CODE;
 
 export async function switchWalletNetwork(
   config: CheckoutConfiguration,


### PR DESCRIPTION
# Summary

Fixes the error handling case upon receving a Metamask error when switching to an unrecognized network is detected, in order to add that network and then switch to it. 

The expected error shape has been added to with an `||`, to safely handle both error shapes if they may occur.

# Detail and impact of the change

Allow again users who do not have zkEVM network in their wallet to connect more smoothly.

## Fixed

- Metamask error handling for unrecogized chain error
- Connect flow for users who have not yet added zkEVM network to their wallet