### PR TITLE
fix(passport): ID-3874 Fix logout issue

### DIFF
--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -455,8 +455,7 @@ describe('AuthManager', () => {
             PassportErrorType.LOGOUT_ERROR,
           ),
         );
-        // In silent mode, signoutSilent is called in parallel with revokeTokens
-        expect(mockSignoutSilent).toHaveBeenCalled();
+        expect(mockSignoutSilent).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -350,13 +350,11 @@ export default class AuthManager {
 
   public async logout(): Promise<void> {
     return withPassportError<void>(async () => {
+      await this.userManager.revokeTokens(['refresh_token']);
+
       if (this.logoutMode === 'silent') {
-        await Promise.all([
-          this.userManager.revokeTokens(['refresh_token']),
-          this.userManager.signoutSilent(),
-        ]);
+        await this.userManager.signoutSilent();
       } else {
-        await this.userManager.revokeTokens(['refresh_token']);
         await this.userManager.signoutRedirect();
       }
     }, PassportErrorType.LOGOUT_ERROR);


### PR DESCRIPTION
# Summary
This PR resolves an issue with the logout method not clearing the application session when silent logout mode is being used.  Calling `eth_requestAccounts` on the zkEVM provider after calling logout would continue to return the user's wallet address until the logout method is called a second time.

This can be reproduced in the Passport SDK sample app.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Fixed
- Passport: Fixed an issue with the logout method not clearing the application session when silent logout mode is being used