### PR TITLE
feat(passport): logout endpoint for game sdks

### DIFF
--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -323,7 +323,7 @@ export class Passport {
    * Returns the logout URL for the current user.
    * @returns {Promise<string>} The logout URL
    */
-  public async getLogoutUrl(): Promise<string> {
+  public async getLogoutUrl(): Promise<string | null> {
     return withMetricsAsync(async () => {
       await this.authManager.removeUser();
       await this.magicAdapter.logout();


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [x] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary
<!-- Keep it short. This is publicly viewable as part of the Changelog / Releases. -->
Windows does not reliably trigger custom URL protocols on redirect. To improve logout behaviour for Game SDKs, a dedicated Passport logout URL with a manual redirect link was added.

This PR updates the Passport package to use the dedicated logout URL for Game SDKs.

[ID-3873](https://immutable.atlassian.net/browse/ID-3873)

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->


[ID-3873]: https://immutable.atlassian.net/browse/ID-3873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ