### PR TITLE
feat(checkout): use address_hash to fill out address field

### DIFF
--- a/packages/checkout/sdk/src/api/blockscout/blockscout.ts
+++ b/packages/checkout/sdk/src/api/blockscout/blockscout.ts
@@ -111,8 +111,8 @@ export class Blockscout {
       // Map address_hash to address if address is not present
       const normalizedItems = response.data?.items?.map((item: BlockscoutToken) => {
         const normalizedToken = { ...item.token };
-        if (!normalizedToken.address && normalizedToken.address_hash) {
-          normalizedToken.address = normalizedToken.address_hash;
+        if (!normalizedToken.address && (normalizedToken as any).address_hash) {
+          normalizedToken.address = (normalizedToken as any).address_hash;
         }
         return { ...item, token: normalizedToken };
       }) || [];

--- a/packages/checkout/sdk/src/api/blockscout/blockscoutType.ts
+++ b/packages/checkout/sdk/src/api/blockscout/blockscoutType.ts
@@ -20,6 +20,7 @@ export interface BlockscoutToken {
 
 export interface BlockscoutTokenData {
   address: string
+  address_hash?: string
   decimals: string
   name: string
   symbol: string
@@ -34,6 +35,7 @@ export interface BlockscoutError {
 
 export interface BlockscoutNativeTokenData {
   address: string
+  address_hash?: string
   decimals: string
   name: string
   symbol: string

--- a/packages/checkout/sdk/src/api/blockscout/blockscoutType.ts
+++ b/packages/checkout/sdk/src/api/blockscout/blockscoutType.ts
@@ -20,7 +20,6 @@ export interface BlockscoutToken {
 
 export interface BlockscoutTokenData {
   address: string
-  address_hash?: string
   decimals: string
   name: string
   symbol: string
@@ -35,7 +34,6 @@ export interface BlockscoutError {
 
 export interface BlockscoutNativeTokenData {
   address: string
-  address_hash?: string
   decimals: string
   name: string
   symbol: string


### PR DESCRIPTION
# Summary
Fixes an issue with blockscout api having changed recently where they are not sending the `token.address` field on L1.

# Detail and impact of the change
It was affecting the bridge, balances component where none of the ERC20s were visible because we relied on the address field. The fix is populating that field with `address_hash` so rest of the components can just use that
