### PR TITLE
fix(passport): ID-3950 Fix login calls not rejecting

### DIFF
--- a/packages/passport/sdk-sample-app/src/components/Message.tsx
+++ b/packages/passport/sdk-sample-app/src/components/Message.tsx
@@ -20,7 +20,7 @@ function Message() {
         sx={{ width: '100%' }}
         position={{ x: 'right', y: 'top' }}
       >
-        <Form>
+        <Form style={{ width: 'inherit' }}>
           <Form.Group>
             <Form.Control
               as="textarea"

--- a/packages/passport/sdk/src/Passport.int.test.ts
+++ b/packages/passport/sdk/src/Passport.int.test.ts
@@ -99,9 +99,17 @@ describe('Passport', () => {
   const mockLoginWithOidc = jest.fn();
   const mockMagicRequest = jest.fn();
   const mockMagicUserIsLoggedIn = jest.fn();
+  let originalWindowOpen: any;
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    // Mock window.open to handle popup detection in authManager
+    originalWindowOpen = window.open;
+    window.open = jest.fn().mockReturnValue({
+      closed: false,
+      close: jest.fn(),
+    });
 
     mockMagicUserIsLoggedIn.mockResolvedValue(true);
     (UserManager as jest.Mock).mockImplementation(() => ({
@@ -122,6 +130,8 @@ describe('Passport', () => {
 
   afterEach(() => {
     resetMswHandlers();
+    // Restore original window.open
+    window.open = originalWindowOpen;
   });
 
   afterAll(async () => {

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -31,6 +31,8 @@ import { PassportConfiguration } from './config';
 import Overlay from './overlay';
 import { LocalForageAsyncStorage } from './storage/LocalForageAsyncStorage';
 
+const LOGIN_POPUP_CLOSED_POLLING_DURATION = 500;
+
 const formUrlEncodedHeader = {
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',
@@ -230,7 +232,7 @@ export default class AuthManager {
       const signinPopup = async () => {
         const extraQueryParams = this.buildExtraQueryParams(anonymousId, directLoginOptions);
 
-        return this.userManager.signinPopup({
+        const userPromise = this.userManager.signinPopup({
           extraQueryParams,
           popupWindowFeatures: {
             width: 410,
@@ -238,6 +240,36 @@ export default class AuthManager {
           },
           popupWindowTarget,
         });
+
+        // ID-3950: https://github.com/authts/oidc-client-ts/issues/2043
+        // The promise returned from `signinPopup` no longer rejects when the popup is closed.
+        // We can prevent this from impacting consumers by obtaining a reference to the popup and rejecting the promise
+        // that is returned by this method if the popup is closed by the user.
+
+        // Attempt to get a reference to the popup window
+        const popupRef = window.open('', popupWindowTarget);
+        if (popupRef) {
+          // Create a promise that rejects when popup is closed
+          const popupClosedPromise = new Promise<never>((_, reject) => {
+            const timer = setInterval(() => {
+              if (popupRef.closed) {
+                clearInterval(timer);
+                reject(new Error('Popup closed by user'));
+              }
+            }, LOGIN_POPUP_CLOSED_POLLING_DURATION);
+
+            // Clean up timer when the user promise resolves/rejects
+            userPromise.finally(() => {
+              clearInterval(timer);
+              popupRef.close();
+            });
+          });
+
+          // Race between user authentication and popup being closed
+          return Promise.race([userPromise, popupClosedPromise]);
+        }
+
+        return userPromise;
       };
 
       // This promise attempts to open the signin popup, and displays the blocked popup overlay if necessary.
@@ -301,8 +333,33 @@ export default class AuthManager {
     return user || this.login();
   }
 
+  private static shouldUseSigninPopupCallback(): boolean {
+    // ID-3950: https://github.com/authts/oidc-client-ts/issues/2043
+    // Detect when the login was initiated via a popup
+    try {
+      const urlParams = new URLSearchParams(window.location.search);
+      const stateParam = urlParams.get('state');
+      const localStorageKey = `oidc.${stateParam}`;
+
+      const localStorageValue = localStorage.getItem(localStorageKey);
+      const loginState = JSON.parse(localStorageValue || '{}');
+
+      return loginState?.request_type === 'si:p';
+    } catch (err) {
+      return false;
+    }
+  }
+
   public async loginCallback(): Promise<undefined | User> {
     return withPassportError<undefined | User>(async () => {
+      // ID-3950: https://github.com/authts/oidc-client-ts/issues/2043
+      // When using `signinPopup` to initiate a login, call the `signinPopupCallback` method and
+      // set the `keepOpen` flag to `true`, as the `login` method is now responsible for closing the popup.
+      // See the comment in the `login` method for more details.
+      if (AuthManager.shouldUseSigninPopupCallback()) {
+        await this.userManager.signinPopupCallback(undefined, true);
+        return undefined;
+      }
       const oidcUser = await this.userManager.signinCallback();
       if (!oidcUser) {
         return undefined;


### PR DESCRIPTION
# Summary
This PR mitigates an issue caused by the third-party OIDC library we use that results in the `login` promise not rejecting when the user closes the login popup. See [here](https://github.com/authts/oidc-client-ts/issues/2043) for more info.

# Detail and impact of the change
## Fixed
- Passport: Fixed an issue with calls to `login`, `eth_requestAccounts`, and `connectImx` not rejecting when the user closes the login popup.