### PR TITLE
feat(checkout): update swap widget to use sanctions v2 check

### DIFF
--- a/packages/checkout/sdk/src/index.ts
+++ b/packages/checkout/sdk/src/index.ts
@@ -156,7 +156,7 @@ export type {
   CheckoutWidgetsVersionConfig,
 } from './types';
 
-export { fetchRiskAssessment, isAddressSanctioned } from './riskAssessment';
+export { fetchRiskAssessment, fetchRiskAssessmentV2, isAddressSanctioned } from './riskAssessment';
 export type { AssessmentResult } from './riskAssessment';
 
 export type { ErrorType } from './errors';

--- a/packages/checkout/sdk/src/index.ts
+++ b/packages/checkout/sdk/src/index.ts
@@ -156,7 +156,13 @@ export type {
   CheckoutWidgetsVersionConfig,
 } from './types';
 
-export { fetchRiskAssessment, fetchRiskAssessmentV2, isAddressSanctioned } from './riskAssessment';
+export {
+  fetchRiskAssessment,
+  fetchRiskAssessmentV2,
+  isAddressSanctioned,
+  isSingleAddressSanctioned,
+  resultHasSanctionedWallets,
+} from './riskAssessment';
 export type { AssessmentResult } from './riskAssessment';
 
 export type { ErrorType } from './errors';

--- a/packages/checkout/sdk/src/riskAssessment/common.ts
+++ b/packages/checkout/sdk/src/riskAssessment/common.ts
@@ -1,0 +1,29 @@
+export type RiskAssessmentResponse = {
+  address: string;
+  risk: RiskAssessmentLevel;
+  risk_reason: string;
+};
+
+export enum RiskAssessmentLevel {
+  LOW = 'Low',
+  MEDIUM = 'Medium',
+  HIGH = 'High',
+  SEVERE = 'Severe',
+}
+
+export type AssessmentResult = {
+  [address: string]: {
+    sanctioned: boolean;
+  };
+};
+
+export const isAddressSanctioned = (
+  riskAssessment: AssessmentResult,
+  address?: string,
+): boolean => {
+  if (address) {
+    return riskAssessment[address.toLowerCase()].sanctioned;
+  }
+
+  return Object.values(riskAssessment).some((assessment) => assessment.sanctioned);
+};

--- a/packages/checkout/sdk/src/riskAssessment/common.ts
+++ b/packages/checkout/sdk/src/riskAssessment/common.ts
@@ -17,6 +17,7 @@ export type AssessmentResult = {
   };
 };
 
+// deprecated  - please use isSingleAddressSanctioned or resultHasSanctionedWallets
 export const isAddressSanctioned = (
   riskAssessment: AssessmentResult,
   address?: string,
@@ -27,3 +28,12 @@ export const isAddressSanctioned = (
 
   return Object.values(riskAssessment).some((assessment) => assessment.sanctioned);
 };
+
+export const isSingleAddressSanctioned = (
+  riskAssessment: AssessmentResult,
+  address: string,
+): boolean => riskAssessment[address.toLowerCase()].sanctioned;
+
+export const resultHasSanctionedWallets = (
+  riskAssessment: AssessmentResult,
+): boolean => Object.values(riskAssessment).some((assessment) => assessment.sanctioned);

--- a/packages/checkout/sdk/src/riskAssessment/index.ts
+++ b/packages/checkout/sdk/src/riskAssessment/index.ts
@@ -1,1 +1,3 @@
 export * from './riskAssessment';
+export * from './riskAssessmentV2';
+export * from './common';

--- a/packages/checkout/sdk/src/riskAssessment/riskAssessment.test.ts
+++ b/packages/checkout/sdk/src/riskAssessment/riskAssessment.test.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
-import { fetchRiskAssessment, isAddressSanctioned } from './riskAssessment';
+import { fetchRiskAssessment } from './riskAssessment';
+import { isAddressSanctioned } from './common';
 import { CheckoutConfiguration } from '../config';
 
 jest.mock('axios');

--- a/packages/checkout/sdk/src/riskAssessment/riskAssessmentV2.test.ts
+++ b/packages/checkout/sdk/src/riskAssessment/riskAssessmentV2.test.ts
@@ -1,0 +1,134 @@
+import axios, { AxiosResponse } from 'axios';
+import { fetchRiskAssessmentV2 } from './riskAssessmentV2';
+import { isAddressSanctioned } from './common';
+import { CheckoutConfiguration } from '../config';
+
+jest.mock('axios');
+
+describe('riskAssessmentV2', () => {
+  const mockedAxios = axios as jest.Mocked<typeof axios>;
+  const mockRemoteConfig = jest.fn();
+
+  const mockedConfig = {
+    remote: {
+      getConfig: mockRemoteConfig,
+    },
+  } as unknown as CheckoutConfiguration;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchRiskAssessmentV2', () => {
+    it('should fetch risk assessment and process it according to config', async () => {
+      mockRemoteConfig.mockResolvedValue({
+        enabled: true,
+        levels: ['severe'],
+      });
+
+      const address1 = '0x1234567890';
+      const address2 = '0xabcdef1234';
+
+      const mockRiskResponse = {
+        status: 200,
+        data: [{
+          address: address1,
+          risk: 'Low',
+          risk_reason: 'No reason',
+        }, {
+          address: address2,
+          risk: 'Severe',
+          risk_reason: 'Sanctioned',
+        }],
+      } as AxiosResponse;
+      mockedAxios.post.mockResolvedValueOnce(mockRiskResponse);
+
+      const sanctions = await fetchRiskAssessmentV2(
+        [
+          { address: address1, tokenAddr: '0xtest1', amount: '100' },
+          { address: address2, tokenAddr: '0xtest2', amount: '200' },
+        ],
+        mockedConfig,
+      );
+
+      expect(sanctions[address1.toLowerCase()]).toEqual({ sanctioned: false });
+      expect(sanctions[address2.toLowerCase()]).toEqual({ sanctioned: true });
+    });
+
+    it('should return default risk assessment if disabled', async () => {
+      mockRemoteConfig.mockResolvedValue({
+        enabled: false,
+        levels: [],
+      });
+
+      const address1 = '0x1234567890';
+
+      const sanctions = await fetchRiskAssessmentV2(
+        [{ address: address1, tokenAddr: 'native', amount: '100' }], // Include required fields even when disabled,
+        mockedConfig,
+      );
+
+      expect(sanctions[address1.toLowerCase()]).toEqual({ sanctioned: false });
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('should return default risk assessment on empty response', async () => {
+      mockRemoteConfig.mockResolvedValue({
+        enabled: true,
+        levels: ['severe'],
+      });
+
+      const address1 = '0x1234567890';
+
+      const mockRiskResponse = {
+        status: 200,
+        data: [],
+      } as AxiosResponse;
+      mockedAxios.post.mockResolvedValueOnce(mockRiskResponse);
+
+      const sanctions = await fetchRiskAssessmentV2(
+        [{ address: address1, tokenAddr: '0xtest', amount: '100' }],
+        mockedConfig,
+      );
+
+      expect(sanctions[address1.toLowerCase()]).toEqual({ sanctioned: false });
+    });
+  });
+
+  describe('isAddressSanctioned', () => {
+    it('should return true if any address is sanctioned', () => {
+      const assessment = {
+        '0x9999999123123123': {
+          sanctioned: false,
+        },
+        '0xabcdef1234567890': {
+          sanctioned: true,
+        },
+      };
+
+      expect(isAddressSanctioned(assessment)).toBe(true);
+    });
+
+    it('should return true if single address is sanctioned', () => {
+      const address = '0x1234567890ABCdef';
+      const assessment = {
+        [address.toLowerCase()]: {
+          sanctioned: true,
+        },
+      };
+
+      expect(isAddressSanctioned(assessment, address)).toBe(true);
+    });
+
+    it('should return false if single address is not sanctioned', () => {
+      const address = '0x1234567890ABCdef';
+      const assessment = {
+        [address.toLowerCase()]: {
+          sanctioned: false,
+        },
+      };
+
+      expect(isAddressSanctioned(assessment, address)).toBe(false);
+    });
+  });
+});

--- a/packages/checkout/sdk/src/riskAssessment/riskAssessmentV2.test.ts
+++ b/packages/checkout/sdk/src/riskAssessment/riskAssessmentV2.test.ts
@@ -45,8 +45,8 @@ describe('riskAssessmentV2', () => {
 
       const sanctions = await fetchRiskAssessmentV2(
         [
-          { address: address1, tokenAddr: '0xtest1', amount: '100' },
-          { address: address2, tokenAddr: '0xtest2', amount: '200' },
+          { address: address1, tokenAddr: '0xtest1', amount: BigInt(100) },
+          { address: address2, tokenAddr: '0xtest2', amount: BigInt(200) },
         ],
         mockedConfig,
       );
@@ -64,7 +64,8 @@ describe('riskAssessmentV2', () => {
       const address1 = '0x1234567890';
 
       const sanctions = await fetchRiskAssessmentV2(
-        [{ address: address1, tokenAddr: 'native', amount: '100' }], // Include required fields even when disabled,
+        // Include required fields even when disabled
+        [{ address: address1, tokenAddr: 'native', amount: BigInt(100) }],
         mockedConfig,
       );
 
@@ -87,7 +88,7 @@ describe('riskAssessmentV2', () => {
       mockedAxios.post.mockResolvedValueOnce(mockRiskResponse);
 
       const sanctions = await fetchRiskAssessmentV2(
-        [{ address: address1, tokenAddr: '0xtest', amount: '100' }],
+        [{ address: address1, tokenAddr: '0xtest', amount: BigInt(100) }],
         mockedConfig,
       );
 

--- a/packages/checkout/sdk/src/riskAssessment/riskAssessmentV2.ts
+++ b/packages/checkout/sdk/src/riskAssessment/riskAssessmentV2.ts
@@ -15,7 +15,7 @@ type SanctionsCheckV2RequestItem = {
 type AssessmentData = {
   address: string;
   tokenAddr: string;
-  amount: string;
+  amount: bigint;
 };
 
 export const fetchRiskAssessmentV2 = async (
@@ -41,7 +41,7 @@ export const fetchRiskAssessmentV2 = async (
     const requestPayload: SanctionsCheckV2RequestItem[] = assessmentData.map((data) => ({
       address: data.address,
       token_addr: data.tokenAddr,
-      amount: data.amount,
+      amount: data.amount.toString(),
     }));
 
     const response = await axios.post<RiskAssessmentResponse[]>(

--- a/packages/checkout/sdk/src/riskAssessment/riskAssessmentV2.ts
+++ b/packages/checkout/sdk/src/riskAssessment/riskAssessmentV2.ts
@@ -4,12 +4,26 @@ import { RiskAssessmentConfig } from '../types';
 import { CheckoutConfiguration } from '../config';
 import { AssessmentResult, RiskAssessmentResponse } from './common';
 
-export const fetchRiskAssessment = async (
-  addresses: string[],
+// New type for v2 request items
+type SanctionsCheckV2RequestItem = {
+  address: string;
+  amount: string;
+  token_addr: string;
+};
+
+// Simplified assessment data - no redundant address info
+type AssessmentData = {
+  address: string;
+  tokenAddr: string;
+  amount: string;
+};
+
+export const fetchRiskAssessmentV2 = async (
+  assessmentData: AssessmentData[],
   config: CheckoutConfiguration,
 ): Promise<AssessmentResult> => {
   const result = Object.fromEntries(
-    addresses.map((address) => [address.toLowerCase(), { sanctioned: false }]),
+    assessmentData.map((data) => [data.address.toLowerCase(), { sanctioned: false }]),
   );
 
   const riskConfig = (await config.remote.getConfig('riskAssessment')) as
@@ -23,11 +37,16 @@ export const fetchRiskAssessment = async (
   try {
     const riskLevels = riskConfig?.levels.map((l) => l.toLowerCase()) ?? [];
 
+    // Prepare v2 request payload - always include token data
+    const requestPayload: SanctionsCheckV2RequestItem[] = assessmentData.map((data) => ({
+      address: data.address,
+      token_addr: data.tokenAddr,
+      amount: data.amount,
+    }));
+
     const response = await axios.post<RiskAssessmentResponse[]>(
-      `${IMMUTABLE_API_BASE_URL[config.environment]}/v1/sanctions/check`,
-      {
-        addresses,
-      },
+      `${IMMUTABLE_API_BASE_URL[config.environment]}/v2/sanctions/check`,
+      requestPayload,
     );
 
     for (const assessment of response.data) {

--- a/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/SwapWidget.tsx
@@ -9,7 +9,6 @@ import {
 import {
   TokenFilterTypes, IMTBLWidgetEvents, SwapWidgetParams,
   SwapDirection,
-  fetchRiskAssessment,
   WalletProviderName,
 } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
@@ -190,28 +189,6 @@ export default function SwapWidget({
       if (viewState.view.type === SharedViews.LOADING_VIEW) {
         showSwapView();
       }
-    })();
-  }, [checkout, provider]);
-
-  useEffect(() => {
-    if (!checkout || swapState.riskAssessment) {
-      return;
-    }
-
-    (async () => {
-      const address = await (await provider?.getSigner())?.getAddress();
-
-      if (!address) {
-        return;
-      }
-
-      const assessment = await fetchRiskAssessment([address], checkout.config);
-      swapDispatch({
-        payload: {
-          type: SwapActions.SET_RISK_ASSESSMENT,
-          riskAssessment: assessment,
-        },
-      });
     })();
   }, [checkout, provider]);
 

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -6,7 +6,7 @@ import {
   Box, ButtCon, Heading, Icon, OptionKey, Tooltip, Body,
 } from '@biom3/react';
 import {
-  fetchRiskAssessment,
+  fetchRiskAssessmentV2,
   isAddressSanctioned,
   TokenInfo,
   WidgetTheme,
@@ -854,7 +854,15 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
       return;
     }
 
-    const riskAssessment = await fetchRiskAssessment([address], checkout.config);
+    // As this is post form data validation, the fallback values is unecessary and only to satisfy type correctess.
+    // Ideally once the form data is validated it should be converted into a not null type to reflect its validity.
+    const riskAssessmentData = [{
+      address,
+      tokenAddr: data?.fromTokenAddress || '',
+      amount: data?.fromAmount || '',
+    }];
+
+    const riskAssessment = await fetchRiskAssessmentV2(riskAssessmentData, checkout.config);
 
     if (riskAssessment && isAddressSanctioned(riskAssessment)) {
       viewDispatch({

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -7,7 +7,7 @@ import {
 } from '@biom3/react';
 import {
   fetchRiskAssessmentV2,
-  isAddressSanctioned,
+  isSingleAddressSanctioned,
   TokenInfo,
   WidgetTheme,
 } from '@imtbl/checkout-sdk';
@@ -864,7 +864,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
 
     const riskAssessment = await fetchRiskAssessmentV2(riskAssessmentData, checkout.config);
 
-    if (riskAssessment && isAddressSanctioned(riskAssessment)) {
+    if (riskAssessment && isSingleAddressSanctioned(riskAssessment, address)) {
       viewDispatch({
         payload: {
           type: ViewActions.UPDATE_VIEW,

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -861,7 +861,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     const riskAssessmentData = [{
       address,
       tokenAddr: fromToken.address,
-      amount: parseUnits(fromAmount, fromToken.decimals).toString(),
+      amount: parseUnits(fromAmount, fromToken.decimals),
     }];
 
     const riskAssessment = await fetchRiskAssessmentV2(riskAssessmentData, checkout.config);

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -828,12 +828,12 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
       control: 'Swap',
       controlType: 'Button',
       extras: {
-        swapFromAddress: data?.fromTokenAddress,
-        swapFromAmount: data?.fromAmount,
-        swapFromTokenSymbol: data?.fromTokenSymbol,
-        swapToAddress: data?.toTokenAddress,
-        swapToAmount: data?.toAmount,
-        swapToTokenSymbol: data?.toTokenSymbol,
+        swapFromAddress: fromToken?.address,
+        swapFromAmount: fromAmount,
+        swapFromTokenSymbol: fromToken?.symbol,
+        swapToAddress: toToken?.address,
+        swapToAmount: toAmount,
+        swapToTokenSymbol: toToken?.symbol,
         isSwapFormValid: isValid,
         hasFundsForGas: !insufficientFundsForGas,
         autoProceed,
@@ -854,12 +854,14 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
       return;
     }
 
-    // As this is post form data validation, the fallback values is unecessary and only to satisfy type correctess.
-    // Ideally once the form data is validated it should be converted into a not null type to reflect its validity.
+    if (!fromToken?.address || !fromAmount) {
+      throw new Error('Invalid form data: fromToken.Address or fromAmount is missing');
+    }
+
     const riskAssessmentData = [{
       address,
-      tokenAddr: data?.fromTokenAddress || '',
-      amount: data?.fromAmount || '',
+      tokenAddr: fromToken.address,
+      amount: fromAmount,
     }];
 
     const riskAssessment = await fetchRiskAssessmentV2(riskAssessmentData, checkout.config);

--- a/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/swap/components/SwapForm.tsx
@@ -861,7 +861,7 @@ export function SwapForm({ data, theme, cancelAutoProceed }: SwapFromProps) {
     const riskAssessmentData = [{
       address,
       tokenAddr: fromToken.address,
-      amount: fromAmount,
+      amount: parseUnits(fromAmount, fromToken.decimals).toString(),
     }];
 
     const riskAssessment = await fetchRiskAssessmentV2(riskAssessmentData, checkout.config);

--- a/packages/checkout/widgets-lib/src/widgets/swap/context/SwapContext.ts
+++ b/packages/checkout/widgets-lib/src/widgets/swap/context/SwapContext.ts
@@ -4,7 +4,6 @@ import {
   NetworkInfo,
   TokenInfo,
   SwapDirection,
-  AssessmentResult,
 } from '@imtbl/checkout-sdk';
 import { Exchange } from '@imtbl/dex-sdk';
 import { createContext } from 'react';
@@ -17,7 +16,6 @@ export interface SwapState {
   supportedTopUps: TopUpFeature | null;
   allowedTokens: TokenInfo[];
   autoProceed: boolean;
-  riskAssessment: AssessmentResult | undefined;
 }
 
 export interface TopUpFeature {
@@ -34,7 +32,6 @@ export const initialSwapState: SwapState = {
   supportedTopUps: null,
   allowedTokens: [],
   autoProceed: false,
-  riskAssessment: undefined,
 };
 
 export interface SwapContextState {
@@ -53,8 +50,7 @@ type ActionPayload =
   | SetSupportedTopUpPayload
   | SetTokenBalancesPayload
   | SetAllowedTokensPayload
-  | SetAutoProceedPayload
-  | SetRiskAssessmentPayload;
+  | SetAutoProceedPayload;
 
 export enum SwapActions {
   SET_EXCHANGE = 'SET_EXCHANGE',
@@ -64,7 +60,6 @@ export enum SwapActions {
   SET_TOKEN_BALANCES = 'SET_TOKEN_BALANCES',
   SET_ALLOWED_TOKENS = 'SET_ALLOWED_TOKENS',
   SET_AUTO_PROCEED = 'SET_AUTO_PROCEED',
-  SET_RISK_ASSESSMENT = 'SET_RISK_ASSESSMENT',
 }
 
 export interface SetExchangePayload {
@@ -101,11 +96,6 @@ export interface SetAutoProceedPayload {
   type: SwapActions.SET_AUTO_PROCEED;
   autoProceed: boolean;
   direction: SwapDirection;
-}
-
-export interface SetRiskAssessmentPayload {
-  type: SwapActions.SET_RISK_ASSESSMENT;
-  riskAssessment: AssessmentResult;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -164,11 +154,6 @@ export const swapReducer: Reducer<SwapState, SwapAction> = (
         ...state,
         autoProceed: action.payload.autoProceed,
         direction: action.payload.direction,
-      };
-    case SwapActions.SET_RISK_ASSESSMENT:
-      return {
-        ...state,
-        riskAssessment: action.payload.riskAssessment,
       };
     default:
       return state;


### PR DESCRIPTION
# Summary

- Added seperate call to V2 sanctions API in risk assessment lib
- Updated swaps widget to call new sanctions check as part of the Swap flow 
  - Now that the check is being consumed as soon as it is done, there is no need to store the result in state and we can therefore remove
