### PR TITLE
chore(checkout): update primary sale widget to use sanctions v2 endpoint

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -246,6 +246,9 @@ export function SaleContextProvider(props: {
     getUserInfo();
   }, [provider]);
 
+  // TODO: check if this is can be removed. It is used on switching payment method to credit/debit.
+  // Need to check with legal if we can remove the sanction check for fiat payments and rely on
+  // third party checks, as our V2 sanctions API required token details.
   useEffect(() => {
     if (!checkout || riskAssessment) {
       return;

--- a/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/context/SaleContextProvider.tsx
@@ -1,6 +1,4 @@
 import {
-  AssessmentResult,
-  fetchRiskAssessment,
   FundingRoute,
   SaleItem, SalePaymentTypes,
 } from '@imtbl/checkout-sdk';
@@ -98,7 +96,6 @@ type SaleContextValues = SaleContextProps & {
   orderQuote: OrderQuote;
   signTokenIds: string[];
   selectedCurrency: OrderQuoteCurrency | undefined;
-  riskAssessment: AssessmentResult | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -141,7 +138,6 @@ const SaleContext = createContext<SaleContextValues>({
   selectedCurrency: undefined,
   waitFulfillmentSettlements: true,
   hideExcludedPaymentTypes: false,
-  riskAssessment: undefined,
 });
 
 SaleContext.displayName = 'SaleSaleContext';
@@ -206,8 +202,6 @@ export function SaleContextProvider(props: {
 
   const [invalidParameters, setInvalidParameters] = useState<boolean>(false);
 
-  const [riskAssessment, setRiskAssessment] = useState<AssessmentResult | undefined>();
-
   const { selectedCurrency, orderQuote, orderQuoteError } = useQuoteOrder({
     items,
     provider,
@@ -245,26 +239,6 @@ export function SaleContextProvider(props: {
 
     getUserInfo();
   }, [provider]);
-
-  // TODO: check if this is can be removed. It is used on switching payment method to credit/debit.
-  // Need to check with legal if we can remove the sanction check for fiat payments and rely on
-  // third party checks, as our V2 sanctions API required token details.
-  useEffect(() => {
-    if (!checkout || riskAssessment) {
-      return;
-    }
-
-    (async () => {
-      const address = await (await provider?.getSigner())?.getAddress();
-
-      if (!address) {
-        return;
-      }
-
-      const assessment = await fetchRiskAssessment([address], checkout.config);
-      setRiskAssessment(assessment);
-    })();
-  }, [checkout, provider]);
 
   const {
     sign: signOrder,
@@ -419,7 +393,6 @@ export function SaleContextProvider(props: {
       selectedCurrency,
       waitFulfillmentSettlements,
       hideExcludedPaymentTypes,
-      riskAssessment,
     }),
     [
       config,
@@ -454,7 +427,6 @@ export function SaleContextProvider(props: {
       selectedCurrency,
       waitFulfillmentSettlements,
       hideExcludedPaymentTypes,
-      riskAssessment,
     ],
   );
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -108,7 +108,7 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
     }
 
     if (!fundingItem.token.address) {
-      throw new Error('Invalid data: fundingItem.token is missing');
+      throw new Error('Invalid data: fundingItem.token.address is missing');
     }
 
     const riskAssessmentData = [{

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PaymentMethods.tsx
@@ -1,7 +1,7 @@
 import { Box, Heading } from '@biom3/react';
 import { useContext, useEffect } from 'react';
 
-import { isAddressSanctioned, SalePaymentTypes } from '@imtbl/checkout-sdk';
+import { SalePaymentTypes } from '@imtbl/checkout-sdk';
 import { useTranslation } from 'react-i18next';
 import { FooterLogo } from '../../../components/Footer/FooterLogo';
 import { HeaderNavigation } from '../../../components/Header/HeaderNavigation';
@@ -32,10 +32,9 @@ export function PaymentMethods() {
     invalidParameters,
     disabledPaymentTypes,
     hideExcludedPaymentTypes,
-    riskAssessment,
   } = useSaleContext();
   const {
-    sendFailedEvent, sendPageView, sendCloseEvent, sendSelectedPaymentMethod,
+    sendPageView, sendCloseEvent, sendSelectedPaymentMethod,
   } = useSaleEvent();
 
   const handleOptionClick = (type: SalePaymentTypes) => {
@@ -51,25 +50,6 @@ export function PaymentMethods() {
       paymentMethod
       && [SalePaymentTypes.DEBIT, SalePaymentTypes.CREDIT].includes(paymentMethod)
     ) {
-      if (riskAssessment && isAddressSanctioned(riskAssessment)) {
-        const error = new Error('Sanctioned address');
-        sendFailedEvent(error.message, {}, [], undefined, { riskAssessment, paymentMethod });
-
-        viewDispatch({
-          payload: {
-            type: ViewActions.UPDATE_VIEW,
-            view: {
-              type: SharedViews.SERVICE_UNAVAILABLE_ERROR_VIEW,
-              error,
-            },
-          },
-        });
-
-        setPaymentMethod(undefined);
-
-        return;
-      }
-
       sign(SignPaymentTypes.FIAT, undefined, () => {
         viewDispatch({
           payload: {


### PR DESCRIPTION
# Summary

Primary sales widget current behaviour:

- Perform a wallet based (V1) sanctions check on widget mount
- Check sanction result and error out if sanctioned
  - when a uses selects credit or debit payment type
  - when a user proceeeds to buy with a token

This PR: 

- upgrades the second case to use the V2 sanctions endpoint as the token details are known
  - calculate the sale amount using the same displayed price calculations as done in the UI for the OrderItems list
- removes the first case as we can safely rely on the third party provider (transak) checks of their own
- remove risk assessment from context state as it is no longer used

## Screenshots

### Requests

Uses the correct total sale price regardless of whether balance is sufficient or not


<img width="483" height="684" alt="Screenshot 2025-09-08 at 10 20 47 am" src="https://github.com/user-attachments/assets/daee1054-31c5-4ebd-8669-5975e6b7e915" />
<img width="737" height="334" alt="Screenshot 2025-09-08 at 10 21 45 am" src="https://github.com/user-attachments/assets/103f5380-8cf4-4722-a3b6-72a19f5baa22" />
<img width="511" height="669" alt="Screenshot 2025-09-08 at 10 22 03 am" src="https://github.com/user-attachments/assets/bd769245-4110-48ff-84a5-c4ef6d888b5a" />
<img width="677" height="301" alt="Screenshot 2025-09-08 at 10 22 20 am" src="https://github.com/user-attachments/assets/b15cc4f8-c1f4-490c-a856-96713c0e26b5" />
<img width="522" height="667" alt="Screenshot 2025-09-08 at 10 22 43 am" src="https://github.com/user-attachments/assets/7202396a-69da-42eb-8e55-bf1109842c27" />
<img width="780" height="319" alt="Screenshot 2025-09-08 at 10 22 53 am" src="https://github.com/user-attachments/assets/e5d128ed-6ba2-4f6b-a659-06accbdca3f3" />

