### PR TITLE
fix(docs): update docs generation action to account for multiple tags

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -28,14 +28,19 @@ jobs:
       - name: Check alpha version
         id: alpha_check
         run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          if echo "$VERSION" | grep -q "alpha"; then
-            echo "Skipping docs generation for alpha version"
-            echo "is_alpha=true" >> $GITHUB_OUTPUT
-            exit 0
-          else
+          # Get all tags on current commit
+          TAGS=$(git tag --points-at HEAD)
+          echo "Tags on current commit: $TAGS"
+          
+          # Check if any of them are non-alpha
+          if echo "$TAGS" | grep -v alpha | grep -q .; then
+            echo "Found non-alpha tag(s) on current commit"
             echo "Generating docs for non-alpha version"
             echo "is_alpha=false" >> $GITHUB_OUTPUT
+          else
+            echo "No non-alpha tags found on current commit"
+            echo "Skipping docs generation for alpha version"
+            echo "is_alpha=true" >> $GITHUB_OUTPUT
           fi
         shell: bash
 


### PR DESCRIPTION
# Summary
The sdk reference is not published for alpha versions, but the `AlphaCheck` step of the workflow was always returning is_alpha=true due to us using multiple tags. I've updated the logic to check all tags and publish if there is any non-alpha tag.

# Detail and impact of the change
There should not be any impact except for allowing this workflow to progress to the second stage of `PublishDocs` when the release is a public stable version.  