### PR TITLE
feat(passport): ID-3934: Render the headless login / embedded login prompt

### DIFF
--- a/packages/passport/sdk/src/Passport.ts
+++ b/packages/passport/sdk/src/Passport.ts
@@ -27,7 +27,7 @@ import {
   User,
   UserProfile,
 } from './types';
-import { ConfirmationScreen } from './confirmation';
+import { ConfirmationScreen, EmbeddedLoginPrompt } from './confirmation';
 import { ZkEvmProvider } from './zkEvm';
 import { Provider } from './zkEvm/types';
 import TypedEventEmitter from './utils/typedEventEmitter';
@@ -57,7 +57,8 @@ const buildImxApiClients = (passportModuleConfiguration: PassportModuleConfigura
 
 export const buildPrivateVars = (passportModuleConfiguration: PassportModuleConfiguration) => {
   const config = new PassportConfiguration(passportModuleConfiguration);
-  const authManager = new AuthManager(config);
+  const embeddedLoginPrompt = new EmbeddedLoginPrompt(config);
+  const authManager = new AuthManager(config, embeddedLoginPrompt);
   const magicProviderProxyFactory = new MagicProviderProxyFactory(authManager, config);
   const magicAdapter = new MagicAdapter(config, magicProviderProxyFactory);
   const confirmationScreen = new ConfirmationScreen(config);
@@ -91,6 +92,7 @@ export const buildPrivateVars = (passportModuleConfiguration: PassportModuleConf
     authManager,
     magicAdapter,
     confirmationScreen,
+    embeddedLoginPrompt,
     immutableXClient,
     multiRollupApiClients,
     passportEventEmitter,
@@ -105,6 +107,8 @@ export class Passport {
   private readonly config: PassportConfiguration;
 
   private readonly confirmationScreen: ConfirmationScreen;
+
+  private readonly embeddedLoginPrompt: EmbeddedLoginPrompt;
 
   private readonly immutableXClient: IMXClient;
 
@@ -125,6 +129,7 @@ export class Passport {
     this.authManager = privateVars.authManager;
     this.magicAdapter = privateVars.magicAdapter;
     this.confirmationScreen = privateVars.confirmationScreen;
+    this.embeddedLoginPrompt = privateVars.embeddedLoginPrompt;
     this.immutableXClient = privateVars.immutableXClient;
     this.multiRollupApiClients = privateVars.multiRollupApiClients;
     this.passportEventEmitter = privateVars.passportEventEmitter;

--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -2,7 +2,7 @@ import { Environment, ImmutableConfiguration } from '@imtbl/config';
 import { User as OidcUser, UserManager, WebStorageStateStore } from 'oidc-client-ts';
 import jwt_decode from 'jwt-decode';
 import AuthManager from './authManager';
-import Overlay from './overlay';
+import ConfirmationOverlay from './overlay/confirmationOverlay';
 import { PassportError, PassportErrorType } from './errors/passportError';
 import { PassportConfiguration } from './config';
 import { mockUser, mockUserImx, mockUserZkEvm } from './test/mocks';
@@ -139,7 +139,7 @@ describe('AuthManager', () => {
         },
       },
     }));
-    (Overlay as jest.Mock).mockReturnValue({
+    (ConfirmationOverlay as jest.Mock).mockReturnValue({
       append: mockOverlayAppend,
       remove: mockOverlayRemove,
     });
@@ -411,7 +411,7 @@ describe('AuthManager', () => {
         const result = await am.login();
 
         expect(result).toEqual(mockUser);
-        expect(Overlay).toHaveBeenCalledWith(configWithPopupOverlayOptions.popupOverlayOptions, true);
+        expect(ConfirmationOverlay).toHaveBeenCalledWith(configWithPopupOverlayOptions.popupOverlayOptions, true);
         expect(mockOverlayAppend).toHaveBeenCalledTimes(1);
       });
 

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -28,8 +28,9 @@ import {
   isUserImx,
 } from './types';
 import { PassportConfiguration } from './config';
-import Overlay from './overlay';
+import ConfirmationOverlay from './overlay/confirmationOverlay';
 import { LocalForageAsyncStorage } from './storage/LocalForageAsyncStorage';
+import { EmbeddedLoginPrompt } from './confirmation';
 
 const LOGIN_POPUP_CLOSED_POLLING_DURATION = 500;
 
@@ -111,6 +112,8 @@ export default class AuthManager {
 
   private readonly config: PassportConfiguration;
 
+  private readonly embeddedLoginPrompt: EmbeddedLoginPrompt;
+
   private readonly logoutMode: Exclude<OidcConfiguration['logoutMode'], undefined>;
 
   /**
@@ -118,10 +121,11 @@ export default class AuthManager {
    */
   private refreshingPromise: Promise<User | null> | null = null;
 
-  constructor(config: PassportConfiguration) {
+  constructor(config: PassportConfiguration, embeddedLoginPrompt: EmbeddedLoginPrompt) {
     this.config = config;
     this.userManager = new UserManager(getAuthConfiguration(config));
     this.deviceCredentialsManager = new DeviceCredentialsManager();
+    this.embeddedLoginPrompt = embeddedLoginPrompt;
     this.logoutMode = config.oidcConfiguration.logoutMode || 'redirect';
   }
 
@@ -228,9 +232,18 @@ export default class AuthManager {
    */
   public async login(anonymousId?: string, directLoginOptions?: DirectLoginOptions): Promise<User> {
     return withPassportError<User>(async () => {
+      let directLoginOptionsToUse: DirectLoginOptions | undefined;
+      if (directLoginOptions) {
+        directLoginOptionsToUse = directLoginOptions;
+      } else {
+        directLoginOptionsToUse = await this.embeddedLoginPrompt.displayEmbeddedLoginPrompt();
+      }
+
+      console.log('directLoginOptionsToUse', directLoginOptionsToUse);
+
       const popupWindowTarget = window.crypto.randomUUID();
       const signinPopup = async () => {
-        const extraQueryParams = this.buildExtraQueryParams(anonymousId, directLoginOptions);
+        const extraQueryParams = this.buildExtraQueryParams(anonymousId, directLoginOptionsToUse);
 
         const userPromise = this.userManager.signinPopup({
           extraQueryParams,
@@ -287,7 +300,7 @@ export default class AuthManager {
 
             // Popup was blocked; append the blocked popup overlay to allow the user to try again.
             let popupHasBeenOpened: boolean = false;
-            const overlay = new Overlay(this.config.popupOverlayOptions, true);
+            const overlay = new ConfirmationOverlay(this.config.popupOverlayOptions, true);
             overlay.append(
               async () => {
                 try {

--- a/packages/passport/sdk/src/confirmation/confirmation.test.ts
+++ b/packages/passport/sdk/src/confirmation/confirmation.test.ts
@@ -7,7 +7,7 @@ import ConfirmationScreen from './confirmation';
 import SpyInstance = jest.SpyInstance;
 import { testConfig } from '../test/mocks';
 import { PassportConfiguration } from '../config';
-import { PASSPORT_EVENT_TYPE, ReceiveMessage } from './types';
+import { PASSPORT_CONFIRMATION_EVENT_TYPE, ConfirmationReceiveMessage } from './types';
 
 let windowSpy: SpyInstance;
 const closeMock = jest.fn();
@@ -92,8 +92,8 @@ describe('confirmation', () => {
       const mockedWindowReadyValue = {
         origin: testConfig.passportDomain,
         data: {
-          eventType: PASSPORT_EVENT_TYPE,
-          messageType: ReceiveMessage.CONFIRMATION_WINDOW_READY,
+          eventType: PASSPORT_CONFIRMATION_EVENT_TYPE,
+          messageType: ConfirmationReceiveMessage.CONFIRMATION_WINDOW_READY,
         },
       };
       addEventListenerMock
@@ -126,8 +126,8 @@ describe('confirmation', () => {
             callback({
               origin: testConfig.passportDomain,
               data: {
-                eventType: PASSPORT_EVENT_TYPE,
-                messageType: ReceiveMessage.TRANSACTION_REJECTED,
+                eventType: PASSPORT_CONFIRMATION_EVENT_TYPE,
+                messageType: ConfirmationReceiveMessage.TRANSACTION_REJECTED,
               },
             });
           });
@@ -179,8 +179,8 @@ describe('confirmation', () => {
       const mockedWindowReadyValue = {
         origin: testConfig.passportDomain,
         data: {
-          eventType: PASSPORT_EVENT_TYPE,
-          messageType: ReceiveMessage.CONFIRMATION_WINDOW_READY,
+          eventType: PASSPORT_CONFIRMATION_EVENT_TYPE,
+          messageType: ConfirmationReceiveMessage.CONFIRMATION_WINDOW_READY,
         },
       };
       addEventListenerMock
@@ -209,8 +209,8 @@ describe('confirmation', () => {
             callback({
               origin: testConfig.passportDomain,
               data: {
-                eventType: PASSPORT_EVENT_TYPE,
-                messageType: ReceiveMessage.MESSAGE_REJECTED,
+                eventType: PASSPORT_CONFIRMATION_EVENT_TYPE,
+                messageType: ConfirmationReceiveMessage.MESSAGE_REJECTED,
               },
             });
           });

--- a/packages/passport/sdk/src/confirmation/embeddedLoginPrompt.ts
+++ b/packages/passport/sdk/src/confirmation/embeddedLoginPrompt.ts
@@ -1,0 +1,95 @@
+import { trackError } from '@imtbl/metrics';
+
+import {
+  EMBEDDED_LOGIN_PROMPT_EVENT_TYPE,
+  EmbeddedLoginPromptResult,
+  EmbeddedLoginPromptReceiveMessage,
+} from './types';
+import { PassportConfiguration } from '../config';
+import EmbeddedLoginPromptOverlay from '../overlay/embeddedLoginPromptOverlay';
+import { DirectLoginOptions } from '../types';
+
+const LOGIN_PROMPT_WINDOW_HEIGHT = 560;
+const LOGIN_PROMPT_WINDOW_WIDTH = 440;
+const LOGIN_PROMPT_WINDOW_BORDER_RADIUS = '16px';
+
+export default class EmbeddedLoginPrompt {
+  private config: PassportConfiguration;
+
+  constructor(config: PassportConfiguration) {
+    this.config = config;
+  }
+
+  private getHref = (clientId: string) => (
+    // `${this.config.authenticationDomain}/im-embedded-login-prompt?client_id=${clientId}`
+    `http://localhost:3001/im-embedded-login-prompt?client_id=${clientId}`
+  );
+
+  private getEmbeddedLoginIFrame = () => {
+    const embeddedLoginPrompt = document.createElement('iframe');
+    embeddedLoginPrompt.src = this.getHref(this.config.oidcConfiguration.clientId);
+    embeddedLoginPrompt.style.width = `${LOGIN_PROMPT_WINDOW_WIDTH}px`;
+    embeddedLoginPrompt.style.height = `${LOGIN_PROMPT_WINDOW_HEIGHT}px`;
+    embeddedLoginPrompt.style.borderRadius = LOGIN_PROMPT_WINDOW_BORDER_RADIUS;
+
+    return embeddedLoginPrompt;
+  }
+
+  displayEmbeddedLoginPrompt(): Promise<DirectLoginOptions> {
+    return new Promise((resolve, reject) => {
+      const embeddedLoginPrompt = this.getEmbeddedLoginIFrame();
+      console.log('embeddedLoginPrompt', embeddedLoginPrompt);
+
+      const messageHandler = ({ data, origin }: MessageEvent) => {
+        if (
+          // origin !== this.config.authenticationDomain
+          origin !== 'http://localhost:3001'
+          || data.eventType !== EMBEDDED_LOGIN_PROMPT_EVENT_TYPE
+        ) {
+          return;
+        }
+
+        switch (data.messageType as EmbeddedLoginPromptReceiveMessage) {
+          case EmbeddedLoginPromptReceiveMessage.LOGIN_METHOD_SELECTED: {
+            const loginMethod = data.loginMethod as EmbeddedLoginPromptResult;
+            let result: DirectLoginOptions;
+            if (loginMethod.loginType === 'email') {
+              result = {
+                directLoginMethod: 'email',
+                marketingConsentStatus: loginMethod.marketingConsent,
+                email: loginMethod.emailAddress,
+              };
+            } else {
+              result = {
+                directLoginMethod: loginMethod.loginType,
+                marketingConsentStatus: loginMethod.marketingConsent,
+              };
+            }
+            resolve(result);
+            this.closeWindow();
+            break;
+          }
+          case EmbeddedLoginPromptReceiveMessage.LOGIN_PROMPT_ERROR: {
+            this.closeWindow();
+            reject(new Error('Error during embedded login prompt'));
+            break;
+          }
+          default:
+            this.closeWindow();
+            reject(new Error('Unsupported message type'));
+        }
+      };
+
+      window.addEventListener('message', messageHandler);
+      EmbeddedLoginPromptOverlay.appendOverlay(embeddedLoginPrompt, () => {
+        this.closeWindow();
+        window.removeEventListener('message', messageHandler);
+        reject(new Error('Popup closed by user'));
+      });
+    });
+  }
+
+  closeWindow() {
+    EmbeddedLoginPromptOverlay.remove();
+  }
+}

--- a/packages/passport/sdk/src/confirmation/index.ts
+++ b/packages/passport/sdk/src/confirmation/index.ts
@@ -1,2 +1,3 @@
 export { default as ConfirmationScreen } from './confirmation';
+export { default as EmbeddedLoginPrompt } from './embeddedLoginPrompt';
 export * from './types';

--- a/packages/passport/sdk/src/confirmation/types.ts
+++ b/packages/passport/sdk/src/confirmation/types.ts
@@ -1,8 +1,10 @@
-export enum SendMessage {
+import { DirectLoginMethod, MarketingConsentStatus } from "../types";
+
+export enum ConfirmationSendMessage {
   CONFIRMATION_START = 'confirmation_start',
 }
 
-export enum ReceiveMessage {
+export enum ConfirmationReceiveMessage {
   CONFIRMATION_WINDOW_READY = 'confirmation_window_ready',
   TRANSACTION_CONFIRMED = 'transaction_confirmed',
   TRANSACTION_ERROR = 'transaction_error',
@@ -12,8 +14,21 @@ export enum ReceiveMessage {
   MESSAGE_REJECTED = 'message_rejected',
 }
 
+export enum EmbeddedLoginPromptReceiveMessage {
+  LOGIN_METHOD_SELECTED = 'login_method_selected',
+  LOGIN_PROMPT_ERROR = 'login_prompt_error',
+}
+
 export type ConfirmationResult = {
   confirmed: boolean;
 };
 
-export const PASSPORT_EVENT_TYPE = 'imx_passport_confirmation';
+export type EmbeddedLoginPromptResult = {
+  marketingConsent: MarketingConsentStatus;
+} & (
+  | { loginType: 'email'; emailAddress: string }
+  | { loginType: Exclude<DirectLoginMethod, 'email'>; emailAddress?: never }
+);
+
+export const PASSPORT_CONFIRMATION_EVENT_TYPE = 'imx_passport_confirmation';
+export const EMBEDDED_LOGIN_PROMPT_EVENT_TYPE = 'im_passport_embedded_login_prompt';

--- a/packages/passport/sdk/src/overlay/confirmationOverlay.test.ts
+++ b/packages/passport/sdk/src/overlay/confirmationOverlay.test.ts
@@ -1,54 +1,54 @@
-import Overlay from './index';
+import ConfirmationOverlay from './confirmationOverlay';
 
-describe('overlay', () => {
+describe('confirmationOverlay', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
   });
 
   it('should append generic overlay', () => {
-    const overlay = new Overlay({}, false);
+    const overlay = new ConfirmationOverlay({}, false);
     overlay.append(() => {}, () => {});
     expect(document.body.innerHTML).toContain('passport-overlay');
   });
 
   it('should append blocked overlay', () => {
-    const overlay = new Overlay({}, true);
+    const overlay = new ConfirmationOverlay({}, true);
     overlay.append(() => {}, () => {});
     expect(document.body.innerHTML).toContain('passport-overlay');
   });
 
   it('should not append generic overlay when generic disabled', () => {
-    const overlay = new Overlay({ disableGenericPopupOverlay: true }, false);
+    const overlay = new ConfirmationOverlay({ disableGenericPopupOverlay: true }, false);
     overlay.append(() => {}, () => {});
     expect(document.body.innerHTML).not.toContain('passport-overlay');
   });
 
   it('should append overlay if only generic disabled and is blocked', () => {
-    const overlay = new Overlay({ disableGenericPopupOverlay: true }, true);
+    const overlay = new ConfirmationOverlay({ disableGenericPopupOverlay: true }, true);
     overlay.append(() => {}, () => {});
     expect(document.body.innerHTML).toContain('passport-overlay');
   });
 
   it('should not append blocked overlay when blocked disabled', () => {
-    const overlay = new Overlay({ disableBlockedPopupOverlay: true }, true);
+    const overlay = new ConfirmationOverlay({ disableBlockedPopupOverlay: true }, true);
     overlay.append(() => {}, () => {});
     expect(document.body.innerHTML).not.toContain('passport-overlay');
   });
 
   it('should append generic overlay when only blocked disabled', () => {
-    const overlay = new Overlay({ disableBlockedPopupOverlay: true }, false);
+    const overlay = new ConfirmationOverlay({ disableBlockedPopupOverlay: true }, false);
     overlay.append(() => {}, () => {});
     expect(document.body.innerHTML).toContain('passport-overlay');
   });
 
   it('should not append generic overlay when overlays disabled', () => {
-    const overlay = new Overlay({ disableGenericPopupOverlay: true, disableBlockedPopupOverlay: true }, false);
+    const overlay = new ConfirmationOverlay({ disableGenericPopupOverlay: true, disableBlockedPopupOverlay: true }, false);
     overlay.append(() => {}, () => {});
     expect(document.body.innerHTML).not.toContain('passport-overlay');
   });
 
   it('should not append blocked overlay when overlays disabled', () => {
-    const overlay = new Overlay({ disableGenericPopupOverlay: true, disableBlockedPopupOverlay: true }, true);
+    const overlay = new ConfirmationOverlay({ disableGenericPopupOverlay: true, disableBlockedPopupOverlay: true }, true);
     overlay.append(() => {}, () => {});
     expect(document.body.innerHTML).not.toContain('passport-overlay');
   });

--- a/packages/passport/sdk/src/overlay/confirmationOverlay.ts
+++ b/packages/passport/sdk/src/overlay/confirmationOverlay.ts
@@ -2,7 +2,7 @@ import { PopupOverlayOptions } from '../types';
 import { PASSPORT_OVERLAY_CLOSE_ID, PASSPORT_OVERLAY_TRY_AGAIN_ID } from './constants';
 import { addLink, getBlockedOverlay, getGenericOverlay } from './elements';
 
-export default class Overlay {
+export default class ConfirmationOverlay {
   private disableGenericPopupOverlay: boolean;
 
   private disableBlockedPopupOverlay: boolean;

--- a/packages/passport/sdk/src/overlay/constants.ts
+++ b/packages/passport/sdk/src/overlay/constants.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 
 export const PASSPORT_OVERLAY_ID = 'passport-overlay';
+export const PASSPORT_OVERLAY_CONTENTS_ID = 'passport-overlay-contents';
 export const PASSPORT_OVERLAY_CLOSE_ID = `${PASSPORT_OVERLAY_ID}-close`;
 export const PASSPORT_OVERLAY_TRY_AGAIN_ID = `${PASSPORT_OVERLAY_ID}-try-again`;
 

--- a/packages/passport/sdk/src/overlay/elements.ts
+++ b/packages/passport/sdk/src/overlay/elements.ts
@@ -5,6 +5,7 @@ import {
   PASSPORT_OVERLAY_CLOSE_ID,
   PASSPORT_OVERLAY_ID,
   PASSPORT_OVERLAY_TRY_AGAIN_ID,
+  PASSPORT_OVERLAY_CONTENTS_ID,
 } from './constants';
 
 const getCloseButton = (): string => `
@@ -29,7 +30,27 @@ const getCloseButton = (): string => `
     </button>
   `;
 
+const getTryAgainButton = () => `
+  <button
+    id="${PASSPORT_OVERLAY_TRY_AGAIN_ID}"
+    style="
+      margin-top: 27px !important;
+      color: #f3f3f3 !important;
+      background: transparent !important;
+      padding: 12px 24px !important;
+      border-radius: 30px !important;
+      border: 2px solid #f3f3f3 !important;
+      font-size: 1em !important;
+      font-weight: 500 !important;
+      cursor: pointer !important;
+    "
+  >
+    Try again
+  </button>
+`;
+
 const getBlockedContents = () => `
+    ${IMMUTABLE_LOGO_SVG}
     <div
       style="
         color: #e01a3d !important;
@@ -52,9 +73,11 @@ const getBlockedContents = () => `
       If the problem continues, adjust your<br />
       browser settings.
     </p>
+    ${getTryAgainButton()}
   `;
 
 const getGenericContents = () => `
+    ${IMMUTABLE_LOGO_SVG}
     <p style="
         color: #b6b6b6 !important;
         text-align: center !important;
@@ -63,28 +86,10 @@ const getGenericContents = () => `
     >
       Secure pop-up not showing?<br />We'll help you re-launch
     </p>
+    ${getTryAgainButton()}
   `;
 
-const getTryAgainButton = () => `
-    <button
-      id="${PASSPORT_OVERLAY_TRY_AGAIN_ID}"
-      style="
-        margin-top: 27px !important;
-        color: #f3f3f3 !important;
-        background: transparent !important;
-        padding: 12px 24px !important;
-        border-radius: 30px !important;
-        border: 2px solid #f3f3f3 !important;
-        font-size: 1em !important;
-        font-weight: 500 !important;
-        cursor: pointer !important;
-      "
-    >
-      Try again
-    </button>
-  `;
-
-const getOverlay = (contents: string): string => `
+export const getOverlay = (contents: string): string => `
     <div
       id="${PASSPORT_OVERLAY_ID}"
       style="
@@ -111,6 +116,7 @@ const getOverlay = (contents: string): string => `
     >
       ${getCloseButton()}
       <div
+        id="${PASSPORT_OVERLAY_CONTENTS_ID}"
         style="
           display: flex !important;
           flex-direction: column !important;
@@ -118,10 +124,36 @@ const getOverlay = (contents: string): string => `
           max-width: 400px !important;
         "
       >
-        ${IMMUTABLE_LOGO_SVG}
-        ${contents}
-        ${getTryAgainButton()}
+        ${contents ?? ''}
       </div>
+    </div>
+  `;
+
+  export const getEmbeddedLoginPromptOverlay = (): string => `
+    <div
+      id="${PASSPORT_OVERLAY_ID}"
+      style="
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+        display: flex !important;
+        flex-direction: column !important;
+        justify-content: center !important;
+        align-items: center !important;
+        z-index: 2147483647 !important;
+      "
+    >
+      <div
+        id="${PASSPORT_OVERLAY_CONTENTS_ID}"
+        style="
+          display: flex !important;
+          flex-direction: column !important;
+          align-items: center !important;
+          max-width: 400px !important;
+        "
+      />
     </div>
   `;
 

--- a/packages/passport/sdk/src/overlay/embeddedLoginPromptOverlay.ts
+++ b/packages/passport/sdk/src/overlay/embeddedLoginPromptOverlay.ts
@@ -1,0 +1,43 @@
+import { PASSPORT_OVERLAY_CONTENTS_ID } from './constants';
+import { getEmbeddedLoginPromptOverlay } from './elements';
+
+export default class EmbeddedLoginPromptOverlay {
+  private static overlay: HTMLDivElement | undefined;
+
+  private static onCloseListener: (() => void) | undefined;
+
+  private static closeButton: HTMLButtonElement | undefined;
+
+  static remove() {
+    if (this.onCloseListener) {
+      this.closeButton?.removeEventListener?.('click', this.onCloseListener);
+    }
+    this.overlay?.remove();
+
+    this.closeButton = undefined;
+    this.onCloseListener = undefined;
+    this.overlay = undefined;
+  }
+
+  static appendOverlay(embeddedLoginPrompt: HTMLIFrameElement, onCloseListener: () => void) {
+    if (!this.overlay) {
+      const overlay = document.createElement('div');
+      overlay.innerHTML = getEmbeddedLoginPromptOverlay();
+      document.body.insertAdjacentElement('beforeend', overlay);
+      const overlayContents = document.querySelector<HTMLDivElement>(`#${PASSPORT_OVERLAY_CONTENTS_ID}`);
+      if (overlayContents) {
+        overlayContents.appendChild(embeddedLoginPrompt);
+      }
+
+      overlay.addEventListener('click', onCloseListener);
+
+      // const closeButton = document.querySelector<HTMLButtonElement>(`#${PASSPORT_OVERLAY_CLOSE_ID}`);
+      // if (closeButton) {
+      //   this.closeButton = closeButton;
+      //   this.onCloseListener = onCloseListener;
+      //   closeButton.addEventListener('click', onCloseListener);
+      // }
+      this.overlay = overlay;
+    }
+  }
+}

--- a/packages/passport/sdk/src/types.ts
+++ b/packages/passport/sdk/src/types.ts
@@ -183,7 +183,6 @@ export enum MarketingConsentStatus {
 }
 
 export type DirectLoginOptions = {
-  directLoginMethod: DirectLoginMethod;
   marketingConsentStatus?: MarketingConsentStatus;
 } & (
   | { directLoginMethod: 'email'; email: string }


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
# Summary
This PR adds support to render the headless login prompt by default when the `login` method is called.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
