### PR TITLE
chore(passport): ID-3992 Headless login doc changes

### DIFF
--- a/examples/passport/setup-with-nextjs/src/app/utils/setupDefault.ts
+++ b/examples/passport/setup-with-nextjs/src/app/utils/setupDefault.ts
@@ -27,6 +27,7 @@ export const passportInstanceWithDisabledOverlays = new passport.Passport({
   popupOverlayOptions: {
     disableGenericPopupOverlay: true,
     disableBlockedPopupOverlay: true,
+    disableHeadlessLoginPromptOverlay: true,
   },
 });
 

--- a/packages/passport/sdk/src/types.ts
+++ b/packages/passport/sdk/src/types.ts
@@ -184,7 +184,7 @@ export enum MarketingConsentStatus {
 }
 
 export type DirectLoginOptions = {
-  marketingConsentStatus?: MarketingConsentStatus;
+  marketingConsentStatus: MarketingConsentStatus;
 } & (
   | { directLoginMethod: 'email'; email: string }
   | { directLoginMethod: Exclude<DirectLoginMethod, 'email'>; email?: never }


### PR DESCRIPTION
# Summary
This PR:
- adds the `disableHeadlessLoginPromptOverlay` property to an example that will be referenced by the docs
- makes the `directLogin.marketingConsentStatus` property mandatory, as it's required by the login flow

# Detail and impact of the change
## Changed
- Passport: Marked the login `directLogin.marketingConsentStatus` property as mandatory to accurately reflect the current state