### PR TITLE
ci(all): SRE-3054: Only run zkevm func-tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -135,4 +135,4 @@ jobs:
         run: pnpm install --frozen-lockfile=false
 
       - name: Run functional tests
-        run: pnpm --filter "@tests/*" --parallel func-test:ci
+        run: pnpm --filter "@tests/func-tests-zkevm" --parallel func-test:ci


### PR DESCRIPTION
We no longer need to run these func-tests on imx sandbox, they put unncessary load on things and are not useful to us.