### PR TITLE
Revert "feat: Skip PaymentOptions screen if there is only one enabled…

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/sale/components/PaymentOptions.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/components/PaymentOptions.tsx
@@ -2,7 +2,7 @@ import { Box, MenuItemSize } from '@biom3/react';
 
 import { SalePaymentTypes } from '@imtbl/checkout-sdk';
 import { motion } from 'framer-motion';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { listItemVariants, listVariants } from '../../../lib/animation/listAnimation';
 import { PaymentOption } from './PaymentOption';
 
@@ -36,12 +36,6 @@ export function PaymentOptions(props: PaymentOptionsProps) {
     ),
     [paymentOptions, disabledOptions, hideDisabledOptions],
   );
-
-  useEffect(() => {
-    if (options.length === 1) {
-      onClick(options[0]);
-    }
-  }, [options, onClick]);
 
   return (
     <Box


### PR DESCRIPTION
… option (#1977)"

This reverts commit d4cb6022330a18c2872a16c4d611364ebabb9d8d.

### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary

Revert the change to auto proceed when there is only one option. This breaks the usage of the PaymentOptions inside the CoinsDrawer.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed
<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->
