### PR TITLE
fix(passport): ID-3991: Increase embedded login prompt height

### DIFF
--- a/packages/passport/sdk/src/confirmation/embeddedLoginPrompt.ts
+++ b/packages/passport/sdk/src/confirmation/embeddedLoginPrompt.ts
@@ -7,7 +7,7 @@ import {
 import { PassportConfiguration } from '../config';
 import EmbeddedLoginPromptOverlay from '../overlay/embeddedLoginPromptOverlay';
 
-const LOGIN_PROMPT_WINDOW_HEIGHT = 560;
+const LOGIN_PROMPT_WINDOW_HEIGHT = 660;
 const LOGIN_PROMPT_WINDOW_WIDTH = 440;
 const LOGIN_PROMPT_WINDOW_BORDER_RADIUS = '16px';
 const LOGIN_PROMPT_KEYFRAME_STYLES_ID = 'passport-embedded-login-keyframes';


### PR DESCRIPTION
# Summary
This PR increases the max-height of the embedded login prompt to ensure that it covers the connect widget.

# Detail and impact of the change
## Changed
- Passport: Increased the max-height of the embedded login prompt slightly.