### PR TITLE
feat(checkout-widgets): Make on-ramp widget header customisable

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/configurations/onramp.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/configurations/onramp.ts
@@ -6,6 +6,8 @@ import { WidgetConfiguration } from './widget';
 export type OnrampWidgetConfiguration = {
   /** Whether to show the menu in the Transak widget (default: true) */
   showMenu?: boolean;
+  /** The custom title to display in the widget header */
+  customTitle?: string;
   /** The custom subtitle to display on the exchange screen in the Transak widget (default: 'Buy') */
   customSubTitle?: string;
 } & WidgetConfiguration;

--- a/packages/checkout/widgets-lib/src/widgets/on-ramp/OnRampWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/on-ramp/OnRampWidget.tsx
@@ -141,6 +141,7 @@ export default function OnRampWidget({
           }
           showBackButton={showBackButton}
           showMenu={onrampConfig?.showMenu}
+          customTitle={onrampConfig?.customTitle}
           customSubTitle={onrampConfig?.customSubTitle}
         />
       )}

--- a/packages/checkout/widgets-lib/src/widgets/on-ramp/views/OnRampMain.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/on-ramp/views/OnRampMain.tsx
@@ -43,6 +43,7 @@ interface OnRampProps {
   passport?: Passport;
   showBackButton?: boolean;
   showMenu?: boolean;
+  customTitle?: string;
   customSubTitle?: string;
 }
 export function OnRampMain({
@@ -52,6 +53,7 @@ export function OnRampMain({
   tokenAddress,
   showBackButton,
   showMenu,
+  customTitle,
   customSubTitle,
 }: OnRampProps) {
   const { connectLoaderState } = useContext(ConnectLoaderContext);
@@ -275,7 +277,7 @@ export function OnRampMain({
       <SimpleLayout
         header={(
           <HeaderNavigation
-            title={t('views.ONRAMP.header.title')}
+            title={customTitle ?? t('views.ONRAMP.header.title')}
             onCloseButtonClick={() => sendOnRampWidgetCloseEvent(eventTarget)}
             showBack={showBack}
             onBackButtonClick={() => {


### PR DESCRIPTION
Jira: https://immutable.atlassian.net/jira/software/projects/GFI/boards/3556?selectedIssue=GFI-45

**Default**
<img width="464" height="675" alt="Screenshot 2025-09-26 at 11 42 49 am" src="https://github.com/user-attachments/assets/e168cbf2-ebfb-4abe-b036-6878929a7a02" />


**No title**
<img width="427" height="641" alt="Screenshot 2025-09-26 at 11 40 24 am" src="https://github.com/user-attachments/assets/9afb1e3a-33df-491a-a43a-8373425c04a8" />


**Random title**
<img width="424" height="654" alt="Screenshot 2025-09-26 at 11 40 51 am" src="https://github.com/user-attachments/assets/4d944fde-20cb-463c-b4a1-f1bf99d0768a" />

