### PR TITLE
feat(checkout-widgets): Allow hide header on On-Ramp widget

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/configurations/onramp.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/configurations/onramp.ts
@@ -10,4 +10,6 @@ export type OnrampWidgetConfiguration = {
   customTitle?: string;
   /** The custom subtitle to display on the exchange screen in the Transak widget (default: 'Buy') */
   customSubTitle?: string;
+  /** Whether to show the header (default: true) */
+  showHeader?: boolean;
 } & WidgetConfiguration;

--- a/packages/checkout/widgets-lib/src/widgets/on-ramp/OnRampWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/on-ramp/OnRampWidget.tsx
@@ -143,6 +143,7 @@ export default function OnRampWidget({
           showMenu={onrampConfig?.showMenu}
           customTitle={onrampConfig?.customTitle}
           customSubTitle={onrampConfig?.customSubTitle}
+          showHeader={onrampConfig?.showHeader}
         />
       )}
 

--- a/packages/checkout/widgets-lib/src/widgets/on-ramp/views/OnRampMain.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/on-ramp/views/OnRampMain.tsx
@@ -45,6 +45,7 @@ interface OnRampProps {
   showMenu?: boolean;
   customTitle?: string;
   customSubTitle?: string;
+  showHeader?: boolean;
 }
 export function OnRampMain({
   passport,
@@ -55,6 +56,7 @@ export function OnRampMain({
   showMenu,
   customTitle,
   customSubTitle,
+  showHeader,
 }: OnRampProps) {
   const { connectLoaderState } = useContext(ConnectLoaderContext);
   const { checkout, provider } = connectLoaderState;
@@ -275,7 +277,7 @@ export function OnRampMain({
   return (
     <Box sx={boxMainStyle(showIframe)}>
       <SimpleLayout
-        header={(
+        header={(showHeader ?? true) ? (
           <HeaderNavigation
             title={customTitle ?? t('views.ONRAMP.header.title')}
             onCloseButtonClick={() => sendOnRampWidgetCloseEvent(eventTarget)}
@@ -288,7 +290,7 @@ export function OnRampMain({
               );
             }}
           />
-        )}
+        ) : undefined}
         footerBackgroundColor="base.color.translucent.emphasis.200"
       >
         <Box sx={containerStyle(showIframe)}>

--- a/packages/checkout/widgets-sample-app/src/components/ui/checkout/checkout.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/checkout/checkout.tsx
@@ -296,6 +296,7 @@ function CheckoutUI() {
           customTitle: "Dromedary On-Ramp",
           customSubTitle: "Camel On-Ramp",
           showMenu: true,
+          showHeader: true,
         },
         */
       },


### PR DESCRIPTION
Jira: https://immutable.atlassian.net/browse/GFI-1196

**Default**
<img width="443" height="644" alt="Screenshot 2025-09-26 at 3 45 12 pm" src="https://github.com/user-attachments/assets/9d4f5734-9660-4677-9e76-b77d0d8f08e1" />

**Removed**
<img width="427" height="579" alt="Screenshot 2025-09-26 at 3 46 42 pm" src="https://github.com/user-attachments/assets/65b62976-b257-48f9-a723-41062199d85d" />
