### PR TITLE
feat(passport): ID-3991-login-prompt-anonymousId

### DIFF
--- a/packages/passport/sdk/src/authManager.test.ts
+++ b/packages/passport/sdk/src/authManager.test.ts
@@ -1324,5 +1324,21 @@ describe('AuthManager', () => {
 
       expect(mockSigninPopup).not.toHaveBeenCalled();
     });
+
+    it('should pass anonymousId to displayEmbeddedLoginPrompt', async () => {
+      const anonymousId = 'test-anonymous-id-12345';
+      const mockEmbeddedLoginPromptResult = {
+        directLoginMethod: 'google' as const,
+        marketingConsentStatus: MarketingConsentStatus.OptedIn,
+        imPassportTraceId: 'test-trace-id',
+      };
+      mockEmbeddedLoginPrompt.displayEmbeddedLoginPrompt.mockResolvedValue(mockEmbeddedLoginPromptResult);
+      mockSigninPopup.mockResolvedValue(mockOidcUser);
+
+      await authManager.login(anonymousId);
+
+      expect(mockEmbeddedLoginPrompt.displayEmbeddedLoginPrompt).toHaveBeenCalledWith(anonymousId);
+      expect(mockEmbeddedLoginPrompt.displayEmbeddedLoginPrompt).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/passport/sdk/src/authManager.ts
+++ b/packages/passport/sdk/src/authManager.ts
@@ -250,7 +250,7 @@ export default class AuthManager {
         const {
           imPassportTraceId: embeddedLoginPromptImPassportTraceId,
           ...embeddedLoginPromptDirectLoginOptions
-        } = await this.embeddedLoginPrompt.displayEmbeddedLoginPrompt();
+        } = await this.embeddedLoginPrompt.displayEmbeddedLoginPrompt(anonymousId);
         directLoginOptionsToUse = embeddedLoginPromptDirectLoginOptions;
         imPassportTraceId = embeddedLoginPromptImPassportTraceId;
       }

--- a/packages/passport/sdk/src/confirmation/embeddedLoginPrompt.test.ts
+++ b/packages/passport/sdk/src/confirmation/embeddedLoginPrompt.test.ts
@@ -65,6 +65,13 @@ describe('EmbeddedLoginPrompt', () => {
       const href = (embeddedLoginPrompt as any).getHref();
       expect(href).toBe(`https://auth.immutable.com/im-embedded-login-prompt?client_id=${mockClientId}&rid=undefined`);
     });
+
+    it('should generate correct href with anonymous ID', () => {
+      const anonymousId = 'hello-world-123';
+      const href = (embeddedLoginPrompt as any).getHref(anonymousId);
+      expect(href).toBe('https://auth.immutable.com/im-embedded-login-prompt?'
+        + `client_id=${mockClientId}&rid=undefined&third_party_a_id=${anonymousId}`);
+    });
   });
 
   describe('appendIFrameStylesIfNeeded', () => {

--- a/packages/passport/sdk/src/confirmation/embeddedLoginPrompt.ts
+++ b/packages/passport/sdk/src/confirmation/embeddedLoginPrompt.ts
@@ -20,11 +20,17 @@ export default class EmbeddedLoginPrompt {
     this.config = config;
   }
 
-  private getHref = () => (
-    `${this.config.authenticationDomain}/im-embedded-login-prompt`
+  private getHref = (anonymousId?: string) => {
+    let href = `${this.config.authenticationDomain}/im-embedded-login-prompt`
     + `?client_id=${this.config.oidcConfiguration.clientId}`
-    + `&rid=${getDetail(Detail.RUNTIME_ID)}`
-  );
+    + `&rid=${getDetail(Detail.RUNTIME_ID)}`;
+
+    if (anonymousId) {
+      href += `&third_party_a_id=${anonymousId}`;
+    }
+
+    return href;
+  };
 
   private static appendIFrameStylesIfNeeded = () => {
     if (document.getElementById(LOGIN_PROMPT_KEYFRAME_STYLES_ID)) {
@@ -71,10 +77,10 @@ export default class EmbeddedLoginPrompt {
     document.head.appendChild(style);
   };
 
-  private getEmbeddedLoginIFrame = () => {
+  private getEmbeddedLoginIFrame = (anonymousId?: string) => {
     const embeddedLoginPrompt = document.createElement('iframe');
     embeddedLoginPrompt.id = LOGIN_PROMPT_IFRAME_ID;
-    embeddedLoginPrompt.src = this.getHref();
+    embeddedLoginPrompt.src = this.getHref(anonymousId);
     embeddedLoginPrompt.style.height = '100vh';
     embeddedLoginPrompt.style.width = '100vw';
     embeddedLoginPrompt.style.maxHeight = `${LOGIN_PROMPT_WINDOW_HEIGHT}px`;
@@ -90,9 +96,9 @@ export default class EmbeddedLoginPrompt {
     return embeddedLoginPrompt;
   };
 
-  public displayEmbeddedLoginPrompt(): Promise<EmbeddedLoginPromptResult> {
+  public displayEmbeddedLoginPrompt(anonymousId?: string): Promise<EmbeddedLoginPromptResult> {
     return new Promise((resolve, reject) => {
-      const embeddedLoginPrompt = this.getEmbeddedLoginIFrame();
+      const embeddedLoginPrompt = this.getEmbeddedLoginIFrame(anonymousId);
       const messageHandler = ({ data, origin }: MessageEvent) => {
         if (
           origin !== this.config.authenticationDomain


### PR DESCRIPTION
https://immutable.atlassian.net/browse/ID-3991

# Summary
This PR passes the `anonymousId` to the embedded login prompt to make tracking easier.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Changed
- Passport: Improved tracking when using the embedded login prompt