### PR TITLE
chore(passport): Fix Seaport fulfillAvailableAdvancedOrders in Passport SDK sample app

### DIFF
--- a/packages/passport/sdk-sample-app/src/components/imx/Trade.tsx
+++ b/packages/passport/sdk-sample-app/src/components/imx/Trade.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Alert, Button, Form, Image, Offcanvas, Spinner, Stack, Table,
 } from 'react-bootstrap';
@@ -25,7 +25,7 @@ function Trade({ showModal: showTradeModal, setShowModal: setShowTradeModal }: M
   const { sdkClient } = useImmutableProvider();
   const { imxProvider } = usePassportProvider();
 
-  const getOrders = async (e?: React.FormEvent<HTMLFormElement>) => {
+  const getOrders = useCallback(async (e?: React.FormEvent<HTMLFormElement>) => {
     e?.preventDefault();
     e?.stopPropagation();
 
@@ -45,11 +45,11 @@ function Trade({ showModal: showTradeModal, setShowModal: setShowTradeModal }: M
       setOrders(result.result);
       setLoadingOrders(false);
     }
-  };
+  }, [sdkClient, showTradeModal, sellTokenName]);
 
   useEffect(() => {
     getOrders().catch(console.error);
-  }, [showTradeModal, sdkClient, getOrders]);
+  }, [getOrders]);
 
   const handleCloseTrade = () => {
     setLoadingTrade(false);

--- a/packages/passport/sdk-sample-app/src/components/zkevm/Request.tsx
+++ b/packages/passport/sdk-sample-app/src/components/zkevm/Request.tsx
@@ -187,7 +187,11 @@ function Request({ showModal, setShowModal }: ModalProps) {
     if (request.params) {
       const newParams = params;
       request.params.forEach((param, i) => {
-        newParams[i] = JSON.stringify(param);
+        try {
+          newParams[i] = JSON.stringify(param);  
+        } catch (err) {
+          newParams[i] = param;
+        }
       });
       setParams(newParams);
     }

--- a/packages/passport/sdk-sample-app/src/components/zkevm/Request.tsx
+++ b/packages/passport/sdk-sample-app/src/components/zkevm/Request.tsx
@@ -188,7 +188,7 @@ function Request({ showModal, setShowModal }: ModalProps) {
       const newParams = params;
       request.params.forEach((param, i) => {
         try {
-          newParams[i] = JSON.stringify(param);  
+          newParams[i] = JSON.stringify(param);
         } catch (err) {
           newParams[i] = param;
         }


### PR DESCRIPTION
# Summary
This PR fixes the `fulfillAvailableAdvancedOrders` example in the Passport SDK sample app.

# Detail and impact of the change
## Fixed
- Passport sample app: Fixed `fulfillAvailableAdvancedOrders` example