### PR TITLE
feat(checkout): Add optional param to display Send title on Transfer widget

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/configurations/transfer.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/configurations/transfer.ts
@@ -5,6 +5,6 @@ import { WidgetConfiguration } from './widget';
  */
 export type TransferWidgetConfiguration = {
   customTitle?: string;
+  customCoinAmountTitle?: string;
   showHeader?: boolean;
-  showCoinAmountHeading?: boolean;
 } & WidgetConfiguration;

--- a/packages/checkout/widgets-lib/src/widgets/transfer/TransferForm.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/transfer/TransferForm.tsx
@@ -30,8 +30,8 @@ export function TransferForm({
   onSend,
   showBackButton,
   showHeader,
-  showCoinAmountHeading,
   title,
+  coinAmountTitle,
 }: {
   config: StrongCheckoutWidgetsConfig;
   viewState: TransferFormState;
@@ -39,8 +39,8 @@ export function TransferForm({
   onSend: () => void;
   showBackButton: boolean | undefined;
   showHeader: boolean;
-  showCoinAmountHeading: boolean;
   title: string;
+  coinAmountTitle: string;
 }) {
   const { t } = useTranslation();
   const { track } = useAnalytics();
@@ -167,11 +167,9 @@ export function TransferForm({
       >
         <Stack gap="base.spacing.x9">
           <Stack gap="base.spacing.x1">
-            {showCoinAmountHeading && (
-              <Heading size="xSmall">
-                {t('views.TRANSFER.form.coinAmountHeading')}
-              </Heading>
-            )}
+            <Heading size="xSmall">
+              {coinAmountTitle}
+            </Heading>
             <SelectInput
               testId="transfer-token-select"
               options={tokenOptions}

--- a/packages/checkout/widgets-lib/src/widgets/transfer/TransferWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/transfer/TransferWidget.tsx
@@ -206,8 +206,8 @@ function TransferWidgetInner(props: TransferWidgetInputs) {
           onSend={onSend}
           showBackButton={props.showBackButton}
           showHeader={props.transferConfig.showHeader ?? true}
-          showCoinAmountHeading={props.transferConfig.showCoinAmountHeading ?? true}
           title={props.transferConfig.customTitle ?? t('views.TRANSFER.header.title')}
+          coinAmountTitle={props.transferConfig.customCoinAmountTitle ?? t('views.TRANSFER.form.coinAmountHeading')}
         />
       );
     case 'AWAITING_APPROVAL':

--- a/packages/checkout/widgets-sample-app/src/components/ui/checkout/checkout.tsx
+++ b/packages/checkout/widgets-sample-app/src/components/ui/checkout/checkout.tsx
@@ -301,6 +301,8 @@ function CheckoutUI() {
         },
         TRANSFER: {
           customTitle: "Dromedary Transfer",
+          customCoinAmountTitle: "Send dromedary",
+          // showHeader: false,
         },
         /*
         ONRAMP: {


### PR DESCRIPTION
#### With new param

```
TRANSFER: {
  ...
  customCoinAmountTitle: "Send dromedary",
},
```

<img width="444" height="679" alt="Screenshot 2025-10-27 at 1 33 58 pm" src="https://github.com/user-attachments/assets/4ac220bd-2f57-4cd2-85d5-c6ba119e3147" />

#### Without new param

```
TRANSFER: {
  ...
},
```

<img width="440" height="688" alt="Screenshot 2025-10-27 at 1 34 33 pm" src="https://github.com/user-attachments/assets/2e679610-ef3a-44b1-b0a5-80939abac1aa" />

#### Removing title

```
TRANSFER: {
  ...
  customCoinAmountTitle: "",
},
```

<img width="454" height="659" alt="Screenshot 2025-10-27 at 1 35 03 pm" src="https://github.com/user-attachments/assets/ae64787c-673f-4c77-b715-3520bcc6043c" />


