### PR TITLE
chore(ci): use github secrets for nx access token

### DIFF
--- a/.github/workflows/build-game-bridge.yaml
+++ b/.github/workflows/build-game-bridge.yaml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     env:
       NODE_OPTIONS: --max-old-space-size=14366
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.TS_IMMUTABLE_SDK_NX_TOKEN }}
     steps:
       - name: Checkout SDK Repository
         id: checkout-sdk

--- a/.github/workflows/passport-sdk-sample-app-deployment.yaml
+++ b/.github/workflows/passport-sdk-sample-app-deployment.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AWS_REGION: us-east-2
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.TS_IMMUTABLE_SDK_NX_TOKEN }}
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,6 +42,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=14366
       SDK_PUBLISH_SLACK_WEBHOOK: ${{ secrets.SDK_PUBLISH_SLACK_WEBHOOK }}
       SDK_PUBLISH_MAJOR_VERSION_ACTORS: ${{ secrets.SDK_PUBLISH_MAJOR_VERSION_ACTORS }}
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.TS_IMMUTABLE_SDK_NX_TOKEN }}
     permissions:
       id-token: write # ! Required for GitHub Attestations, removing will create a Sev 0 incident !
       attestations: write # ! Required for GitHub Attestations, removing will create a Sev 0 incident !

--- a/.github/workflows/title-validation.yaml
+++ b/.github/workflows/title-validation.yaml
@@ -11,9 +11,6 @@ on:
 permissions:
   pull-requests: read
 
-env:
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.TS_IMMUTABLE_SDK_NX_TOKEN }}
-
 jobs:
   title-validation:
     name: Validate PR title

--- a/nx.json
+++ b/nx.json
@@ -90,6 +90,5 @@
     }
   },
   "defaultBase": "main",
-  "parallel": 8,
-  "nxCloudAccessToken": "Mzg3ZGY1MWUtYmYyNy00ZmE4LTkyNDAtYjYxZmJmYmE4NWQ3fHJlYWQ="
+  "parallel": 8
 }


### PR DESCRIPTION
# Summary
Remove nx access token and use access token in github secrets, environment variable supersedes nx.json

# Detail and impact of the change
## Added 
- NX Access Token secret variable in workflows that use NX

## Removed
- NX Access Token from nx.json

## Security
- Rotate NX access token after merge
