### PR TITLE
fix(passport): remove toUserImx validation from registerOffchain

### DIFF
--- a/packages/passport/sdk/src/starkEx/passportImxProvider.test.ts
+++ b/packages/passport/sdk/src/starkEx/passportImxProvider.test.ts
@@ -1,0 +1,141 @@
+import { IMXClient } from '@imtbl/x-client';
+import { ImxApiClients, imx } from '@imtbl/generated-clients';
+import { Auth, User } from '@imtbl/auth';
+import { GuardianClient, MagicTEESigner } from '@imtbl/wallet';
+import { PassportImxProvider } from './passportImxProvider';
+import { ImxGuardianClient } from './imxGuardianClient';
+import registerOffchain from './workflows/registerOffchain';
+import { getStarkSigner } from './getStarkSigner';
+import { PassportError, PassportErrorType } from '../errors/passportError';
+
+jest.mock('./workflows/registerOffchain');
+jest.mock('./getStarkSigner');
+
+describe('PassportImxProvider', () => {
+  let provider: PassportImxProvider;
+  let mockAuth: jest.Mocked<Auth>;
+  let mockMagicTEESigner: jest.Mocked<MagicTEESigner>;
+  let mockImxApiClients: ImxApiClients;
+  let mockGuardianClient: jest.Mocked<GuardianClient>;
+  let mockImxGuardianClient: jest.Mocked<ImxGuardianClient>;
+
+  // Mock user WITHOUT IMX metadata (new user)
+  const mockUserWithoutImx: User = {
+    expired: false,
+    idToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJnb29nbGUtb2F1dGgyfDEyMzQ1NiIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsInBhc3Nwb3J0Ijp7fX0.test',
+    accessToken: 'access-token-123',
+    refreshToken: 'refresh-token-123',
+    profile: {
+      sub: 'google-oauth2|123456',
+      email: 'user@example.com',
+      nickname: 'testuser',
+    },
+  };
+
+  // Mock user WITH IMX metadata (already registered)
+  const mockUserWithImx: User = {
+    ...mockUserWithoutImx,
+    idToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJnb29nbGUtb2F1dGgyfDEyMzQ1NiIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsInBhc3Nwb3J0Ijp7ImlteFfldGhfYWRkcmVzcyI6IjB4YWJjIiwiaW14X3N0YXJrX2FkZHJlc3MiOiIweDc4OSIsImlteFf1c2VyX2FkbWluX2FkZHJlc3MiOiIweGRlZiJ9fQ.test',
+  };
+
+  beforeEach(() => {
+    mockAuth = {
+      getUser: jest.fn(),
+      forceUserRefresh: jest.fn(),
+      eventEmitter: {
+        on: jest.fn(),
+        off: jest.fn(),
+        emit: jest.fn(),
+      } as any,
+    } as any;
+
+    mockMagicTEESigner = {
+      getAddress: jest.fn().mockResolvedValue('0xmagic'),
+    } as any;
+
+    mockImxApiClients = new ImxApiClients({} as any);
+    mockGuardianClient = {} as any;
+    mockImxGuardianClient = {} as any;
+
+    const mockStarkSigner = {
+      getAddress: jest.fn().mockResolvedValue('0xstark'),
+      signMessage: jest.fn(),
+    };
+    (getStarkSigner as jest.Mock).mockResolvedValue(mockStarkSigner);
+
+    provider = new PassportImxProvider({
+      auth: mockAuth,
+      immutableXClient: new IMXClient({ baseConfig: {} as any }),
+      passportEventEmitter: mockAuth.eventEmitter as any,
+      magicTEESigner: mockMagicTEESigner,
+      imxApiClients: mockImxApiClients,
+      guardianClient: mockGuardianClient,
+      imxGuardianClient: mockImxGuardianClient,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('registerOffchain', () => {
+    describe('when user is NEW (no IMX metadata)', () => {
+      it('should successfully register new user without throwing error', async () => {
+        // Arrange: User just logged in, NO IMX metadata yet
+        mockAuth.getUser.mockResolvedValue(mockUserWithoutImx);
+
+        const mockRegisterResponse: imx.RegisterUserResponse = {
+          tx_hash: '0xabc123',
+        };
+        (registerOffchain as jest.Mock).mockResolvedValue(mockRegisterResponse);
+
+        // Act
+        const result = await provider.registerOffchain();
+
+        // Assert: Should succeed without throwing
+        expect(result).toEqual(mockRegisterResponse);
+
+        // Verify workflow was called with User (not UserImx)
+        expect(registerOffchain).toHaveBeenCalledWith(
+          mockMagicTEESigner,
+          expect.anything(), // starkSigner
+          mockUserWithoutImx, // User without IMX metadata
+          mockAuth,
+          mockImxApiClients,
+        );
+      });
+    });
+
+    describe('when user is ALREADY registered (has IMX metadata)', () => {
+      it('should call workflow successfully', async () => {
+        // Arrange: User already has IMX metadata
+        mockAuth.getUser.mockResolvedValue(mockUserWithImx);
+
+        const mockRegisterResponse: imx.RegisterUserResponse = {
+          tx_hash: '',
+        };
+        (registerOffchain as jest.Mock).mockResolvedValue(mockRegisterResponse);
+
+        // Act
+        const result = await provider.registerOffchain();
+
+        // Assert
+        expect(result).toEqual(mockRegisterResponse);
+        expect(registerOffchain).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('getAddress', () => {
+    it('should throw error when user has no IMX metadata', async () => {
+      mockAuth.getUser.mockResolvedValue(mockUserWithoutImx);
+
+      await expect(provider.getAddress()).rejects.toThrow(
+        new PassportError(
+          'User has not been registered with StarkEx',
+          PassportErrorType.USER_NOT_REGISTERED_ERROR,
+        ),
+      );
+    });
+  });
+});

--- a/packages/passport/sdk/src/starkEx/passportImxProvider.ts
+++ b/packages/passport/sdk/src/starkEx/passportImxProvider.ts
@@ -181,7 +181,7 @@ export class PassportImxProvider implements IMXProvider {
         return await registerOffchain(
           this.magicTEESigner,
           starkSigner,
-          toUserImx(user),
+          user,
           this.auth,
           this.imxApiClients,
         );


### PR DESCRIPTION
## Summary
Fix critical regression introduced in commit 240cd2f that blocks new users from registering with ImmutableX.

## Problem
- `registerOffchain()` validates IMX metadata (via `toUserImx`) BEFORE calling the registration workflow
- New users don't have IMX metadata until AFTER registration completes
- This creates a Catch-22: users need metadata to register, but need to register to get metadata

## Impact
- ⚠️ **CRITICAL**: All new users on SDK v2.12.0+ cannot register with ImmutableX
- Existing users (registered before Dec 8, 2025) are unaffected

## Solution
- Pass `User` directly instead of `toUserImx(user)` to `registerOffchain` workflow
- Metadata validation happens AFTER registration in `forceUserRefresh()`
- Restores pre-240cd2f behavior

## Evidence
- **Kerry** (created Dec 3) ✅ registered successfully before bug
- **Brandon** (created Jan 12) ❌ blocked after bug was introduced

## Changes
- Modified `passportImxProvider.ts`: removed `toUserImx()` call on line 184
- Added test coverage for new user registration without IMX metadata

## Testing
- ✅ All existing tests pass
- ✅ New test verifies registration succeeds for users without IMX metadata

## Related
- Original commit: 240cd2f (Dec 8, 2025)
- Affected versions: 2.12.0+
- Ticket: ID-4233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores new-user registration by adjusting `registerOffchain` to accept raw `User` rather than `toUserImx(user)`.
> 
> - Updates `passportImxProvider.ts` to pass `user` into `registerOffchain`, avoiding premature IMX metadata validation
> - Adds `passportImxProvider.test.ts` covering: registration for users without IMX metadata, already-registered users, and `getAddress` error when metadata is missing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc0570291fcb0c80efd46aa347efbb85080bd724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->