### PR TITLE
fix(checkout-widgets): resolve checkout stuck in Crunching Numbers when paying with IMX (Issue 3)

### DIFF
--- a/packages/checkout/widgets-lib/src/lib/utils.test.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.test.ts
@@ -535,6 +535,10 @@ describe('utils', () => {
       expect(isNativeToken('NATIVE')).toBeTruthy();
     });
 
+    it('should return true if address is zero address (used by some APIs for native token)', () => {
+      expect(isNativeToken('0x0000000000000000000000000000000000000000')).toBeTruthy();
+    });
+
     it('should return false if address is not NATIVE', () => {
       expect(isNativeToken('0x123')).toBeFalsy();
     });

--- a/packages/checkout/widgets-lib/src/lib/utils.ts
+++ b/packages/checkout/widgets-lib/src/lib/utils.ts
@@ -183,9 +183,14 @@ export const isZkEvmChainId = (chainId: ChainId) => chainId === ChainId.IMTBL_ZK
 export const isL1EthChainId = (chainId: ChainId) => chainId === ChainId.SEPOLIA
   || chainId === ChainId.ETHEREUM;
 
+/** Zero address used by some APIs (e.g. primary-sales) to denote native token (e.g. tIMX on zkEVM) */
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
 export const isNativeToken = (
   address: string | undefined,
-): boolean => !address || address.toLocaleLowerCase() === NATIVE;
+): boolean => !address
+  || address.toLocaleLowerCase() === NATIVE
+  || address.toLocaleLowerCase() === ZERO_ADDRESS;
 
 export function getRemoteImage(environment: Environment | undefined, path: string) {
   return `${CHECKOUT_CDN_BASE_URL[environment ?? Environment.PRODUCTION]}/v1/blob/img${path}`;

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalances.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalances.ts
@@ -2,7 +2,7 @@ import {
   Checkout, ItemBalance, WrappedBrowserProvider, TokenBalance, TransactionRequirement,
 } from '@imtbl/checkout-sdk';
 import { Environment } from '@imtbl/config';
-import { compareStr } from '../../../lib/utils';
+import { compareStr, isNativeToken } from '../../../lib/utils';
 import {
   OrderQuoteCurrency,
   FundingBalance,
@@ -11,6 +11,7 @@ import {
 import {
   getAlternativeFundingSteps,
   getERC20ItemRequirement,
+  getNativeItemRequirement,
   getFnToPushAndSortFundingBalances,
   getFundingBalances,
   getGasEstimate,
@@ -75,11 +76,9 @@ export const fetchFundingBalances = async (
         return null;
       }
 
-      const itemRequirements = getERC20ItemRequirement(
-        amount,
-        spenderAddress,
-        currency.address,
-      );
+      const itemRequirements = isNativeToken(currency.address)
+        ? getNativeItemRequirement(amount)
+        : getERC20ItemRequirement(amount, spenderAddress, currency.address);
 
       const transactionOrGasAmount = getIsGasless()
         ? undefined

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalancesUtils.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/fetchFundingBalancesUtils.ts
@@ -7,6 +7,7 @@ import {
   TransactionOrGasType,
   TokenInfo,
   ERC20ItemRequirement,
+  NativeItemRequirement,
   FundingRoute,
   RoutingOutcomeType,
   FundingStep,
@@ -37,6 +38,13 @@ export const getERC20ItemRequirement = (
     type: ItemType.ERC20,
     tokenAddress,
     spenderAddress,
+    amount,
+  },
+];
+
+export const getNativeItemRequirement = (amount: string): NativeItemRequirement[] => [
+  {
+    type: ItemType.NATIVE,
     amount,
   },
 ];


### PR DESCRIPTION
# Fix Checkout stuck in Crunching Numbers (SDK 2.12.7)

## Summary

This PR addresses Issue 3 reported after upgrading to `@imtbl/sdk ^2.12.7` in the Treeverse integration. See `docs/TREEVERSE_ISSUES_ANALYSIS.md` for the full analysis.

---

## Issue 3: Checkout widget stuck in "Crunching Numbers" when paying with IMX on testnet

**Expected:** Checkout flow should complete or show an error, not hang indefinitely.

**Fix:** When fetching funding balances for native tokens (e.g. tIMX on zkEVM), the primary-sales API returns a zero address. The code was using `ERC20ItemRequirement`, which calls `getTokenContract().decimals()` and fails for non-contract addresses, causing `CheckoutError` and leaving the widget stuck in loading. Now uses `NativeItemRequirement` for native tokens instead of `ERC20ItemRequirement`.

**Packages:** checkout-widgets

---

## How to test locally

1. **Setup:**
   ```bash
   pnpm build
   pnpm --filter @imtbl/checkout-widgets-sample-app run start
   ```

2. **Test flow:**
   - Open the checkout sample app (e.g. http://localhost:3000/checkout)
   - Click **Primary Sale** or **Direct NFT Purchase**
   - Connect Passport
   - Select **IMX** as payment currency
   - Click pay with tokens

3. **Expected (fixed):** The flow should complete normally or show an error/funding options screen, instead of hanging indefinitely on "Crunching Numbers".

4. **Optional — simulate the bug (without fix):**
   - Use the `treeverse-issues-reproduction` branch
   - Enable the "Simulate Issue 3" checkbox at the top of the page (or add `?simulateIssue3=1` to the URL)
   - Repeat the flow — without the fix, the widget would hang; with the fix, the flow completes

5. **Optional — bypass primary-sales API (mock):**
   - Add `?mockPrimarySales=1` to the URL to use mock quote data (triggers the native token flow with tIMX zero address)
