### PR TITLE
feat(auth): add parent_origin parameter to embedded login prompt URL

### DIFF
--- a/packages/auth/src/login/embeddedLoginPrompt.ts
+++ b/packages/auth/src/login/embeddedLoginPrompt.ts
@@ -23,7 +23,8 @@ export default class EmbeddedLoginPrompt {
   private getHref = () => {
     const href = `${this.config.authenticationDomain}/im-embedded-login-prompt`
     + `?client_id=${this.config.oidcConfiguration.clientId}`
-    + `&rid=${getDetail(Detail.RUNTIME_ID)}`;
+    + `&rid=${getDetail(Detail.RUNTIME_ID)}`
+    + `&parent_origin=${encodeURIComponent(window.location.origin)}`;
 
     return href;
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Hi👋, please ensure the PR title follows the below standards:
- [x] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

## Security context

This PR is part of the remediation for **SAR-127 — Passport Headless Login** ([internal doc](https://immutable.atlassian.net/wiki/spaces/SEC/pages/3411017730/SAR-127+Passport+headless+login)), tracked under [BLO-9](https://linear.app/imtbl/issue/BLO-9/sar-127-prevent-email-harvesting-in-passport-headless-login-flow).

**What the assessment found:**
The embedded login iframe was using `postMessage(data, "*")` — a wildcard target origin — when communicating back to the parent window. This means any page capable of embedding the iframe could intercept messages containing sensitive authentication data (tokens, user session information). A malicious actor hosting such a page would receive those messages silently, with no way for the iframe to distinguish a legitimate parent from a hostile one.

**How this PR addresses it:**
By appending `parent_origin=<encoded-origin>` to the iframe `src` URL, the SDK now tells the embedded login prompt which origin legitimately spawned it. The companion PR [passport-login#211](https://github.com/immutable/passport-login/pull/211) reads that parameter and uses it as the explicit `targetOrigin` in every `postMessage` call — replacing the wildcard. This ensures authentication messages are only delivered to the window that is authorised to receive them.

> **Note on backward compatibility:** Partners must upgrade to this SDK version before [passport-login#211](https://github.com/immutable/passport-login/pull/211) is deployed. If the iframe is deployed without the SDK upgrade, `parent_origin` will be absent and the iframe will fall back to `"*"` (current behaviour). Both PRs should be coordinated accordingly.

---

# Summary
Appends `parent_origin` query parameter to the embedded login prompt iframe URL so the iframe can validate the parent origin for `postMessage` trust verification. This change works in conjunction with [passport-login#211](https://github.com/immutable/passport-login/pull/211) and both are intended to address the task [BLO-9](https://linear.app/imtbl/issue/BLO-9/sar-127-prevent-email-harvesting-in-passport-headless-login-flow).

# Detail and impact of the change

## Added 
- Added `parent_origin` query parameter to the iframe src URL in `getHref()` method
- The parameter passes the parent window's origin (`window.location.origin`) to the `/im-embedded-login-prompt` iframe
- Value is properly URL-encoded using `encodeURIComponent`

# Anything else worth calling out?
This change enables the embedded login prompt iframe to verify which parent origin to trust when handling cross-origin `postMessage` communication, improving security for the embedded authentication flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://imtbl.slack.com/archives/C0AK1E8BJ0Z/p1775618804693999?thread_ts=1775618804.693999&cid=C0AK1E8BJ0Z)