### PR TITLE
fix(audience): add @imtbl/audience to publish workflow version-seeding filter

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -99,7 +99,7 @@ jobs:
           git config user.email "platform-sa@users.noreply.github.com"
 
       - name: Initialize current versions
-        run: pnpm --filter @imtbl/sdk... --filter @imtbl/checkout-widgets... exec sh -c "jq --arg version \"$(npm view @imtbl/metrics versions --json | jq -r '.[-1]')\" '.version = \$version' package.json > package.tmp.json && mv package.tmp.json package.json"
+        run: pnpm --filter @imtbl/sdk... --filter @imtbl/checkout-widgets... --filter @imtbl/audience... exec sh -c "jq --arg version \"$(npm view @imtbl/metrics versions --json | jq -r '.[-1]')\" '.version = \$version' package.json > package.tmp.json && mv package.tmp.json package.json"
 
       - name: Setup new package versions
         run: pnpm nx release version --specifier ${{ env.RELEASE_TYPE }} $( ${{ env.DRY_RUN }} && echo "--dry-run" || echo "")


### PR DESCRIPTION
## What's broken

The publish workflow keeps trying to ship `@imtbl/audience` as version `0.0.1-alpha.0`, but that slot on npm is already taken by an old broken copy. npm won't let us overwrite it, so the publish silently skips audience every time.

## Why

Before publishing, the workflow stamps a fresh version number onto each package. It only does this for packages in the `@imtbl/sdk` and `@imtbl/checkout-widgets` families — audience isn't on the list, so it never gets a new number and keeps colliding with the bad slot.

## The fix

Add audience to the list. One line:

```diff
-        run: pnpm --filter @imtbl/sdk... --filter @imtbl/checkout-widgets... exec sh -c "..."
+        run: pnpm --filter @imtbl/sdk... --filter @imtbl/checkout-widgets... --filter @imtbl/audience... exec sh -c "..."
```

The `...` at the end also pulls in `@imtbl/audience-core` automatically, so both get stamped together with the rest of the SDK family.

## Unblocks

- **SDK-66** — publishing WebSDK on npm.
- **SDK-63** — Play can stop vendoring `imtbl-audience-0.0.0.tgz` ([immutable/play#5151](https://github.com/immutable/play/pull/5151)) once a real version lands on npm.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>