### PR TITLE
fix(audience): build @imtbl/audience in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -104,10 +104,10 @@ jobs:
       - name: Setup new package versions
         run: pnpm nx release version --specifier ${{ env.RELEASE_TYPE }} $( ${{ env.DRY_RUN }} && echo "--dry-run" || echo "")
 
-      - name: Build SDK & Checkout Widgets
+      - name: Build SDK, Checkout Widgets & Audience
         run: pnpm build
 
-      - name: Pack SDK & Checkout Widgets packages and dependencies
+      - name: Pack SDK, Checkout Widgets & Audience packages and dependencies
         run: pnpm pack-npm-packages
 
       # ! Do NOT remove any of these attestation subject paths - this will cause a Sev 0 incident !

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "responselike": "^2.0.0"
   },
   "scripts": {
-    "build": "nx run-many -p @imtbl/sdk,@imtbl/checkout-widgets -t build",
+    "build": "nx run-many -p @imtbl/sdk,@imtbl/checkout-widgets,@imtbl/audience -t build",
     "build:examples": "pnpm --recursive --filter '@examples/**' build",
     "build:onlysdk": "NODE_OPTIONS=--max-old-space-size=14366 nx run-many --target=build --projects=@imtbl/sdk && pnpm syncpack:format",
     "dev": "FORCE_COLOR=1 pnpm --filter @imtbl/sdk... --filter @imtbl/checkout-widgets... run transpile && pnpm --parallel --filter @imtbl/sdk... --filter @imtbl/checkout-widgets... run transpile --watch",


### PR DESCRIPTION
## Problem

`@imtbl/audience` is published to npm but the package is empty — no `dist/` folder, just `package.json` and `LICENSE.md`. Anything trying to import from it fails at module resolution because the entry point file (`dist/node/index.cjs`) doesn't exist.

```
$ npm pack @imtbl/audience@alpha --dry-run --json | jq -r '.[].files[].path'
LICENSE.md
package.json
```

## Cause

The publish workflow runs `pnpm build` with an explicit list of packages:

```
"build": "nx run-many -p @imtbl/sdk,@imtbl/checkout-widgets -t build"
```

`@imtbl/audience` isn't in the list, so it's never built before the pack step. The pack step then ships an empty tarball because `@imtbl/audience/package.json` only includes `dist/` and there's nothing there.

## Fix

Add `@imtbl/audience` to the build list. Update the workflow step labels so they match what's actually built and packed.

## Test plan

- [ ] Trigger the publish workflow via `workflow_dispatch` with `dry_run: true` and check the resulting `imtbl-audience-*.tgz` artifact for files under `dist/`.
- [ ] Or verify locally:
  ```
  pnpm build
  cd packages/audience/sdk && pnpm pack --dry-run
  ```
  Output should list files under `dist/node/`, `dist/browser/`, and `dist/types/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)