### PR TITLE
feat(pixel): remove identify() from pixel tracker

### DIFF
--- a/packages/audience/pixel/src/bootstrap.test.ts
+++ b/packages/audience/pixel/src/bootstrap.test.ts
@@ -5,7 +5,6 @@
 
 const mockInit = jest.fn();
 const mockPage = jest.fn();
-const mockIdentify = jest.fn();
 const mockSetConsent = jest.fn();
 const mockDestroy = jest.fn();
 
@@ -13,7 +12,6 @@ jest.mock('./pixel', () => ({
   Pixel: jest.fn().mockImplementation(() => ({
     init: mockInit,
     page: mockPage,
-    identify: mockIdentify,
     setConsent: mockSetConsent,
     destroy: mockDestroy,
   })),
@@ -65,14 +63,12 @@ describe('bootstrap', () => {
     (window as Record<string, unknown>).__imtbl = [
       ['init', { key: 'pk_test' }],
       ['consent', 'full'],
-      ['identify', 'user-1', 'passport', { email: 'a@b.com' }],
     ];
 
     require('./bootstrap');
 
     expect(mockInit).toHaveBeenCalledWith({ key: 'pk_test' });
     expect(mockSetConsent).toHaveBeenCalledWith('full');
-    expect(mockIdentify).toHaveBeenCalledWith('user-1', 'passport', { email: 'a@b.com' });
   });
 
   it('installs loader and handles new commands after load', () => {

--- a/packages/audience/pixel/src/bootstrap.ts
+++ b/packages/audience/pixel/src/bootstrap.ts
@@ -23,13 +23,6 @@ function handleCommand(command: Command): void {
     case 'page':
       pixel.page(args[0] as Parameters<Pixel['page']>[0]);
       break;
-    case 'identify':
-      pixel.identify(
-        args[0] as string,
-        args[1] as Parameters<Pixel['identify']>[1],
-        args[2] as Parameters<Pixel['identify']>[2],
-      );
-      break;
     case 'consent':
       pixel.setConsent(args[0] as Parameters<Pixel['setConsent']>[0]);
       break;

--- a/packages/audience/pixel/src/loader.test.ts
+++ b/packages/audience/pixel/src/loader.test.ts
@@ -18,11 +18,11 @@ describe('createLoader', () => {
     const loader = createLoader(handler);
 
     loader.push(['init', { key: 'pk_123' }]);
-    loader.push(['identify', 'user-1']);
+    loader.push(['page', { url: '/home' }]);
 
     expect(handler).toHaveBeenCalledTimes(2);
     expect(handler).toHaveBeenCalledWith(['init', { key: 'pk_123' }]);
-    expect(handler).toHaveBeenCalledWith(['identify', 'user-1']);
+    expect(handler).toHaveBeenCalledWith(['page', { url: '/home' }]);
   });
 
   it('replays queued commands from the stub array', () => {
@@ -51,9 +51,9 @@ describe('createLoader', () => {
     expect(handler).toHaveBeenCalledTimes(1);
 
     // New command via push
-    loader.push(['identify', 'user-2']);
+    loader.push(['page', { url: '/about' }]);
     expect(handler).toHaveBeenCalledTimes(2);
-    expect(handler).toHaveBeenLastCalledWith(['identify', 'user-2']);
+    expect(handler).toHaveBeenLastCalledWith(['page', { url: '/about' }]);
   });
 
   it('handles empty window.__imtbl gracefully', () => {

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -230,62 +230,6 @@ describe('Pixel', () => {
     });
   });
 
-  describe('identify', () => {
-    it('enqueues identify message with identityType at full consent', () => {
-      mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-abc', isNew: false });
-
-      const pixel = new Pixel();
-      activePixel = pixel;
-      pixel.init({ key: 'pk_test', environment: 'dev', consent: 'full' });
-      mockEnqueue.mockClear();
-
-      pixel.identify('user-1', 'passport', { email: 'test@example.com' });
-
-      expect(mockEnqueue).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'identify',
-          userId: 'user-1',
-          identityType: 'passport',
-          surface: 'pixel',
-          traits: expect.objectContaining({
-            email: 'test@example.com',
-            sessionId: 'session-abc',
-          }),
-        }),
-      );
-    });
-
-    it('enqueues identify message without traits', () => {
-      mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-abc', isNew: false });
-
-      const pixel = new Pixel();
-      activePixel = pixel;
-      pixel.init({ key: 'pk_test', environment: 'dev', consent: 'full' });
-      mockEnqueue.mockClear();
-
-      pixel.identify('steam-id-123', 'steam');
-
-      expect(mockEnqueue).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'identify',
-          userId: 'steam-id-123',
-          identityType: 'steam',
-        }),
-      );
-    });
-
-    it('does not enqueue identify at anonymous consent', () => {
-      const pixel = new Pixel();
-      activePixel = pixel;
-      pixel.init({ key: 'pk_test', environment: 'dev', consent: 'anonymous' });
-
-      pixel.identify('user-1', 'passport');
-      // Only the auto page view + session_start, no identify
-      const calls = mockEnqueue.mock.calls.map((c: unknown[]) => (c[0] as Record<string, unknown>));
-      expect(calls.find((c) => c.type === 'identify')).toBeUndefined();
-    });
-  });
-
   describe('session_end', () => {
     it('fires session_end on pagehide when session is active', () => {
       const pixel = new Pixel();

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -3,11 +3,8 @@ import type {
   ConsentLevel,
   PageMessage,
   TrackMessage,
-  IdentifyMessage,
-  UserTraits,
   ConsentManager,
   CmpDetector,
-  IdentityType,
 } from '@imtbl/audience-core';
 import {
   MessageQueue,
@@ -161,27 +158,6 @@ export class Pixel {
         ...properties,
       },
       userId: this.consent!.level === 'full' ? this.userId : undefined,
-    };
-
-    this.queue!.enqueue(message);
-  }
-
-  identify(userId: string, identityType: IdentityType, traits?: UserTraits): void {
-    if (!this.isReady() || this.consent!.level !== 'full') return;
-
-    this.userId = userId;
-    const { sessionId, isNew } = getOrCreateSession(this.domain);
-    this.refreshSession(sessionId, isNew);
-
-    const message: IdentifyMessage = {
-      ...this.buildBase(),
-      type: 'identify',
-      userId,
-      identityType,
-      traits: {
-        ...traits,
-        sessionId,
-      } as UserTraits,
     };
 
     this.queue!.enqueue(message);

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -50,8 +50,6 @@ export class Pixel {
 
   private anonymousId = '';
 
-  private userId: string | undefined;
-
   private sessionId: string | undefined;
 
   private sessionStartTime: number | undefined;
@@ -157,7 +155,7 @@ export class Pixel {
         sessionId,
         ...properties,
       },
-      userId: this.consent!.level === 'full' ? this.userId : undefined,
+      userId: undefined,
     };
 
     this.queue!.enqueue(message);
@@ -232,7 +230,7 @@ export class Pixel {
       type: 'track',
       eventName,
       properties: { ...properties, sessionId },
-      userId: this.consent!.level === 'full' ? this.userId : undefined,
+      userId: undefined,
     };
 
     this.queue!.enqueue(message);
@@ -256,7 +254,7 @@ export class Pixel {
       type: 'track',
       eventName: 'session_start',
       properties: { sessionId },
-      userId: this.consent!.level === 'full' ? this.userId : undefined,
+      userId: undefined,
     };
 
     this.queue!.enqueue(message);
@@ -277,7 +275,7 @@ export class Pixel {
         sessionId: this.sessionId,
         duration,
       },
-      userId: this.consent!.level === 'full' ? this.userId : undefined,
+      userId: undefined,
     };
 
     this.queue!.enqueue(message);


### PR DESCRIPTION
## Summary

Closes SDK-101

- Removes the `identify()` method from the `Pixel` class and the `'identify'` command handler from `bootstrap.ts`
- Removes associated test cases (−95 lines, net −91)
- No changes to `@imtbl/audience-core` or `@imtbl/audience-sdk` — the SDK retains full identify/alias support

## Why

The pixel is a **passive** tracking surface — its job is auto-collecting device fingerprints, attribution context, and page views with zero instrumentation from the studio. `identify()` conflicts with this design:

1. **No realistic caller.** The pixel is integrated by pasting a `<script>` snippet onto a landing page. The integrator doesn't have access to `userId` or `identityType` — those come from authenticated sessions, which is Web SDK territory.
2. **Only works at `full` consent**, which is not the pixel's primary use case (`anonymous` consent for device fingerprinting/attribution).
3. **Identity signals are already captured passively** via form submission auto-capture (email hashing at `full` consent).
4. **Sharpens the surface boundary**: Pixel = passive attribution. SDK = active instrumentation.

Bundle impact: −315 bytes raw / −83 bytes gzipped (modest, since TS types are erased at compile time — the real win is architectural clarity).

## Test plan

- [x] All 74 pixel tests pass after removal
- [ ] Verify pixel bundle builds successfully
- [ ] Confirm no identify-related exports leak from the pixel package

🤖 Generated with [Claude Code](https://claude.com/claude-code)