### PR TITLE
refactor(audience): unify consent level checks via capability-query functions

### DIFF
--- a/packages/audience/core/src/consent.test.ts
+++ b/packages/audience/core/src/consent.test.ts
@@ -1,4 +1,6 @@
-import { createConsentManager } from './consent';
+import {
+  createConsentManager, canTrack, canIdentify, includesUserId,
+} from './consent';
 import type { HttpSend } from './transport';
 import { TransportError } from './errors';
 
@@ -23,6 +25,32 @@ function createMockQueue() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+describe('consent capability queries', () => {
+  it.each([
+    ['none', false],
+    ['anonymous', true],
+    ['full', true],
+  ] as const)('canTrack(%s) returns %s', (level, expected) => {
+    expect(canTrack(level)).toBe(expected);
+  });
+
+  it.each([
+    ['none', false],
+    ['anonymous', false],
+    ['full', true],
+  ] as const)('canIdentify(%s) returns %s', (level, expected) => {
+    expect(canIdentify(level)).toBe(expected);
+  });
+
+  it.each([
+    ['none', false],
+    ['anonymous', false],
+    ['full', true],
+  ] as const)('includesUserId(%s) returns %s', (level, expected) => {
+    expect(includesUserId(level)).toBe(expected);
+  });
 });
 
 describe('createConsentManager', () => {

--- a/packages/audience/core/src/consent.test.ts
+++ b/packages/audience/core/src/consent.test.ts
@@ -1,5 +1,5 @@
 import {
-  createConsentManager, canTrack, canIdentify, includesUserId,
+  createConsentManager, canTrack, canIdentify,
 } from './consent';
 import type { HttpSend } from './transport';
 import { TransportError } from './errors';
@@ -42,14 +42,6 @@ describe('consent capability queries', () => {
     ['full', true],
   ] as const)('canIdentify(%s) returns %s', (level, expected) => {
     expect(canIdentify(level)).toBe(expected);
-  });
-
-  it.each([
-    ['none', false],
-    ['anonymous', false],
-    ['full', true],
-  ] as const)('includesUserId(%s) returns %s', (level, expected) => {
-    expect(includesUserId(level)).toBe(expected);
   });
 });
 

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -11,6 +11,25 @@ export interface ConsentManager {
   setLevel(next: ConsentLevel): void;
 }
 
+// --- Consent capability queries ---
+// Single source of truth for what each consent level permits. Use these
+// instead of raw string comparisons so rule changes only touch this file.
+
+/** Can this consent level record anonymous page/track events? */
+export function canTrack(level: ConsentLevel): boolean {
+  return level !== 'none';
+}
+
+/** Can this consent level bind events to a named identity (identify/alias)? */
+export function canIdentify(level: ConsentLevel): boolean {
+  return level === 'full';
+}
+
+/** Should the userId field be attached to outgoing messages? */
+export function includesUserId(level: ConsentLevel): boolean {
+  return level === 'full';
+}
+
 export function detectDoNotTrack(): boolean {
   if (typeof navigator === 'undefined') return false;
   // DNT header

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -15,18 +15,13 @@ export interface ConsentManager {
 // Single source of truth for what each consent level permits. Use these
 // instead of raw string comparisons so rule changes only touch this file.
 
-/** Can this consent level record anonymous page/track events? */
+/** Can this consent level record events (page views, track calls)? */
 export function canTrack(level: ConsentLevel): boolean {
   return level !== 'none';
 }
 
-/** Can this consent level bind events to a named identity (identify/alias)? */
+/** Can this consent level use identity features (identify, alias, userId, email hash)? */
 export function canIdentify(level: ConsentLevel): boolean {
-  return level === 'full';
-}
-
-/** Should the userId field be attached to outgoing messages? */
-export function includesUserId(level: ConsentLevel): boolean {
   return level === 'full';
 }
 

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -11,16 +11,10 @@ export interface ConsentManager {
   setLevel(next: ConsentLevel): void;
 }
 
-// --- Consent capability queries ---
-// Single source of truth for what each consent level permits. Use these
-// instead of raw string comparisons so rule changes only touch this file.
-
-/** Can this consent level record events (page views, track calls)? */
 export function canTrack(level: ConsentLevel): boolean {
   return level !== 'none';
 }
 
-/** Can this consent level use identity features (identify, alias, userId, email hash)? */
 export function canIdentify(level: ConsentLevel): boolean {
   return level === 'full';
 }

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -50,7 +50,10 @@ export type { SessionResult } from './session';
 export { collectAttribution } from './attribution';
 export type { Attribution } from './attribution';
 
-export { createConsentManager, detectDoNotTrack } from './consent';
+export {
+  createConsentManager, detectDoNotTrack,
+  canTrack, canIdentify, includesUserId,
+} from './consent';
 export type { ConsentManager } from './consent';
 
 export { detectCmp, startCmpDetection } from './cmp';

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -52,7 +52,7 @@ export type { Attribution } from './attribution';
 
 export {
   createConsentManager, detectDoNotTrack,
-  canTrack, canIdentify, includesUserId,
+  canTrack, canIdentify,
 } from './consent';
 export type { ConsentManager } from './consent';
 

--- a/packages/audience/pixel/src/autocapture.ts
+++ b/packages/audience/pixel/src/autocapture.ts
@@ -1,4 +1,5 @@
 import type { ConsentLevel } from '@imtbl/audience-core';
+import { canTrack, includesUserId } from '@imtbl/audience-core';
 
 export interface AutocaptureOptions {
   /** Enable form submission auto-capture. Default: true */
@@ -68,7 +69,7 @@ export function setupAutocapture(
 
   if (options.forms !== false) {
     const onSubmit = (e: Event): void => {
-      if (getConsent() === 'none') return;
+      if (!canTrack(getConsent())) return;
 
       const form = e.target as HTMLFormElement;
       if (!form || form.tagName !== 'FORM') return;
@@ -81,7 +82,7 @@ export function setupAutocapture(
       };
 
       const consent = getConsent();
-      if (consent === 'full') {
+      if (includesUserId(consent)) {
         const email = findEmail(form);
         if (email) {
           // Hash before enqueuing — raw email never enters the queue.
@@ -109,7 +110,7 @@ export function setupAutocapture(
 
   if (options.clicks !== false) {
     const onClick = (e: Event): void => {
-      if (getConsent() === 'none') return;
+      if (!canTrack(getConsent())) return;
 
       const target = e.target as HTMLElement;
       const anchor = target.closest?.('a') as HTMLAnchorElement | null;

--- a/packages/audience/pixel/src/autocapture.ts
+++ b/packages/audience/pixel/src/autocapture.ts
@@ -1,5 +1,5 @@
 import type { ConsentLevel } from '@imtbl/audience-core';
-import { canTrack, includesUserId } from '@imtbl/audience-core';
+import { canTrack, canIdentify } from '@imtbl/audience-core';
 
 export interface AutocaptureOptions {
   /** Enable form submission auto-capture. Default: true */
@@ -82,7 +82,7 @@ export function setupAutocapture(
       };
 
       const consent = getConsent();
-      if (includesUserId(consent)) {
+      if (canIdentify(consent)) {
         const email = findEmail(form);
         if (email) {
           // Hash before enqueuing — raw email never enters the queue.

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -72,7 +72,7 @@ jest.mock('@imtbl/audience-core', () => ({
       };
     },
   ),
-  canTrack: (level: string) => level !== 'none',
+  canTrack: jest.fn().mockImplementation((level: string) => level !== 'none'),
 }));
 
 // Mock fetch globally

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -72,6 +72,7 @@ jest.mock('@imtbl/audience-core', () => ({
       };
     },
   ),
+  canTrack: (level: string) => level !== 'none',
 }));
 
 // Mock fetch globally

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -22,6 +22,7 @@ import {
   collectAttribution,
   getOrCreateSession,
   createConsentManager,
+  canTrack as consentAllowsTracking,
   startCmpDetection,
 } from '@imtbl/audience-core';
 import { setupAutocapture } from './autocapture';
@@ -124,7 +125,7 @@ export class Pixel {
     if (isAutoConsent) {
       // CMP detection will fire the deferred page view when consent upgrades.
       this.startCmpDetection();
-    } else if (this.consent.level !== 'none') {
+    } else if (consentAllowsTracking(this.consent.level)) {
       // Static consent — fire page view immediately.
       this.initialPageViewFired = true;
       this.page();
@@ -168,7 +169,7 @@ export class Pixel {
     // Fire the deferred page view if consent was upgraded from 'none'
     // (covers the case where CMP detection failed and the caller
     // manually sets consent as a fallback).
-    if (level !== 'none' && !this.initialPageViewFired) {
+    if (consentAllowsTracking(level) && !this.initialPageViewFired) {
       this.initialPageViewFired = true;
       this.page();
     }
@@ -200,7 +201,7 @@ export class Pixel {
       this.consent!.setLevel(level);
 
       // Fire the deferred page view on first consent upgrade from 'none'.
-      if (level !== 'none' && !this.initialPageViewFired) {
+      if (consentAllowsTracking(level) && !this.initialPageViewFired) {
         this.initialPageViewFired = true;
         this.page();
       }
@@ -210,7 +211,7 @@ export class Pixel {
       onCmpUpdate,
       (detector: CmpDetector) => {
         // CMP found — apply the initial consent level it reported.
-        if (detector.level !== 'none') {
+        if (consentAllowsTracking(detector.level)) {
           onCmpUpdate(detector.level);
         }
       },
@@ -338,7 +339,7 @@ export class Pixel {
   // -- Guards -------------------------------------------------------------
 
   private canTrack(): boolean {
-    return this.isReady() && this.consent!.level !== 'none';
+    return this.isReady() && consentAllowsTracking(this.consent!.level);
   }
 
   private isReady(): boolean {

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -22,7 +22,7 @@ import {
   collectAttribution,
   getOrCreateSession,
   createConsentManager,
-  canTrack as consentAllowsTracking,
+  canTrack,
   startCmpDetection,
 } from '@imtbl/audience-core';
 import { setupAutocapture } from './autocapture';
@@ -125,7 +125,7 @@ export class Pixel {
     if (isAutoConsent) {
       // CMP detection will fire the deferred page view when consent upgrades.
       this.startCmpDetection();
-    } else if (consentAllowsTracking(this.consent.level)) {
+    } else if (canTrack(this.consent.level)) {
       // Static consent — fire page view immediately.
       this.initialPageViewFired = true;
       this.page();
@@ -140,7 +140,7 @@ export class Pixel {
   }
 
   page(properties?: Record<string, unknown>): void {
-    if (!this.canTrack()) return;
+    if (!this.isTrackingAllowed()) return;
 
     const { sessionId, isNew } = getOrCreateSession(this.domain);
     this.refreshSession(sessionId, isNew);
@@ -169,7 +169,7 @@ export class Pixel {
     // Fire the deferred page view if consent was upgraded from 'none'
     // (covers the case where CMP detection failed and the caller
     // manually sets consent as a fallback).
-    if (consentAllowsTracking(level) && !this.initialPageViewFired) {
+    if (canTrack(level) && !this.initialPageViewFired) {
       this.initialPageViewFired = true;
       this.page();
     }
@@ -201,7 +201,7 @@ export class Pixel {
       this.consent!.setLevel(level);
 
       // Fire the deferred page view on first consent upgrade from 'none'.
-      if (consentAllowsTracking(level) && !this.initialPageViewFired) {
+      if (canTrack(level) && !this.initialPageViewFired) {
         this.initialPageViewFired = true;
         this.page();
       }
@@ -211,7 +211,7 @@ export class Pixel {
       onCmpUpdate,
       (detector: CmpDetector) => {
         // CMP found — apply the initial consent level it reported.
-        if (consentAllowsTracking(detector.level)) {
+        if (canTrack(detector.level)) {
           onCmpUpdate(detector.level);
         }
       },
@@ -221,7 +221,7 @@ export class Pixel {
   // -- Auto-capture helper --------------------------------------------------
 
   private track(eventName: string, properties: Record<string, unknown>): void {
-    if (!this.canTrack()) return;
+    if (!this.isTrackingAllowed()) return;
 
     const { sessionId, isNew } = getOrCreateSession(this.domain);
     this.refreshSession(sessionId, isNew);
@@ -248,7 +248,7 @@ export class Pixel {
   }
 
   private fireSessionStart(sessionId: string): void {
-    if (!this.canTrack()) return;
+    if (!this.isTrackingAllowed()) return;
 
     const message: TrackMessage = {
       ...this.buildBase(),
@@ -262,7 +262,7 @@ export class Pixel {
   }
 
   private fireSessionEnd(): void {
-    if (!this.canTrack() || !this.sessionId) return;
+    if (!this.isTrackingAllowed() || !this.sessionId) return;
 
     const duration = this.sessionStartTime
       ? Math.round((Date.now() - this.sessionStartTime) / 1000)
@@ -338,8 +338,8 @@ export class Pixel {
 
   // -- Guards -------------------------------------------------------------
 
-  private canTrack(): boolean {
-    return this.isReady() && consentAllowsTracking(this.consent!.level);
+  private isTrackingAllowed(): boolean {
+    return this.isReady() && canTrack(this.consent!.level);
   }
 
   private isReady(): boolean {

--- a/packages/audience/pixel/src/snippet.ts
+++ b/packages/audience/pixel/src/snippet.ts
@@ -1,11 +1,11 @@
-import type { Environment } from '@imtbl/audience-core';
+import type { ConsentLevel, Environment } from '@imtbl/audience-core';
 
 const DEFAULT_CDN_URL = 'https://cdn.immutable.com/pixel/v1/imtbl.js';
 
 export interface SnippetOptions {
   key: string;
   cdnUrl?: string;
-  consent?: 'none' | 'anonymous' | 'full';
+  consent?: ConsentLevel;
   environment?: Environment;
 }
 

--- a/packages/audience/sdk/src/index.ts
+++ b/packages/audience/sdk/src/index.ts
@@ -1,4 +1,4 @@
 export { Audience } from './sdk';
-export { IdentityType } from '@imtbl/audience-core';
+export { IdentityType, canTrack, canIdentify } from '@imtbl/audience-core';
 export type { AudienceConfig } from './types';
 export type { Environment, ConsentLevel, UserTraits } from '@imtbl/audience-core';

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -27,6 +27,9 @@ import {
   collectAttribution,
   getOrCreateSession,
   createConsentManager,
+  canTrack,
+  canIdentify,
+  includesUserId,
   SESSION_START,
   SESSION_END,
 } from '@imtbl/audience-core';
@@ -82,7 +85,7 @@ export class Audience {
     this.debug = new DebugLogger(config.debug ?? false);
 
     let isNewSession = false;
-    if (consentLevel !== 'none') {
+    if (canTrack(consentLevel)) {
       this.anonymousId = getOrCreateAnonymousId(cookieDomain);
       isNewSession = this.startSession();
     } else {
@@ -144,12 +147,12 @@ export class Audience {
 
   /** True when consent is 'none' — SDK should not enqueue anything. */
   private isTrackingDisabled(): boolean {
-    return this.consent.level === 'none';
+    return !canTrack(this.consent.level);
   }
 
   /** Returns userId if consent is full, undefined otherwise. */
   private effectiveUserId(): string | undefined {
-    return this.consent.level === 'full' ? this.userId : undefined;
+    return includesUserId(this.consent.level) ? this.userId : undefined;
   }
 
   /** Create or resume a session, returning whether it's new. */
@@ -274,7 +277,7 @@ export class Audience {
     identityType?: IdentityType,
     traits?: UserTraits,
   ): void {
-    if (this.consent.level !== 'full') {
+    if (!canIdentify(this.consent.level)) {
       this.debug.logWarning('identify() requires full consent — call ignored.');
       return;
     }
@@ -314,7 +317,7 @@ export class Audience {
     from: { id: string; identityType: IdentityType },
     to: { id: string; identityType: IdentityType },
   ): void {
-    if (this.consent.level !== 'full') {
+    if (!canIdentify(this.consent.level)) {
       this.debug.logWarning('alias() requires full consent — call ignored.');
       return;
     }
@@ -350,7 +353,7 @@ export class Audience {
 
     this.debug.logConsent(previous, level);
 
-    const isUpgradeFromNone = previous === 'none' && level !== 'none';
+    const isUpgradeFromNone = !canTrack(previous) && canTrack(level);
 
     // When upgrading from none, create the persisted anonymousId first
     // so the consent sync sends the correct ID to the server.

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -362,7 +362,7 @@ export class Audience {
 
     // Web-specific cleanup before core handles queue purge/transform and server sync.
     // session_end is intentionally not emitted — no events should be sent after opt-out.
-    if (level === 'none') {
+    if (!canTrack(level)) {
       this.queue.stop();
     }
 
@@ -371,10 +371,10 @@ export class Audience {
     this.consent.setLevel(level);
 
     // Web-specific cleanup after core's transition.
-    if (level === 'none') {
+    if (!canTrack(level)) {
       deleteCookie(COOKIE_NAME, this.cookieDomain);
       deleteCookie(SESSION_COOKIE, this.cookieDomain);
-    } else if (level === 'anonymous' && previous === 'full') {
+    } else if (canIdentify(previous) && !canIdentify(level)) {
       this.userId = undefined;
     }
 

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -29,7 +29,6 @@ import {
   createConsentManager,
   canTrack,
   canIdentify,
-  includesUserId,
   SESSION_START,
   SESSION_END,
 } from '@imtbl/audience-core';
@@ -152,7 +151,7 @@ export class Audience {
 
   /** Returns userId if consent is full, undefined otherwise. */
   private effectiveUserId(): string | undefined {
-    return includesUserId(this.consent.level) ? this.userId : undefined;
+    return canIdentify(this.consent.level) ? this.userId : undefined;
   }
 
   /** Create or resume a session, returning whether it's new. */

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -144,7 +144,7 @@ export class Audience {
 
   // --- Helpers ---
 
-  /** True when consent is 'none' — SDK should not enqueue anything. */
+  /** True when the current consent level does not permit tracking. */
   private isTrackingDisabled(): boolean {
     return !canTrack(this.consent.level);
   }


### PR DESCRIPTION
## Summary

- Add two helper functions to `@imtbl/audience-core`:
  - `canTrack(level)` — true if the level allows event recording
  - `canIdentify(level)` — true if the level allows identity features (identify, alias, userId, email hashing)
- Export both from `@imtbl/audience-core` and `@imtbl/audience`
- Replace `=== 'none'` / `=== 'full'` comparisons in `@imtbl/audience` (`sdk.ts`) and `@imtbl/pixel` (`pixel.ts`, `autocapture.ts`) with calls to these helpers
- Retype `SnippetOptions.consent` from `'none' | 'anonymous' | 'full'` to `ConsentLevel`
- Rename Pixel's private `canTrack()` method to `isTrackingAllowed()`

LInear: [SDK-122](https://linear.app/imtbl/issue/SDK-122/audience-sdk-unify-consent-level-checks)

## Tests

- core: 150 tests pass (6 new)
- sdk: 49 tests pass
- pixel: 78 tests pass
- `pnpm typecheck` and `pnpm lint` clean across all three packages