### PR TITLE
feat(audience): typed track() surface for v1 event catalogue (SDK-116)

### DIFF
--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -133,6 +133,8 @@ interface EventPropsMap {
   link_clicked: LinkClickedProperties;
 }
 
+export type AudienceEventName = keyof EventPropsMap;
+
 /**
  * Event name → property type. Falls back to `Record<string, unknown>` for
  * unknown names. Used by `sdk.track()` to type-check property shapes at the

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -1,0 +1,149 @@
+export const AudienceEvents = {
+  SIGN_UP: 'sign_up',
+  SIGN_IN: 'sign_in',
+  WISHLIST_ADD: 'wishlist_add',
+  WISHLIST_REMOVE: 'wishlist_remove',
+  PURCHASE: 'purchase',
+
+  GAME_LAUNCH: 'game_launch',
+  PROGRESSION: 'progression',
+  RESOURCE: 'resource',
+
+  EMAIL_ACQUIRED: 'email_acquired',
+  GAME_PAGE_VIEWED: 'game_page_viewed',
+  LINK_CLICKED: 'link_clicked',
+} as const;
+
+export interface SignUpProperties {
+  /** Optional. */
+  method?: string;
+}
+
+export interface SignInProperties {
+  /** Optional. */
+  method?: string;
+}
+
+export interface WishlistAddProperties {
+  /** Required. */
+  gameId: string;
+  /** Optional. */
+  source?: string;
+  /** Optional. */
+  platform?: string;
+}
+
+export interface WishlistRemoveProperties {
+  /** Required. */
+  gameId: string;
+}
+
+export interface PurchaseProperties {
+  /** Required. */
+  currency: string;
+  /** Required. */
+  value: number;
+  /** Optional. */
+  itemId?: string;
+  /** Optional. */
+  itemName?: string;
+  /** Optional. */
+  quantity?: number;
+  /** Optional. */
+  transactionId?: string;
+}
+
+export interface GameLaunchProperties {
+  /** Optional. */
+  platform?: string;
+  /** Optional. */
+  version?: string;
+  /** Optional. */
+  buildId?: string;
+}
+
+export type ProgressionStatus = 'start' | 'complete' | 'fail';
+
+export interface ProgressionProperties {
+  /** Required. */
+  status: ProgressionStatus;
+  /** Optional. */
+  world?: string;
+  /** Optional. */
+  level?: string;
+  /** Optional. */
+  stage?: string;
+  /** Optional. */
+  score?: number;
+  /** Optional. */
+  durationSec?: number;
+}
+
+export type ResourceFlow = 'sink' | 'source';
+
+export interface ResourceProperties {
+  /** Required. */
+  flow: ResourceFlow;
+  /** Required. */
+  currency: string;
+  /** Required. */
+  amount: number;
+  /** Optional. */
+  itemType?: string;
+  /** Optional. */
+  itemId?: string;
+}
+
+export interface EmailAcquiredProperties {
+  /** Optional. */
+  source?: string;
+}
+
+export interface GamePageViewedProperties {
+  /** Required. */
+  gameId: string;
+  /** Optional. */
+  gameName?: string;
+  /** Optional. */
+  slug?: string;
+}
+
+export interface LinkClickedProperties {
+  /** Required. */
+  url: string;
+  /** Optional. */
+  label?: string;
+  /** Optional. */
+  source?: string;
+  /** Optional. */
+  gameId?: string;
+}
+
+interface EventPropsMap {
+  sign_up: SignUpProperties;
+  sign_in: SignInProperties;
+  wishlist_add: WishlistAddProperties;
+  wishlist_remove: WishlistRemoveProperties;
+  purchase: PurchaseProperties;
+  game_launch: GameLaunchProperties;
+  progression: ProgressionProperties;
+  resource: ResourceProperties;
+  email_acquired: EmailAcquiredProperties;
+  game_page_viewed: GamePageViewedProperties;
+  link_clicked: LinkClickedProperties;
+}
+
+/**
+ * Event name → property type. Falls back to `Record<string, unknown>` for
+ * unknown names. Used by `sdk.track()` to type-check property shapes at the
+ * call site. Invariants pinned by `sdk.test-d.ts` — run it before simplifying.
+ * For example, `sdk.track('purchase', { currency: 'USD' })` fails to compile
+ * because `PurchaseProperties.value` is missing.
+ *
+ * If you change `PropsFor` (e.g. remove `Record<string, unknown>`), run
+ * `pnpm typecheck` after any edit. `sdk.test-d.ts` has deliberately-wrong
+ * `sdk.track()` calls that should fail to compile. If your edit makes any
+ * of them start compiling, the build breaks.
+ */
+export type PropsFor<E extends string> =
+  E extends keyof EventPropsMap ? EventPropsMap[E] : Record<string, unknown>;

--- a/packages/audience/sdk/src/index.ts
+++ b/packages/audience/sdk/src/index.ts
@@ -3,12 +3,14 @@ export { AudienceEvents } from './events';
 export { IdentityType, canTrack, canIdentify } from '@imtbl/audience-core';
 export type { AudienceConfig } from './types';
 export type {
+  AudienceEventName,
   EmailAcquiredProperties,
   GameLaunchProperties,
   GamePageViewedProperties,
   LinkClickedProperties,
   ProgressionProperties,
   ProgressionStatus,
+  PropsFor,
   PurchaseProperties,
   ResourceFlow,
   ResourceProperties,

--- a/packages/audience/sdk/src/index.ts
+++ b/packages/audience/sdk/src/index.ts
@@ -1,4 +1,20 @@
 export { Audience } from './sdk';
+export { AudienceEvents } from './events';
 export { IdentityType, canTrack, canIdentify } from '@imtbl/audience-core';
 export type { AudienceConfig } from './types';
+export type {
+  EmailAcquiredProperties,
+  GameLaunchProperties,
+  GamePageViewedProperties,
+  LinkClickedProperties,
+  ProgressionProperties,
+  ProgressionStatus,
+  PurchaseProperties,
+  ResourceFlow,
+  ResourceProperties,
+  SignInProperties,
+  SignUpProperties,
+  WishlistAddProperties,
+  WishlistRemoveProperties,
+} from './events';
 export type { ConsentLevel, UserTraits } from '@imtbl/audience-core';

--- a/packages/audience/sdk/src/sdk.test-d.ts
+++ b/packages/audience/sdk/src/sdk.test-d.ts
@@ -1,0 +1,120 @@
+import { Audience, AudienceEvents } from './index';
+
+declare const sdk: Audience;
+
+sdk.track('sign_up');
+sdk.track('sign_up', { method: 'email' });
+sdk.track('sign_in');
+sdk.track('sign_in', { method: 'passport' });
+sdk.track('wishlist_add', { gameId: 'abc' });
+sdk.track('wishlist_add', { gameId: 'abc', source: 'game_page', platform: 'steam' });
+sdk.track('wishlist_remove', { gameId: 'abc' });
+sdk.track('purchase', { currency: 'USD', value: 9.99 });
+sdk.track('purchase', {
+  currency: 'USD',
+  value: 9.99,
+  itemId: 'sku_1',
+  itemName: 'Gold Pack',
+  quantity: 2,
+  transactionId: 'txn_42',
+});
+sdk.track('game_launch');
+sdk.track('game_launch', { platform: 'webgl', version: '1.2.0', buildId: 'ci-42' });
+sdk.track('progression', { status: 'start' });
+sdk.track('progression', { status: 'complete', world: 'tutorial' });
+sdk.track('progression', {
+  status: 'fail',
+  world: 'forest',
+  level: '5',
+  stage: 'boss',
+  score: 420,
+  durationSec: 87,
+});
+sdk.track('resource', { flow: 'sink', currency: 'gold', amount: 50 });
+sdk.track('resource', {
+  flow: 'source',
+  currency: 'USD',
+  amount: 9.99,
+  itemType: 'iap',
+  itemId: 'sku_1',
+});
+sdk.track('email_acquired');
+sdk.track('email_acquired', { source: 'linked_account_steam' });
+sdk.track('game_page_viewed', { gameId: 'abc' });
+sdk.track('game_page_viewed', { gameId: 'abc', gameName: 'Devilfish', slug: 'devilfish' });
+sdk.track('link_clicked', { url: 'https://example.com' });
+sdk.track('link_clicked', {
+  url: 'https://example.com',
+  label: 'Play Now',
+  source: 'game_page',
+  gameId: 'abc',
+});
+
+sdk.track(AudienceEvents.SIGN_UP, { method: 'email' });
+sdk.track(AudienceEvents.PURCHASE, { currency: 'USD', value: 9.99 });
+sdk.track(AudienceEvents.PROGRESSION, { status: 'complete' });
+
+// @ts-expect-error — missing required 'value'
+sdk.track('purchase', { currency: 'USD' });
+
+// @ts-expect-error — missing required 'gameId'
+sdk.track('wishlist_add', {});
+
+// @ts-expect-error — missing required 'status'
+sdk.track('progression', { world: 'tutorial' });
+
+// @ts-expect-error — missing required 'flow', 'currency', 'amount'
+sdk.track('resource', { itemType: 'iap' });
+
+// @ts-expect-error — missing required 'url'
+sdk.track('link_clicked', { label: 'Play Now' });
+
+// @ts-expect-error — missing required 'gameId'
+sdk.track('game_page_viewed', {});
+
+// @ts-expect-error — purchase requires properties
+sdk.track('purchase');
+
+// @ts-expect-error — wishlist_add requires properties
+sdk.track('wishlist_add');
+
+// @ts-expect-error — wishlist_remove requires properties
+sdk.track('wishlist_remove');
+
+// @ts-expect-error — progression requires properties
+sdk.track('progression');
+
+// @ts-expect-error — resource requires properties
+sdk.track('resource');
+
+// @ts-expect-error — game_page_viewed requires properties
+sdk.track('game_page_viewed');
+
+// @ts-expect-error — link_clicked requires properties
+sdk.track('link_clicked');
+
+// @ts-expect-error — unknown property 'currenyc'
+sdk.track('purchase', { currenyc: 'USD', value: 9.99 });
+
+// @ts-expect-error — unknown property 'extra'
+sdk.track('purchase', { currency: 'USD', value: 9.99, extra: 1 });
+
+// @ts-expect-error — unknown property 'isLoggedIn'
+sdk.track('link_clicked', { url: 'x', isLoggedIn: true });
+
+// @ts-expect-error — 'value' must be number
+sdk.track('purchase', { currency: 'USD', value: '9.99' });
+
+// @ts-expect-error — 'status' must be a ProgressionStatus
+sdk.track('progression', { status: 'done' });
+
+// @ts-expect-error — 'flow' must be a ResourceFlow
+sdk.track('resource', { flow: 'both', currency: 'gold', amount: 1 });
+
+sdk.track('beta_key_redeemed', { source: 'influencer' });
+sdk.track('discord_joined');
+sdk.track('trailer_watched', { duration: 45, platform: 'youtube' });
+
+declare const dynamicName: string;
+sdk.track(dynamicName, { anything: 'goes' });
+sdk.track(dynamicName);

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -234,6 +234,123 @@ describe('Audience', () => {
 
       sdk.shutdown();
     });
+
+    it('enqueues sign_up with method property', async () => {
+      const sdk = createSDK();
+
+      sdk.track('sign_up', { method: 'email' });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'sign_up',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.properties).toEqual({ method: 'email' });
+
+      sdk.shutdown();
+    });
+
+    it('enqueues game_launch with optional fields', async () => {
+      const sdk = createSDK();
+
+      sdk.track('game_launch', {
+        platform: 'webgl',
+        version: '1.2.0',
+        buildId: 'ci-42',
+      });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'game_launch',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.properties).toEqual({
+        platform: 'webgl',
+        version: '1.2.0',
+        buildId: 'ci-42',
+      });
+
+      sdk.shutdown();
+    });
+
+    it('enqueues progression with status and optional gameplay fields', async () => {
+      const sdk = createSDK();
+
+      sdk.track('progression', {
+        status: 'complete',
+        world: 'forest',
+        level: '5',
+        stage: 'boss',
+        score: 420,
+        durationSec: 87,
+      });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'progression',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.properties).toEqual({
+        status: 'complete',
+        world: 'forest',
+        level: '5',
+        stage: 'boss',
+        score: 420,
+        durationSec: 87,
+      });
+
+      sdk.shutdown();
+    });
+
+    it('enqueues resource with flow, currency, and amount', async () => {
+      const sdk = createSDK();
+
+      sdk.track('resource', {
+        flow: 'source',
+        currency: 'gold',
+        amount: 50,
+        itemType: 'quest_reward',
+        itemId: 'quest_42',
+      });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'resource',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.properties).toEqual({
+        flow: 'source',
+        currency: 'gold',
+        amount: 50,
+        itemType: 'quest_reward',
+        itemId: 'quest_42',
+      });
+
+      sdk.shutdown();
+    });
+
+    it('enqueues wishlist_add with gameId and optional fields', async () => {
+      const sdk = createSDK();
+
+      sdk.track('wishlist_add', {
+        gameId: 'devilfish',
+        source: 'game_page',
+        platform: 'steam',
+      });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'wishlist_add',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.properties).toEqual({
+        gameId: 'devilfish',
+        source: 'game_page',
+        platform: 'steam',
+      });
+
+      sdk.shutdown();
+    });
   });
 
   describe('page', () => {
@@ -536,7 +653,7 @@ describe('Audience', () => {
       expect(document.cookie).toContain(`${COOKIE_NAME}=`);
 
       sdk.identify(TEST_USER.id, TEST_USER.identityType);
-      sdk.track('purchase', { value: 9.99 });
+      sdk.track('purchase', { currency: 'USD', value: 9.99 });
       await sdk.flush();
 
       const trackMsg = sentMessages().find(

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -29,7 +29,7 @@ import {
   SESSION_END,
 } from '@imtbl/audience-core';
 import { DebugLogger } from './debug';
-import type { PropsFor } from './events';
+import type { AudienceEventName, PropsFor } from './events';
 import type { AudienceConfig } from './types';
 import {
   LIBRARY_NAME, LIBRARY_VERSION, LOG_PREFIX, DEFAULT_CONSENT_SOURCE,
@@ -234,9 +234,11 @@ export class Audience {
   /**
    * Record a player action like a purchase, sign-up, or game launch.
    * Pass the event name and any properties you want to analyse later.
+   * For the predefined event names (`sign_up`, `purchase`, etc.),
+   * TypeScript enforces the property shape at the call site.
    * No-op when consent is 'none'.
    */
-  track<E extends string>(
+  track<E extends AudienceEventName | string & {}>(
     event: E,
     ...args: {} extends PropsFor<E>
       ? [properties?: PropsFor<E>]

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -29,6 +29,7 @@ import {
   SESSION_END,
 } from '@imtbl/audience-core';
 import { DebugLogger } from './debug';
+import type { PropsFor } from './events';
 import type { AudienceConfig } from './types';
 import {
   LIBRARY_NAME, LIBRARY_VERSION, LOG_PREFIX, DEFAULT_CONSENT_SOURCE,
@@ -235,15 +236,21 @@ export class Audience {
    * Pass the event name and any properties you want to analyse later.
    * No-op when consent is 'none'.
    */
-  track(event: string, properties?: Record<string, unknown>): void {
+  track<E extends string>(
+    event: E,
+    ...args: {} extends PropsFor<E>
+      ? [properties?: PropsFor<E>]
+      : [properties: PropsFor<E>]
+  ): void {
     if (this.isTrackingDisabled()) return;
     getOrCreateSession(this.cookieDomain);
 
+    const [properties] = args;
     this.enqueue('track', {
       ...this.baseMessage(),
       type: 'track',
       eventName: truncate(event),
-      properties,
+      properties: properties as Record<string, unknown> | undefined,
       userId: this.effectiveUserId(),
     });
   }


### PR DESCRIPTION
# Summary

Adds pre-defined events per the [Web SDK Event Reference (v1)](https://immutable.atlassian.net/wiki/spaces/~84417537/pages/3862560801/Web+SDK+Event+Reference+v1). 

Linear: [SDK-116](https://linear.app/imtbl/issue/SDK-116/pre-defined-events-v1).

# Detail and impact of the change

## Added

- Rewrites `sdk.track()` as a generic `track<E extends string>` with a `PropsFor<E>` conditional type mapping each of 11 event names to its property interface
- Exports `AudienceEvents`, 11 `*Properties` interfaces, `ProgressionStatus`, `ResourceFlow`
- Adds `sdk.test-d.ts` with compile-time negative assertions
- Adds runtime regression tests for 5 of the new events

## Demo

https://github.com/user-attachments/assets/201ee92e-c23d-447c-989b-e68589c2a05a

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm typegen` — 54/54 passing
