### PR TITLE
refactor(audience): remove redundant Required/Optional JSDoc (SDK-116)

### DIFF
--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -15,107 +15,73 @@ export const AudienceEvents = {
 } as const;
 
 export interface SignUpProperties {
-  /** Optional. */
   method?: string;
 }
 
 export interface SignInProperties {
-  /** Optional. */
   method?: string;
 }
 
 export interface WishlistAddProperties {
-  /** Required. */
   gameId: string;
-  /** Optional. */
   source?: string;
-  /** Optional. */
   platform?: string;
 }
 
 export interface WishlistRemoveProperties {
-  /** Required. */
   gameId: string;
 }
 
 export interface PurchaseProperties {
-  /** Required. */
   currency: string;
-  /** Required. */
   value: number;
-  /** Optional. */
   itemId?: string;
-  /** Optional. */
   itemName?: string;
-  /** Optional. */
   quantity?: number;
-  /** Optional. */
   transactionId?: string;
 }
 
 export interface GameLaunchProperties {
-  /** Optional. */
   platform?: string;
-  /** Optional. */
   version?: string;
-  /** Optional. */
   buildId?: string;
 }
 
 export type ProgressionStatus = 'start' | 'complete' | 'fail';
 
 export interface ProgressionProperties {
-  /** Required. */
   status: ProgressionStatus;
-  /** Optional. */
   world?: string;
-  /** Optional. */
   level?: string;
-  /** Optional. */
   stage?: string;
-  /** Optional. */
   score?: number;
-  /** Optional. */
   durationSec?: number;
 }
 
 export type ResourceFlow = 'sink' | 'source';
 
 export interface ResourceProperties {
-  /** Required. */
   flow: ResourceFlow;
-  /** Required. */
   currency: string;
-  /** Required. */
   amount: number;
-  /** Optional. */
   itemType?: string;
-  /** Optional. */
   itemId?: string;
 }
 
 export interface EmailAcquiredProperties {
-  /** Optional. */
   source?: string;
 }
 
 export interface GamePageViewedProperties {
-  /** Required. */
   gameId: string;
-  /** Optional. */
   gameName?: string;
-  /** Optional. */
   slug?: string;
 }
 
 export interface LinkClickedProperties {
-  /** Required. */
   url: string;
-  /** Optional. */
   label?: string;
-  /** Optional. */
   source?: string;
-  /** Optional. */
   gameId?: string;
 }
 


### PR DESCRIPTION
# Summary

Removes the `/** Required. */` / `/** Optional. */` JSDoc labels from every property in `events.ts`. TypeScript's `?` modifier already encodes optionality — the labels duplicate the syntax without adding information.

Linear: [SDK-116](https://linear.app/imtbl/issue/SDK-116/pre-defined-events-v1).
