### PR TITLE
feat(audience): CDN bundle entry point and tsup build (SDK-115)

### DIFF
--- a/packages/audience/sdk/jest.cdn-artifact.config.ts
+++ b/packages/audience/sdk/jest.cdn-artifact.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from 'jest';
+
+// Runs the CDN artifact smoke test in isolation from the default suite.
+// Default suite (jest.config.ts) scopes to src/ and tests TypeScript source;
+// this config scopes to test/ and asserts against the built IIFE in dist/cdn.
+const config: Config = {
+  roots: ['<rootDir>/test'],
+  // jsdom, not node: at least one transitive dep in the bundle touches a
+  // browser global (navigator, sessionStorage, or similar) during module
+  // init, so a bare node realm throws before the side-effect global
+  // assignment runs. jsdom provides those globals, matching the real
+  // <script>-tag target environment the bundle is built for.
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(t|j)sx?$': '@swc/jest',
+  },
+};
+
+export default config;

--- a/packages/audience/sdk/package.json
+++ b/packages/audience/sdk/package.json
@@ -52,14 +52,16 @@
   },
   "repository": "immutable/ts-immutable-sdk.git",
   "scripts": {
-    "build": "pnpm transpile && pnpm typegen",
+    "build": "pnpm transpile && pnpm transpile:cdn && pnpm typegen",
     "transpile": "tsup --config tsup.config.js",
+    "transpile:cdn": "tsup --config ./tsup.cdn.js",
     "typegen": "tsc --customConditions default --emitDeclarationOnly --outDir dist/types && rollup -c rollup.dts.config.js && find dist/types -name '*.d.ts' ! -name 'index.d.ts' -delete",
     "lint": "eslint ./src --ext .ts,.jsx,.tsx --max-warnings=0",
     "pack:root": "pnpm pack --pack-destination $(dirname $(pnpm root -w))",
     "prepack": "node scripts/prepack.mjs",
     "postpack": "node scripts/postpack.mjs",
-    "test": "jest --passWithNoTests",
+    "test": "jest --passWithNoTests && pnpm test:cdn-artifact",
+    "test:cdn-artifact": "pnpm transpile:cdn && jest --config jest.cdn-artifact.config.ts",
     "test:watch": "jest --watch",
     "typecheck": "tsc --customConditions development --noEmit --jsx preserve"
   },

--- a/packages/audience/sdk/src/cdn.test.ts
+++ b/packages/audience/sdk/src/cdn.test.ts
@@ -1,0 +1,53 @@
+import type { ImmutableAudienceGlobal } from './cdn';
+
+describe('cdn entry point', () => {
+  beforeEach(() => {
+    delete (globalThis as unknown as { ImmutableAudience?: unknown }).ImmutableAudience;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { ImmutableAudience?: unknown }).ImmutableAudience;
+  });
+
+  it('attaches the SDK surface to window.ImmutableAudience', async () => {
+    await import('./cdn');
+    const g = (globalThis as unknown as {
+      ImmutableAudience?: ImmutableAudienceGlobal;
+    }).ImmutableAudience;
+
+    expect(g).toBeDefined();
+    expect(typeof g!.init).toBe('function');
+    expect(typeof g!.AudienceEvents).toBe('object');
+    expect(typeof g!.canTrack).toBe('function');
+    expect(typeof g!.canIdentify).toBe('function');
+    expect(g!.IdentityType.Passport).toBe('passport');
+    expect(g!.IdentityType.Steam).toBe('steam');
+    expect(g!.IdentityType.Custom).toBe('custom');
+    expect(typeof g!.version).toBe('string');
+    expect(g!.version.length).toBeGreaterThan(0);
+
+    const err = new g!.AudienceError({
+      code: 'NETWORK_ERROR',
+      message: 'test',
+      status: 0,
+      endpoint: 'https://example.com',
+    });
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('does not overwrite a pre-existing global', async () => {
+    const sentinel = { Audience: 'FAKE' };
+    (globalThis as unknown as { ImmutableAudience?: unknown }).ImmutableAudience = sentinel;
+
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    await import('./cdn');
+
+    expect(
+      (globalThis as unknown as { ImmutableAudience?: unknown }).ImmutableAudience,
+    ).toBe(sentinel);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('loaded twice'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Remove the old <script> tag'));
+    warn.mockRestore();
+  });
+});

--- a/packages/audience/sdk/src/cdn.ts
+++ b/packages/audience/sdk/src/cdn.ts
@@ -1,0 +1,44 @@
+import {
+  AudienceError,
+  IdentityType,
+  canIdentify,
+  canTrack,
+} from '@imtbl/audience-core';
+
+import { Audience } from './sdk';
+import { AudienceEvents } from './events';
+import { LIBRARY_VERSION } from './config';
+
+export type ImmutableAudienceGlobal = {
+  init: typeof Audience.init;
+  AudienceError: typeof AudienceError;
+  AudienceEvents: typeof AudienceEvents;
+  IdentityType: typeof IdentityType;
+  canIdentify: typeof canIdentify;
+  canTrack: typeof canTrack;
+  version: string;
+};
+
+// Fallback for es2018 targets that predate globalThis (Safari < 12.1).
+const globalObj = (
+  typeof globalThis !== 'undefined' ? globalThis : window
+) as unknown as { ImmutableAudience?: ImmutableAudienceGlobal };
+
+if (globalObj.ImmutableAudience) {
+  const existingVersion = globalObj.ImmutableAudience.version ?? 'unknown';
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[@imtbl/audience] CDN bundle loaded twice; keeping v${existingVersion}. `
+    + 'Remove the old <script> tag to load a different version.',
+  );
+} else {
+  globalObj.ImmutableAudience = {
+    init: Audience.init.bind(Audience),
+    AudienceError,
+    AudienceEvents,
+    IdentityType,
+    canIdentify,
+    canTrack,
+    version: LIBRARY_VERSION,
+  };
+}

--- a/packages/audience/sdk/src/index.ts
+++ b/packages/audience/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export { Audience } from './sdk';
 export { AudienceEvents } from './events';
 export { IdentityType, canTrack, canIdentify } from '@imtbl/audience-core';
+export type { ImmutableAudienceGlobal } from './cdn';
 export type { AudienceConfig } from './types';
 export type {
   AudienceEventName,

--- a/packages/audience/sdk/test/cdn-artifact.test.ts
+++ b/packages/audience/sdk/test/cdn-artifact.test.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Tests the actual built IIFE, not the TypeScript source. Catches failure
+// modes that src/cdn.test.ts cannot: a broken tsup.cdn.js config, a missing
+// noExternal entry, an unreplaced __SDK_VERSION__ placeholder, or an IIFE
+// wrapper that clobbers the side-effect global assignment.
+//
+// Runs under testEnvironment: 'jsdom' so `window`, `navigator`, and
+// `globalThis` are all present — matching a real <script>-tag load.
+
+const ARTIFACT_PATH = path.resolve(
+  __dirname,
+  '../dist/cdn/imtbl-audience.global.js',
+);
+
+type AudienceInstance = {
+  track: (...args: unknown[]) => unknown;
+  shutdown: () => void;
+};
+
+type AudienceGlobal = {
+  init: (config: { publishableKey: string; [k: string]: unknown }) => AudienceInstance;
+  AudienceError: unknown;
+  AudienceEvents: Record<string, string>;
+  IdentityType: Record<string, string>;
+  canIdentify: unknown;
+  canTrack: unknown;
+  version: string;
+};
+
+describe('CDN bundle artifact', () => {
+  let g: AudienceGlobal;
+  let fetchMock: jest.Mock;
+
+  beforeAll(() => {
+    if (!fs.existsSync(ARTIFACT_PATH)) {
+      throw new Error(
+        `CDN artifact not found at ${ARTIFACT_PATH}. `
+        + 'Run `pnpm transpile:cdn` (or `pnpm build`) before this test.',
+      );
+    }
+
+    // jsdom does not provide fetch; stub it before the bundle (or any init
+    // call) touches it. Returns a generic OK so transport code does not
+    // blow up when flushing queued events during the init() smoke test.
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => '',
+    });
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    const source = fs.readFileSync(ARTIFACT_PATH, 'utf8');
+    // Evaluates the pre-built bundle in the test's realm, the same way a
+    // <script> tag does. Not user input — it's our own build output — so
+    // the implied-eval rule doesn't apply. vm.runInThisContext was tried
+    // first but runs in Node's root context, bypassing jsdom's window.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    new Function(source)();
+    g = (globalThis as unknown as { ImmutableAudience: AudienceGlobal })
+      .ImmutableAudience;
+  });
+
+  afterAll(() => {
+    delete (globalThis as unknown as { ImmutableAudience?: unknown })
+      .ImmutableAudience;
+    delete (globalThis as unknown as { fetch?: unknown }).fetch;
+  });
+
+  it('attaches ImmutableAudience to globalThis as a side effect', () => {
+    expect(g).toBeDefined();
+  });
+
+  it('exposes every runtime value that the npm entry exports', () => {
+    expect(typeof g.init).toBe('function');
+    expect(typeof g.AudienceError).toBe('function');
+    expect(typeof g.AudienceEvents).toBe('object');
+    expect(typeof g.IdentityType).toBe('object');
+    expect(typeof g.canIdentify).toBe('function');
+    expect(typeof g.canTrack).toBe('function');
+    expect(typeof g.version).toBe('string');
+  });
+
+  it('replaces the __SDK_VERSION__ placeholder at build time', () => {
+    expect(g.version).not.toBe('__SDK_VERSION__');
+    expect(g.version.length).toBeGreaterThan(0);
+  });
+
+  it('populates the IdentityType enum', () => {
+    expect(g.IdentityType.Passport).toBe('passport');
+    expect(g.IdentityType.Steam).toBe('steam');
+    expect(g.IdentityType.Custom).toBe('custom');
+  });
+
+  it('init() returns a working Audience instance end-to-end', () => {
+    // Happy path a studio would copy-paste: ImmutableAudience.init({...}).
+    // Verifies the IIFE wrapper preserved the class constructor end-to-end,
+    // not just the type of init.
+    const audience = g.init({ publishableKey: 'pk_test_smoketest' });
+    try {
+      expect(audience).toBeDefined();
+      expect(typeof audience.track).toBe('function');
+      expect(typeof audience.shutdown).toBe('function');
+    } finally {
+      audience.shutdown();
+    }
+  });
+});

--- a/packages/audience/sdk/tsconfig.eslint.json
+++ b/packages/audience/sdk/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"],
+  "include": ["src", "test", "jest.cdn-artifact.config.ts"],
   "exclude": []
 }

--- a/packages/audience/sdk/tsconfig.json
+++ b/packages/audience/sdk/tsconfig.json
@@ -6,5 +6,12 @@
     "customConditions": ["development"]
   },
   "include": ["src"],
-  "exclude": ["dist", "jest.config.ts", "node_modules", "src/**/*.test.ts"]
+  "exclude": [
+    "dist",
+    "jest.config.ts",
+    "jest.cdn-artifact.config.ts",
+    "node_modules",
+    "src/**/*.test.ts",
+    "test"
+  ]
 }

--- a/packages/audience/sdk/tsup.cdn.js
+++ b/packages/audience/sdk/tsup.cdn.js
@@ -1,0 +1,24 @@
+// @ts-check
+import { defineConfig } from 'tsup';
+import { replace } from 'esbuild-plugin-replace';
+import pkg from './package.json' with { type: 'json' };
+
+// IIFE bundle of @imtbl/audience for <script>-tag loading. Runs after the
+// ESM/CJS build in tsup.config.js — `clean: false` preserves that output.
+export default defineConfig({
+  entry: { 'imtbl-audience': 'src/cdn.ts' },
+  format: ['iife'],
+  outDir: 'dist/cdn',
+  outExtension: () => ({ js: '.global.js' }),
+  minify: true,
+  clean: false,
+  target: 'es2018',
+  platform: 'browser',
+  dts: false,
+  treeshake: true,
+  // IIFE has no runtime module resolution — inline everything, including npm deps.
+  noExternal: [/.*/],
+  esbuildPlugins: [
+    replace({ __SDK_VERSION__: pkg.version === '0.0.0' ? '0.0.0-local' : pkg.version }),
+  ],
+});

--- a/packages/audience/sdk/tsup.config.js
+++ b/packages/audience/sdk/tsup.config.js
@@ -29,7 +29,7 @@ export default defineConfig((options) => {
           modules: ['crypto', 'buffer', 'process'],
         }),
         replace({
-          __SDK_VERSION__: pkg.version === '0.0.0' ? '2.0.0' : pkg.version,
+          __SDK_VERSION__: pkg.version === '0.0.0' ? '0.0.0-local' : pkg.version,
         }),
       ],
     };


### PR DESCRIPTION
# Summary

Adds a single-file IIFE build of `@imtbl/audience` at `dist/cdn/imtbl-audience.global.js` so studios can embed via `<script>` and call `ImmutableAudience.Audience.init({...})` — no bundler, no `npm install` required.

Linear: [SDK-115](https://linear.app/imtbl/issue/SDK-115/cdn-bundle).