### PR TITLE
docs(audience): add @imtbl/audience README (SDK-115)

### DIFF
--- a/packages/audience/pixel/README.md
+++ b/packages/audience/pixel/README.md
@@ -151,3 +151,10 @@ Note: the nonce covers the inline snippet only. The CDN-loaded script (`imtbl.js
 | Firefox | 78+ |
 | Safari | 14+ |
 | Edge | 80+ |
+
+## Documentation
+
+- [Tracking Pixel](https://docs.immutable.com/docs/products/audience/tracking-pixel) — this package (setup, consent modes, auto-tracked events)
+- [Web SDK](https://docs.immutable.com/docs/products/audience/web-sdk) — sibling `@imtbl/audience` package for typed event tracking and identity management
+- [REST API](https://docs.immutable.com/docs/products/audience/rest-api) — backend reference for direct integration
+- [Data dictionary](https://docs.immutable.com/docs/products/audience/data-dictionary) — predefined event names and property schemas

--- a/packages/audience/sdk/README.md
+++ b/packages/audience/sdk/README.md
@@ -8,27 +8,6 @@ IIFE for `<script>`-tag loading.
 > stabilising but breaking changes may still land before the first
 > published release.
 
-## Which Immutable event-tracking product is this?
-
-Immutable ships two complementary event-tracking products in this
-monorepo. Pick based on your integration shape:
-
-- **`@imtbl/audience`** (this package) — the programmatic SDK. You call
-  `Audience.init()` from your app code and explicitly track events
-  (`track('purchase', {...})`, `identify()`, `setConsent()`, etc.).
-  Pick this when you need fine-grained control, typed events, player
-  identity, or explicit consent state machines.
-- **`@imtbl/pixel`** ([sibling package](../pixel/README.md)) — a drop-in
-  `<script>` snippet that captures page views, device signals, and
-  attribution data passively. Zero configuration beyond a publishable
-  key. Pick this for marketing sites, landing pages, and web shops
-  where you want to measure campaign performance without writing
-  tracking code.
-
-The two share the same backend pipeline, the same anonymous-id cookie
-(`imtbl_anon_id`), and the same publishable-key format — they're
-designed to coexist on a single site if you need both at once.
-
 ## Install
 
 ```sh
@@ -41,9 +20,7 @@ yarn add @imtbl/audience
 
 For the CDN build, drop one `<script>` tag into your HTML and call
 `ImmutableAudience.init({...})` — no bundler, no `npm install`.
-Once `@imtbl/audience` is published, the bundle URL will be
-`https://cdn.jsdelivr.net/npm/@imtbl/audience@<version>/dist/cdn/imtbl-audience.global.js`
-(replace `<version>` with a specific release tag).
+The bundle URL is `https://cdn.immutable.com/audience/v1/imtbl.js`.
 
 ## Quickstart — ESM
 
@@ -51,7 +28,7 @@ Once `@imtbl/audience` is published, the bundle URL will be
 import { Audience } from '@imtbl/audience';
 
 const audience = Audience.init({
-  publishableKey: 'pk_imapik-test-...',
+  publishableKey: 'YOUR_PUBLISHABLE_KEY',
   consent: 'anonymous',
   onError: (err) => console.error(err.code, err.message),
 });
@@ -68,14 +45,14 @@ audience.shutdown();
 ## Quickstart — CDN
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@imtbl/audience@<version>/dist/cdn/imtbl-audience.global.js"></script>
+<script src="https://cdn.immutable.com/audience/v1/imtbl.js"></script>
 <script>
   const {
     init, AudienceError, AudienceEvents,
     IdentityType, canTrack, canIdentify,
   } = window.ImmutableAudience;
   const audience = init({
-    publishableKey: 'pk_imapik-test-...',
+    publishableKey: 'YOUR_PUBLISHABLE_KEY',
     consent: 'anonymous',
     onError: (err) => console.error(err.code, err.message),
   });
@@ -84,45 +61,13 @@ audience.shutdown();
 </script>
 ```
 
-The CDN bundle attaches `init` (the same static factory ESM consumers
-call as `Audience.init({...})`) alongside `AudienceError`,
-`AudienceEvents`, `IdentityType`, `canTrack`, `canIdentify`, and
-`version`, so every runtime helper an ESM consumer needs is reachable
-from the CDN global too.
+## Documentation
 
-## Error handling
-
-`AudienceError.code` is a closed union — `'FLUSH_FAILED'`,
-`'CONSENT_SYNC_FAILED'`, `'NETWORK_ERROR'`, `'VALIDATION_REJECTED'` —
-so you can branch on the failure mode:
-
-```ts
-Audience.init({
-  publishableKey: 'pk_imapik-test-...',
-  onError: (err) => {
-    switch (err.code) {
-      case 'VALIDATION_REJECTED':
-        // Terminal: messages were dropped. Inspect err.responseBody
-        // for per-message detail when the backend provides it.
-        break;
-      default:
-        // Transient: the queue will retry automatically.
-        break;
-    }
-    telemetry.captureException(err);
-  },
-});
-```
-
-Exceptions thrown from `onError` are swallowed by the SDK so a
-bad handler can't wedge the queue.
-
-## Interactive sample app
-
-For a live harness that exercises every public method, every typed
-`track()` event, and every reachable `AudienceErrorCode` against the
-real sandbox backend, see [`packages/audience/sdk-sample-app`](https://github.com/immutable/ts-immutable-sdk/tree/main/packages/audience/sdk-sample-app)
-in the `ts-immutable-sdk` monorepo.
+- [Web SDK](https://docs.immutable.com/docs/products/audience/web-sdk) — API reference, usage, integration walkthrough
+- [Tracking Pixel](https://docs.immutable.com/docs/products/audience/tracking-pixel) — sibling `@imtbl/pixel` package for drop-in page-view tracking
+- [REST API](https://docs.immutable.com/docs/products/audience/rest-api) — backend reference for direct integration
+- [Data dictionary](https://docs.immutable.com/docs/products/audience/data-dictionary) — predefined event names and property schemas
+- [Sample app](../sdk-sample-app) — runnable example showing init, tracking, identity, and consent
 
 ## License
 


### PR DESCRIPTION
## Summary

- Trims SDK README to install, ESM/CDN quickstarts, documentation links, and license
- Updates CDN URL to `https://cdn.immutable.com/audience/v1/imtbl.js`
- Normalises publishable key placeholder to `YOUR_PUBLISHABLE_KEY`
- Adds `## Documentation` section with docs.immutable.com links to both SDK and Pixel READMEs

Linear: [SDK-115](https://linear.app/imtbl/issue/SDK-115/cdn-bundle)