### PR TITLE
ci(audience): add CDN deploy workflow (SDK-130)

### DIFF
--- a/.github/workflows/deploy-audience-cdn.yaml
+++ b/.github/workflows/deploy-audience-cdn.yaml
@@ -1,0 +1,76 @@
+name: Deploy Audience SDK to CDN
+
+on:
+  push:
+    paths:
+      - "packages/audience/sdk/**"
+      - "packages/audience/core/**"
+    branches:
+      - main
+  workflow_dispatch:
+
+# Required for GitHub OIDC to assume the AWS role
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-audience-cdn
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-east-1
+      S3_BUCKET: audience-sdk-prod
+      S3_KEY: audience/v1/imtbl.js
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.1
+
+      - name: setup
+        uses: ./.github/actions/setup
+
+      - name: Build audience SDK bundle
+        run: pnpm --filter @imtbl/audience build
+
+      - name: Verify bundle exists
+        run: |
+          if [ ! -f packages/audience/sdk/dist/cdn/imtbl-audience.global.js ]; then
+            echo "::error::Build output not found at packages/audience/sdk/dist/cdn/imtbl-audience.global.js"
+            exit 1
+          fi
+          echo "Bundle size: $(wc -c < packages/audience/sdk/dist/cdn/imtbl-audience.global.js) bytes"
+          echo "Gzipped size: $(gzip -c packages/audience/sdk/dist/cdn/imtbl-audience.global.js | wc -c) bytes"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # pin@v4.1.0
+        with:
+          role-to-assume: ${{ secrets.AWS_IMMUTABLE_PROD_ADMIN_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp packages/audience/sdk/dist/cdn/imtbl-audience.global.js \
+            s3://${{ env.S3_BUCKET }}/${{ env.S3_KEY }} \
+            --cache-control "public, max-age=86400" \
+            --content-type "application/javascript"
+
+      - name: Verify S3 upload
+        run: |
+          aws s3api head-object \
+            --bucket ${{ env.S3_BUCKET }} \
+            --key ${{ env.S3_KEY }} \
+            --query '{ContentType: ContentType, ContentLength: ContentLength, CacheControl: CacheControl}' \
+            --output table
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CF_PIXEL_PROD_DISTRIBUTION_ID }} \
+            --paths "/${{ env.S3_KEY }}"
+
+      - name: Log deployment
+        run: |
+          echo "Deployed to: https://cdn.immutable.com/${{ env.S3_KEY }}"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that deploys the `@imtbl/audience` CDN bundle on pushes to `main`.

- Triggers on changes to `packages/audience/sdk/**` or `packages/audience/core/**`
- Builds the SDK, uploads `dist/cdn/imtbl-audience.global.js` to `s3://audience-sdk-prod/audience/v1/imtbl.js`
- Invalidates the CloudFront cache for the uploaded path
- Uses the same IAM role and CloudFront distribution as `deploy-pixel-cdn.yaml`
- Supports manual trigger via `workflow_dispatch`

Depends on immutable/platform-infrastructure#5204 (S3 bucket and CloudFront origin must exist first).

Linear: [SDK-130](https://linear.app/imtbl/issue/SDK-130/deploy-audience-cdn-bundle-to-cdnimmutablecom)