### PR TITLE
fix(auth-next-server): deduplicate concurrent token refresh to prevent invalid_grant

### DIFF
--- a/packages/auth-next-server/src/refresh.ts
+++ b/packages/auth-next-server/src/refresh.ts
@@ -85,20 +85,16 @@ export function extractZkEvmFromIdToken(idToken?: string): ZkEvmData | undefined
   return undefined;
 }
 
-/**
- * Refresh access token using the refresh token.
- * This is called server-side in the JWT callback when the access token is expired.
- *
- * @param refreshToken - The refresh token to use
- * @param clientId - The OAuth client ID
- * @param authDomain - The authentication domain (default: https://auth.immutable.com)
- * @returns The refreshed tokens
- * @throws Error if refresh fails
- */
-export async function refreshAccessToken(
+// Deduplicates concurrent refresh calls for the same refresh token.
+// OAuth refresh tokens are single-use: if two requests arrive simultaneously
+// with the same expired token, only the first call reaches the provider.
+// Subsequent callers await the same promise and receive the same result.
+const refreshPromises = new Map<string, Promise<RefreshedTokens>>();
+
+async function doRefreshAccessToken(
   refreshToken: string,
   clientId: string,
-  authDomain: string = DEFAULT_AUTH_DOMAIN,
+  authDomain: string,
 ): Promise<RefreshedTokens> {
   const tokenUrl = `${authDomain}/oauth/token`;
 
@@ -140,4 +136,30 @@ export async function refreshAccessToken(
     idToken: tokenData.id_token,
     accessTokenExpires: decodeJwtExpiry(tokenData.access_token),
   };
+}
+
+/**
+ * Refresh access token using the refresh token.
+ * This is called server-side in the JWT callback when the access token is expired.
+ *
+ * @param refreshToken - The refresh token to use
+ * @param clientId - The OAuth client ID
+ * @param authDomain - The authentication domain (default: https://auth.immutable.com)
+ * @returns The refreshed tokens
+ * @throws Error if refresh fails
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+  clientId: string,
+  authDomain: string = DEFAULT_AUTH_DOMAIN,
+): Promise<RefreshedTokens> {
+  const cacheKey = `${clientId}:${refreshToken}`;
+  const inflight = refreshPromises.get(cacheKey);
+  if (inflight) return inflight;
+
+  const promise = doRefreshAccessToken(refreshToken, clientId, authDomain).finally(() => {
+    refreshPromises.delete(cacheKey);
+  });
+  refreshPromises.set(cacheKey, promise);
+  return promise;
 }


### PR DESCRIPTION
## Summary

- OAuth refresh tokens are single-use, but NextAuth has no built-in concurrency protection — parallel requests hitting the same expired token all fire independent refresh calls, causing the second+ callers to get `400 invalid_grant` and have `RefreshTokenError` set on their session
- Added promise deduplication in `refreshAccessToken`: concurrent callers with the same refresh token share one in-flight promise instead of each making a separate network request
- The internal HTTP logic moved to `doRefreshAccessToken`; the public API is unchanged

## How it works

```
Request A → refreshPromises.get(key) = undefined → starts fetch, stores promise
Request B → refreshPromises.get(key) = Promise<...> → awaits same promise
Request C → refreshPromises.get(key) = Promise<...> → awaits same promise

Provider receives 1 request (not 3) → all callers receive the same refreshed tokens
```

The map entry is cleaned up via `.finally()` so the next genuine refresh (after the token rotates) works normally.

## Test plan

- [ ] Sign in, open 3 tabs simultaneously — all tabs should remain authenticated after token expiry rather than one succeeding and others getting `RefreshTokenError`
- [ ] Verify middleware + route handler concurrent path doesn't trigger double refresh
- [ ] Confirm `forceRefresh` (zkEvm registration flow) still works correctly via the `trigger === 'update'` path in the JWT callback (that path calls `refreshAccessToken` directly and benefits from the same deduplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches server-side OAuth token refresh behavior; while the API is unchanged, incorrect deduping/cleanup could cause stale refresh results or masking of refresh errors under load.
> 
> **Overview**
> Prevents `invalid_grant` errors under parallel requests by **deduplicating concurrent `refreshAccessToken` calls** per `clientId`+`refreshToken`, ensuring only one refresh request is sent and other callers await the same promise.
> 
> Refactors the actual HTTP refresh logic into an internal `doRefreshAccessToken` helper and cleans up the in-flight promise cache via `.finally()` so subsequent refreshes proceed normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccecbe505c39ae0b8bb96d989b321cc5d5e244a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->