### PR TITLE
feat(audience): remove identify(traits) overload from Web SDK (SDK-224)

### DIFF
--- a/packages/audience/sdk-sample-app/README.md
+++ b/packages/audience/sdk-sample-app/README.md
@@ -45,7 +45,7 @@ For dev-environment access, leave the key as a test key and set
 SDK auto-derives sandbox vs prod from the key prefix; dev is not a
 first-class environment and must be reached via explicit override.
 
-## Ten-step walkthrough
+## Nine-step walkthrough
 
 1. Paste a test key into **Setup**, leave Initial Consent at `none`, click **Init**.
 2. Open the **Consent** panel, click **anonymous**. Status bar updates.
@@ -53,10 +53,9 @@ first-class environment and must be reached via explicit override.
 4. Expand **Typed Events → purchase** (6th row in the accordion), fill in `currency=USD`, `value=9.99`, click **Send**. Watch the live TS snippet mirror the form as you type.
 5. Set Consent to **full**.
 6. In **Identity → Named identify**, enter `user@example.com`, type `email`, traits `{"name":"Jane"}`, click.
-7. In **Identity → Traits-only identify**, enter `{"plan":"pro"}`, click.
-8. In **Identity → Alias**, connect a Steam ID to the email above.
-9. Set Consent back to **none**. Notice the queue purge in the event log.
-10. In **Lifecycle → Simulate error**, pick `NETWORK_ERROR` from the dropdown and click **Fire onError**. The `onError` entry lands in the event log with the documented shape.
+7. In **Identity → Alias**, connect a Steam ID to the email above.
+8. Set Consent back to **none**. Notice the queue purge in the event log.
+9. In **Lifecycle → Simulate error**, pick `NETWORK_ERROR` from the dropdown and click **Fire onError**. The `onError` entry lands in the event log with the documented shape.
 
 ## `AudienceEvents` catalogue
 

--- a/packages/audience/sdk-sample-app/index.html
+++ b/packages/audience/sdk-sample-app/index.html
@@ -211,25 +211,6 @@
 
         <details class="accordion-item">
           <summary class="accordion-header">
-            <span class="accordion-title">Update traits</span>
-          </summary>
-          <div class="accordion-content">
-            <p class="helper-text">Update an existing player's traits without re-identifying.</p>
-            <div class="field">
-              <label for="traits-json">Traits (JSON)</label>
-              <textarea id="traits-json" rows="3" placeholder='{"plan":"pro","region":"AU"}'></textarea>
-            </div>
-            <div class="actions">
-              <button id="btn-identify-traits" disabled>
-                Update traits only
-                <small class="btn-sig">identify(traits)</small>
-              </button>
-            </div>
-          </div>
-        </details>
-
-        <details class="accordion-item">
-          <summary class="accordion-header">
             <span class="accordion-title">Alias</span>
           </summary>
           <div class="accordion-content">

--- a/packages/audience/sdk-sample-app/sample-app.js
+++ b/packages/audience/sdk-sample-app/sample-app.js
@@ -346,7 +346,7 @@
     'btn-page', 'btn-flush', 'btn-reset', 'btn-shutdown',
     'btn-consent-none', 'btn-consent-anon', 'btn-consent-full',
     'btn-custom-event',
-    'btn-identify', 'btn-identify-traits',
+    'btn-identify',
   ];
 
   function setInitState(on) {
@@ -559,7 +559,6 @@
     $('btn-consent-anon').addEventListener('click', function () { onSetConsent('anonymous'); });
     $('btn-consent-full').addEventListener('click', function () { onSetConsent('full'); });
     $('btn-identify').addEventListener('click', onIdentify);
-    $('btn-identify-traits').addEventListener('click', onIdentifyTraits);
     $('btn-alias').addEventListener('click', onAlias);
     ['alias-from-id', 'alias-to-id', 'alias-from-type', 'alias-to-type'].forEach(function (id) {
       $(id).addEventListener('input', syncAliasButton);
@@ -819,27 +818,6 @@
       updateStatus();
     } catch (err) {
       log('identify()', errMsg(err), 'err');
-    }
-  }
-
-  function onIdentifyTraits() {
-    if (!audience) return;
-    if (!requiresFullConsent('identify()')) return;
-    var traits;
-    try { traits = parseTraits($('traits-json').value); }
-    catch (err) { log('identify()', 'invalid JSON: ' + err.message, 'err'); return; }
-    if (!traits) {
-      log('identify()', 'traits required', 'err');
-      return;
-    }
-    try {
-      audience.identify(traits);
-      enqueued();
-      identityMirror.traits = traits;
-      renderIdentityState();
-      log('identify(traits)', traits, 'ok');
-    } catch (err) {
-      log('identify(traits)', errMsg(err), 'err');
     }
   }
 

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -628,53 +628,6 @@ describe('Audience', () => {
       expect(ids).toHaveLength(0);
       sdk.shutdown();
     });
-
-    it('ignores null passed as traits', async () => {
-      const sdk = createSDK({ consent: 'full' });
-
-      sdk.identify(null as any);
-      await sdk.flush();
-
-      const ids = sentMessages().filter((m: any) => m.type === 'identify');
-      // null is not a valid traits object — should not enqueue
-      expect(ids).toHaveLength(0);
-
-      sdk.shutdown();
-    });
-
-    it('ignores array passed as traits', async () => {
-      const sdk = createSDK({ consent: 'full' });
-
-      sdk.identify(['not', 'traits'] as any);
-      await sdk.flush();
-
-      const ids = sentMessages().filter((m: any) => m.type === 'identify');
-      expect(ids).toHaveLength(0);
-
-      sdk.shutdown();
-    });
-
-    it('sends anonymous identify with traits only', async () => {
-      const sdk = createSDK({ consent: 'full' });
-
-      sdk.identify({
-        source: 'steam',
-        steamId: TEST_STEAM.id,
-      });
-      await sdk.flush();
-
-      const msg = sentMessages().find(
-        (m: any) => m.type === 'identify',
-      );
-      expect(msg).toBeDefined();
-      expect(msg.userId).toBeUndefined();
-      expect(msg.traits).toEqual({
-        source: 'steam',
-        steamId: TEST_STEAM.id,
-      });
-
-      sdk.shutdown();
-    });
   });
 
   describe('alias', () => {

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -285,43 +285,23 @@ export class Audience {
    * an account. Before identify(), the SDK only knows an anonymous cookie ID.
    * After, all future events are tied to this player.
    *
-   * Named: `sdk.identify('user@example.com', 'email', { name: 'Jane' })`
-   * Traits only: `sdk.identify({ source: 'steam', steamId: '765...' })`
+   * `sdk.identify('user@example.com', 'email', { name: 'Jane' })`
    *
    * Requires 'full' consent.
    */
-  identify(id: string, identityType: IdentityType, traits?: UserTraits): void;
-
-  identify(traits: UserTraits): void;
-
-  identify(
-    idOrTraits: string | UserTraits,
-    identityType?: IdentityType,
-    traits?: UserTraits,
-  ): void {
+  identify(id: string, identityType: IdentityType, traits?: UserTraits): void {
     if (!canIdentify(this.consent.level)) {
       this.debug.logWarning('identify() requires full consent — call ignored.');
       return;
     }
     getOrCreateSession(this.cookieDomain);
 
-    if (idOrTraits !== null && typeof idOrTraits === 'object' && !Array.isArray(idOrTraits)) {
-      this.enqueue('identify', {
-        ...this.baseMessage(),
-        type: 'identify',
-        traits: idOrTraits,
-      });
-      return;
-    }
-
-    if (typeof idOrTraits !== 'string') return;
-
-    const id = truncate(idOrTraits);
-    this.userId = id;
+    const resolvedId = truncate(id);
+    this.userId = resolvedId;
     this.enqueue('identify', {
       ...this.baseMessage(),
       type: 'identify',
-      userId: id,
+      userId: resolvedId,
       identityType,
       traits,
     });


### PR DESCRIPTION
## Summary

- Removes the traits-only `identify(traits)` overload from the Web SDK public surface, matching the Unity SDK revert in SDK-222 / PR #696
- Collapses the overloaded implementation into a single `identify(userId, identityType, traits?)` method — no more runtime type-dispatch
- Removes the "Update traits" panel from the sample app and cleans up all references in tests and docs

## Why

The traits-only overload cannot carry an `identityType`, which is now mandatory on every identify event so CDP data-deletion requests can match records to the correct identity namespace. An identify event without a type cannot be cleaned up.

## Changes

| File | Change |
|---|---|
| `packages/audience/sdk/src/sdk.ts` | Remove `identify(traits)` overload + simplify implementation |
| `packages/audience/sdk/src/sdk.test.ts` | Remove 3 tests covering the removed overload |
| `packages/audience/sdk-sample-app/index.html` | Remove "Update traits" accordion section |
| `packages/audience/sdk-sample-app/sample-app.js` | Remove `onIdentifyTraits` handler and button wiring |
| `packages/audience/sdk-sample-app/README.md` | Remove traits-only step from walkthrough |

## Test plan

- [x] `jest` — 60/60 tests pass
- [x] `tsc --noEmit` — no type errors
- [ ] Confluence doc updates (Web SDK Event Reference, Implementation Plan) — tracked in SDK-224

## Linear

Closes SDK-224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change: `identify(traits)` is removed, so existing integrations and sample-app workflows must be updated to always pass `identityType` (and may silently lose trait-only updates until migrated). Runtime risk is otherwise contained to identity event construction and UI/test cleanup.
> 
> **Overview**
> **Breaking change:** removes the traits-only `identify(traits)` overload from the Web SDK and collapses `identify()` to a single `identify(id, identityType, traits?)` signature, eliminating runtime type-dispatch and ensuring identify events always include an `identityType`.
> 
> Updates the sample app UI/docs to drop the “Update traits” panel and walkthrough step, removes the associated handler/button wiring, and deletes tests that asserted the old overload behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59dcf2258051d03dd3ff9ed2c579f278fe0dbfcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->