### PR TITLE
fix(ci): build audience-core before SDK bundle in CDN deploy workflow (AUD-239)

### DIFF
--- a/.github/workflows/deploy-audience-cdn.yaml
+++ b/.github/workflows/deploy-audience-cdn.yaml
@@ -32,14 +32,8 @@ jobs:
       - name: setup
         uses: ./.github/actions/setup
 
-      - name: Build metrics
-        run: pnpm --filter @imtbl/metrics build
-
-      - name: Build audience-core
-        run: pnpm --filter @imtbl/audience-core build
-
       - name: Build audience SDK bundle
-        run: pnpm --filter @imtbl/audience build
+        run: pnpm --filter @imtbl/audience... build
 
       - name: Verify bundle exists
         run: |

--- a/.github/workflows/deploy-audience-cdn.yaml
+++ b/.github/workflows/deploy-audience-cdn.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: setup
         uses: ./.github/actions/setup
 
+      - name: Build metrics
+        run: pnpm --filter @imtbl/metrics build
+
       - name: Build audience-core
         run: pnpm --filter @imtbl/audience-core build
 

--- a/.github/workflows/deploy-audience-cdn.yaml
+++ b/.github/workflows/deploy-audience-cdn.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: setup
         uses: ./.github/actions/setup
 
+      - name: Build audience-core
+        run: pnpm --filter @imtbl/audience-core build
+
       - name: Build audience SDK bundle
         run: pnpm --filter @imtbl/audience build
 


### PR DESCRIPTION
## Summary

- The `deploy-audience-cdn.yaml` workflow was failing on every triggered run because it built `@imtbl/audience` without first building its local workspace dependency `@imtbl/audience-core`
- In CI there is no pre-built `dist/` folder, so esbuild could not resolve `@imtbl/audience-core` imports
- Adds a `pnpm --filter @imtbl/audience-core build` step immediately before the SDK bundle build

https://linear.app/imtbl/issue/SDK-265/fixci-cdn-deploy-workflow-fails-missing-audience-core-build-step
Broken since: #2863

## Test plan

- [ ] Confirm the "Deploy Audience SDK to CDN" workflow passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow change that only affects build scoping for the CDN deploy job; low risk aside from potentially longer build time or unexpected dependency build interactions.
> 
> **Overview**
> The CDN deploy workflow now runs `pnpm --filter @imtbl/audience... build` instead of building only `@imtbl/audience`, ensuring its local workspace dependencies (e.g., `audience-core`) are built as part of the bundle step so the CI build can resolve imports before uploading to S3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37273315b6a1bb8fecddfe981e9d376a8b93960a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->