### PR TITLE
feat(pixel): capture-phase scroll tracking for SPAs and internal scroll containers (SDK-276)

### DIFF
--- a/packages/audience/pixel/README.md
+++ b/packages/audience/pixel/README.md
@@ -85,7 +85,7 @@ All events fire automatically with no instrumentation required.
 | `session_end` | Page unload (`visibilitychange` / `pagehide`) | `sessionId`, `duration` (seconds) |
 | `form_submitted` | HTML form submission | `formAction`, `formId`, `formName`, `fieldNames`. `emailHash` at `full` consent only. |
 | `link_clicked` | Outbound link click (external domains only) | `linkUrl`, `linkText`, `elementId`, `outbound: true` |
-| `scroll_depth` | Scroll milestone reached (25%, 50%, 75%, 90%, 100%) | `depth` (integer). No event fires on pages where the document does not scroll. |
+| `scroll_depth` | Scroll milestone reached (25%, 50%, 75%, 90%, 100%) | `depth` (integer). Fires on both standard document scroll and SPA internal scroll containers (e.g. `overflow: auto` divs) larger than 50% of the viewport. Milestones reset on each `page` call so SPA route changes start fresh. No event fires on pages with no scrollable area at all. **iframe limitation:** a cross-origin iframe cannot be observed from the parent page — install the pixel inside the iframe itself for those integrations. |
 
 ### Disabling specific auto-capture
 

--- a/packages/audience/pixel/README.md
+++ b/packages/audience/pixel/README.md
@@ -85,7 +85,7 @@ All events fire automatically with no instrumentation required.
 | `session_end` | Page unload (`visibilitychange` / `pagehide`) | `sessionId`, `duration` (seconds) |
 | `form_submitted` | HTML form submission | `formAction`, `formId`, `formName`, `fieldNames`. `emailHash` at `full` consent only. |
 | `link_clicked` | Outbound link click (external domains only) | `linkUrl`, `linkText`, `elementId`, `outbound: true` |
-| `scroll_depth` | Scroll milestone reached (25%, 50%, 75%, 90%, 100%) | `depth` (integer). Fires on both standard document scroll and SPA internal scroll containers (e.g. `overflow: auto` divs) larger than 50% of the viewport. Milestones reset on each `page` call so SPA route changes start fresh. No event fires on pages with no scrollable area at all. **iframe limitation:** a cross-origin iframe cannot be observed from the parent page — install the pixel inside the iframe itself for those integrations. |
+| `scroll_depth` | Scroll milestone reached (25%, 50%, 75%, 90%, 100%) | `depth` (integer). Fires on standard document scroll or on any internal scroll container larger than half the viewport. Milestones reset on each `page` call. |
 
 ### Disabling specific auto-capture
 

--- a/packages/audience/pixel/package.json
+++ b/packages/audience/pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@imtbl/pixel",
   "description": "Immutable Tracking Pixel — drop-in JavaScript snippet for device fingerprint, page view, and attribution data",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "Immutable",
   "private": true,
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",

--- a/packages/audience/pixel/src/autocapture.test.ts
+++ b/packages/audience/pixel/src/autocapture.test.ts
@@ -48,13 +48,14 @@ describe('autocapture', () => {
   });
 
   function setup(options: Record<string, unknown> = {}) {
-    teardown = setupAutocapture(
+    const result = setupAutocapture(
       {
         forms: true, clicks: true, scroll: false, ...options,
       },
       enqueue,
       () => consent,
     );
+    teardown = result.teardown;
   }
 
   // ---------- Form submissions ----------
@@ -494,7 +495,7 @@ describe('autocapture', () => {
 
   describe('config defaults', () => {
     it('enables both listeners when no options specified', () => {
-      teardown = setupAutocapture({}, enqueue, () => consent);
+      teardown = setupAutocapture({}, enqueue, () => consent).teardown;
 
       const form = document.createElement('form');
       form.action = '/signup';
@@ -612,7 +613,7 @@ describe('autocapture', () => {
 
         // Scroll to 25% → scrollY = (2000-500) * 0.25 = 375
         (window as Record<string, unknown>).scrollY = 375;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
@@ -620,7 +621,7 @@ describe('autocapture', () => {
 
         // Scroll to 55% → should fire 50 (25 already fired)
         (window as Record<string, unknown>).scrollY = 825;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).toHaveBeenCalledTimes(2);
@@ -632,7 +633,7 @@ describe('autocapture', () => {
 
         // Jump straight to 80% → should fire 25, 50, 75
         (window as Record<string, unknown>).scrollY = 1200;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
@@ -646,18 +647,18 @@ describe('autocapture', () => {
 
         // Scroll to 60%
         (window as Record<string, unknown>).scrollY = 900;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         const countAfterFirst = enqueue.mock.calls.length;
 
         // Scroll back up to 30%, then to 60% again
         (window as Record<string, unknown>).scrollY = 450;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         (window as Record<string, unknown>).scrollY = 900;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         // No new milestones should have fired
@@ -669,7 +670,7 @@ describe('autocapture', () => {
 
         // Scroll to 100%
         (window as Record<string, unknown>).scrollY = 1500;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
@@ -685,7 +686,7 @@ describe('autocapture', () => {
         setup({ scroll: true });
 
         (window as Record<string, unknown>).scrollY = 1500;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).not.toHaveBeenCalled();
@@ -696,9 +697,9 @@ describe('autocapture', () => {
 
         // Fire multiple scroll events without flushing rAF
         (window as Record<string, unknown>).scrollY = 375;
-        window.dispatchEvent(new Event('scroll'));
-        window.dispatchEvent(new Event('scroll'));
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
 
         // Only one rAF should have been scheduled
         expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1);
@@ -736,7 +737,7 @@ describe('autocapture', () => {
 
         // Even if a scroll event fires (e.g. iOS overscroll bounce), there is
         // nothing to scroll past, so no milestone should fire.
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).not.toHaveBeenCalled();
@@ -752,7 +753,7 @@ describe('autocapture', () => {
         setup({ scroll: false });
 
         (window as Record<string, unknown>).scrollY = 1500;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).not.toHaveBeenCalled();
@@ -760,10 +761,10 @@ describe('autocapture', () => {
 
       it('enables scroll tracking by default', () => {
         // Call setupAutocapture directly to verify production defaults
-        teardown = setupAutocapture({}, enqueue, () => consent);
+        teardown = setupAutocapture({}, enqueue, () => consent).teardown;
 
         (window as Record<string, unknown>).scrollY = 375;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
@@ -780,10 +781,152 @@ describe('autocapture', () => {
         teardown();
 
         (window as Record<string, unknown>).scrollY = 1500;
-        window.dispatchEvent(new Event('scroll'));
+        document.dispatchEvent(new Event('scroll'));
         flushRAF();
 
         expect(enqueue).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('SPA internal scroll containers', () => {
+      /**
+       * Stub an internal element's scroll geometry. The element must be
+       * appended to document.body so the capture-phase listener on `document`
+       * receives events dispatched on it.
+       */
+      function setContainerGeometry(
+        el: HTMLElement,
+        scrollHeight: number,
+        clientHeight: number,
+        scrollTop: number,
+      ) {
+        Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+        Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+        Object.defineProperty(el, 'scrollTop', { value: scrollTop, configurable: true, writable: true });
+      }
+
+      beforeEach(() => {
+        // Document itself does not scroll (SPA pattern).
+        setScrollGeometry(600, 600, 0);
+      });
+
+      it('fires milestones when an internal container scrolls', () => {
+        setup({ scroll: true });
+
+        const container = document.createElement('div');
+        // 500px container in a 600px viewport → clientHeight/innerHeight = 83% → passes filter
+        setContainerGeometry(container, 2000, 500, 0);
+        document.body.appendChild(container);
+
+        // Scroll to 26% → scrollTop = (2000-500)*0.26 = 390
+        (container as Record<string, unknown>).scrollTop = 390;
+        container.dispatchEvent(new Event('scroll'));
+        flushRAF();
+
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
+        expect(enqueue).toHaveBeenCalledTimes(1);
+      });
+
+      it('fires all five milestones when container is scrolled to 100%', () => {
+        setup({ scroll: true });
+
+        const container = document.createElement('div');
+        setContainerGeometry(container, 2000, 500, 0);
+        document.body.appendChild(container);
+
+        // 100% → scrollTop = 2000-500 = 1500
+        (container as Record<string, unknown>).scrollTop = 1500;
+        container.dispatchEvent(new Event('scroll'));
+        flushRAF();
+
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 50 });
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 75 });
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 90 });
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 100 });
+        expect(enqueue).toHaveBeenCalledTimes(5);
+      });
+
+      it('ignores containers smaller than 50% of viewport height', () => {
+        setup({ scroll: true });
+
+        const small = document.createElement('div');
+        // clientHeight = 200 px, innerHeight = 600 → 200 ≤ 300 → filtered out
+        setContainerGeometry(small, 2000, 200, 0);
+        document.body.appendChild(small);
+
+        (small as Record<string, unknown>).scrollTop = 1500;
+        small.dispatchEvent(new Event('scroll'));
+        flushRAF();
+
+        expect(enqueue).not.toHaveBeenCalled();
+      });
+
+      it('fires each milestone only once across multiple large containers (global dedup)', () => {
+        setup({ scroll: true });
+
+        const main = document.createElement('div');
+        const sidebar = document.createElement('div');
+        setContainerGeometry(main, 2000, 500, 0);
+        setContainerGeometry(sidebar, 1000, 500, 0);
+        document.body.appendChild(main);
+        document.body.appendChild(sidebar);
+
+        // Scroll main to 30% → fires 25
+        (main as Record<string, unknown>).scrollTop = 450;
+        main.dispatchEvent(new Event('scroll'));
+        flushRAF();
+        expect(enqueue).toHaveBeenCalledTimes(1);
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
+
+        // Scroll sidebar to 60% → 25 already fired, should only fire 50
+        (sidebar as Record<string, unknown>).scrollTop = 300;
+        sidebar.dispatchEvent(new Event('scroll'));
+        flushRAF();
+        expect(enqueue).toHaveBeenCalledTimes(2);
+        expect(enqueue).toHaveBeenLastCalledWith('scroll_depth', { depth: 50 });
+      });
+
+      it('does not fire for a detached element not in the document', () => {
+        setup({ scroll: true });
+
+        const detached = document.createElement('div');
+        setContainerGeometry(detached, 2000, 500, 0);
+        // Not appended to body — capture phase won't reach document.
+        (detached as Record<string, unknown>).scrollTop = 1500;
+        detached.dispatchEvent(new Event('scroll'));
+        flushRAF();
+
+        expect(enqueue).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('reset', () => {
+      beforeEach(() => {
+        setScrollGeometry(2000, 500, 0);
+      });
+
+      it('allows milestones to re-fire after resetScroll() (SPA route change)', () => {
+        const result = setupAutocapture({ scroll: true }, enqueue, () => consent);
+        teardown = result.teardown;
+
+        // Fire 25 milestone.
+        (window as Record<string, unknown>).scrollY = 375;
+        document.dispatchEvent(new Event('scroll'));
+        flushRAF();
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
+        expect(enqueue).toHaveBeenCalledTimes(1);
+
+        // Simulate SPA route change: scroll back to top, then call resetScroll.
+        (window as Record<string, unknown>).scrollY = 0;
+        result.resetScroll();
+
+        // Scrolling to 25% again should re-fire the milestone.
+        (window as Record<string, unknown>).scrollY = 375;
+        document.dispatchEvent(new Event('scroll'));
+        flushRAF();
+        expect(enqueue).toHaveBeenCalledTimes(2);
+        expect(enqueue).toHaveBeenLastCalledWith('scroll_depth', { depth: 25 });
       });
     });
   });

--- a/packages/audience/pixel/src/autocapture.test.ts
+++ b/packages/audience/pixel/src/autocapture.test.ts
@@ -928,6 +928,70 @@ describe('autocapture', () => {
         expect(enqueue).toHaveBeenCalledTimes(2);
         expect(enqueue).toHaveBeenLastCalledWith('scroll_depth', { depth: 25 });
       });
+
+      it('cancels pending rAF so stale scroll position cannot fire against new page', () => {
+        const result = setupAutocapture({ scroll: true }, enqueue, () => consent);
+        teardown = result.teardown;
+
+        // User has scrolled to 50% — rAF is scheduled but has not yet fired.
+        (window as Record<string, unknown>).scrollY = 750;
+        document.dispatchEvent(new Event('scroll'));
+        expect(enqueue).not.toHaveBeenCalled(); // rAF not flushed yet
+
+        // SPA navigates: pixel.page() calls resetScroll() before the rAF fires.
+        // The reused container still reports scrollY = 750 momentarily.
+        result.resetScroll();
+
+        // Flushing the (now-cancelled) rAF must not fire any milestone against
+        // the new page view.
+        flushRAF();
+        expect(enqueue).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('concurrent containers', () => {
+      function setContainerGeometry(
+        el: HTMLElement,
+        scrollHeight: number,
+        clientHeight: number,
+        scrollTop: number,
+      ) {
+        Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+        Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+        Object.defineProperty(el, 'scrollTop', { value: scrollTop, configurable: true, writable: true });
+      }
+
+      beforeEach(() => {
+        setScrollGeometry(600, 600, 0);
+      });
+
+      it('processes every container that scrolled within a single rAF', () => {
+        setup({ scroll: true });
+
+        const main = document.createElement('div');
+        const sidebar = document.createElement('div');
+        setContainerGeometry(main, 2000, 500, 0);
+        setContainerGeometry(sidebar, 1000, 500, 0);
+        document.body.appendChild(main);
+        document.body.appendChild(sidebar);
+
+        // Two large containers scroll in the same frame (before rAF flush).
+        // main → 30% (450/1500), sidebar → 60% (300/500).
+        // Without per-container queueing, only the second target would be
+        // checked and main's milestone would be lost.
+        (main as Record<string, unknown>).scrollTop = 450;
+        main.dispatchEvent(new Event('scroll'));
+        (sidebar as Record<string, unknown>).scrollTop = 300;
+        sidebar.dispatchEvent(new Event('scroll'));
+
+        flushRAF();
+
+        // Both 25 (from main) and 50 (from sidebar) should fire — global dedup
+        // applies across all containers processed in the frame.
+        expect(enqueue).toHaveBeenCalledTimes(2);
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 25 });
+        expect(enqueue).toHaveBeenCalledWith('scroll_depth', { depth: 50 });
+      });
     });
   });
 

--- a/packages/audience/pixel/src/autocapture.ts
+++ b/packages/audience/pixel/src/autocapture.ts
@@ -77,8 +77,8 @@ function setupScrollTracking(
   getConsent: ConsentFn,
 ): { teardown: () => void; reset: () => void } {
   const fired = new Set<number>();
+  const pending = new Set<Element>();
   let rafId = 0;
-  let pendingEl: Element | null = null;
 
   const checkAndFire = (el: Element, scrollPos: number): void => {
     if (!canTrack(getConsent())) return;
@@ -97,6 +97,14 @@ function setupScrollTracking(
     }
   };
 
+  const cancelPending = (): void => {
+    pending.clear();
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = 0;
+    }
+  };
+
   const onScroll = (e: Event): void => {
     if (fired.size === SCROLL_MILESTONES.length) return;
 
@@ -107,18 +115,18 @@ function setupScrollTracking(
     // Ignore small containers (dropdowns, tooltips, autocompletes).
     if (target.clientHeight <= window.innerHeight * 0.5) return;
 
-    pendingEl = target;
+    pending.add(target);
 
     if (rafId) return;
     rafId = requestAnimationFrame(() => {
       rafId = 0;
-      const el = pendingEl;
-      pendingEl = null;
-      if (!el) return;
-      const scrollPos = el === document.documentElement
-        ? window.scrollY
-        : el.scrollTop;
-      checkAndFire(el, scrollPos);
+      pending.forEach((el) => {
+        const scrollPos = el === document.documentElement
+          ? window.scrollY
+          : el.scrollTop;
+        checkAndFire(el, scrollPos);
+      });
+      pending.clear();
     });
   };
 
@@ -130,10 +138,13 @@ function setupScrollTracking(
   return {
     teardown: () => {
       document.removeEventListener('scroll', onScroll, { capture: true });
-      if (rafId) cancelAnimationFrame(rafId);
+      cancelPending();
     },
+    // Cancel any pending rAF so a stale scroll position from the previous
+    // page view can't fire milestones against the freshly-cleared set.
     reset: () => {
       fired.clear();
+      cancelPending();
     },
   };
 }

--- a/packages/audience/pixel/src/autocapture.ts
+++ b/packages/audience/pixel/src/autocapture.ts
@@ -56,31 +56,37 @@ function getFieldNames(form: HTMLFormElement): string[] {
 
 // -- Scroll depth tracking --------------------------------------------------
 
-/** Milestones that fire exactly once per page load. */
+/** Milestones that fire exactly once per page view. */
 const SCROLL_MILESTONES = [25, 50, 75, 90, 100];
 
 /**
  * Fires `scroll_depth` once per milestone (25/50/75/90/100) as the user
- * scrolls. No milestone fires on pages where the document doesn't scroll —
- * short pages and SPAs with internal scroll containers behave the same way.
+ * scrolls. Works for both standard document scroll and SPA internal scroll
+ * containers. Milestones reset when `reset()` is called (e.g. on SPA route
+ * changes via `pixel.page()`).
+ *
+ * Uses a capture-phase listener on `document` so scroll events on any
+ * descendant element are caught without enumerating containers upfront.
+ * Small containers (clientHeight ≤ 50% of viewport) are ignored to avoid
+ * noise from dropdowns, tooltips, and autocomplete lists.
  *
  * Consent is checked at fire time, not at attach time.
  */
 function setupScrollTracking(
   enqueue: EnqueueFn,
   getConsent: ConsentFn,
-): () => void {
+): { teardown: () => void; reset: () => void } {
   const fired = new Set<number>();
   let rafId = 0;
+  let pendingEl: Element | null = null;
 
-  const checkAndFire = (): void => {
+  const checkAndFire = (el: Element, scrollPos: number): void => {
     if (!canTrack(getConsent())) return;
 
-    const { scrollHeight, clientHeight } = document.documentElement;
-    if (scrollHeight <= clientHeight) return; // Page is not scrollable.
+    const scrollable = el.scrollHeight - el.clientHeight;
+    if (scrollable <= 0) return;
 
-    const scrollable = scrollHeight - clientHeight;
-    const pct = Math.min(100, Math.round((window.scrollY / scrollable) * 100));
+    const pct = Math.min(100, Math.round((scrollPos / scrollable) * 100));
 
     for (let i = 0; i < SCROLL_MILESTONES.length; i++) {
       const milestone = SCROLL_MILESTONES[i];
@@ -91,29 +97,53 @@ function setupScrollTracking(
     }
   };
 
-  // Check initial scroll position (e.g. anchor links, restored scroll).
-  checkAndFire();
+  const onScroll = (e: Event): void => {
+    if (fired.size === SCROLL_MILESTONES.length) return;
 
-  const onScroll = (): void => {
-    if (rafId) return; // Already scheduled
+    const target = e.target === document
+      ? document.documentElement
+      : e.target as Element;
+
+    // Ignore small containers (dropdowns, tooltips, autocompletes).
+    if (target.clientHeight <= window.innerHeight * 0.5) return;
+
+    pendingEl = target;
+
+    if (rafId) return;
     rafId = requestAnimationFrame(() => {
       rafId = 0;
-      checkAndFire();
+      const el = pendingEl;
+      pendingEl = null;
+      if (!el) return;
+      const scrollPos = el === document.documentElement
+        ? window.scrollY
+        : (el as HTMLElement).scrollTop;
+      checkAndFire(el, scrollPos);
     });
   };
 
-  window.addEventListener('scroll', onScroll, { passive: true });
+  // Check initial scroll position (e.g. anchor links, restored scroll).
+  checkAndFire(document.documentElement, window.scrollY);
 
-  return () => {
-    window.removeEventListener('scroll', onScroll);
-    if (rafId) cancelAnimationFrame(rafId);
+  document.addEventListener('scroll', onScroll, { capture: true, passive: true });
+
+  return {
+    teardown: () => {
+      document.removeEventListener('scroll', onScroll, { capture: true });
+      if (rafId) cancelAnimationFrame(rafId);
+    },
+    reset: () => {
+      fired.clear();
+    },
   };
 }
 
 /**
  * Attach document-level listeners for form submissions, outbound link clicks,
  * and scroll depth milestones.
- * Returns a teardown function that removes all listeners.
+ * Returns `{ teardown, resetScroll }` — call `teardown()` to remove all
+ * listeners, and `resetScroll()` to clear fired milestones (e.g. on SPA
+ * route changes).
  *
  * - Single document-level listener per event type (event delegation).
  * - Consent is checked at fire time, not at attach time.
@@ -123,8 +153,9 @@ export function setupAutocapture(
   options: AutocaptureOptions,
   enqueue: EnqueueFn,
   getConsent: ConsentFn,
-): () => void {
+): { teardown: () => void; resetScroll: () => void } {
   const teardowns: Array<() => void> = [];
+  let scrollReset: () => void = () => undefined;
 
   if (options.forms !== false) {
     const onSubmit = (e: Event): void => {
@@ -195,8 +226,13 @@ export function setupAutocapture(
   }
 
   if (options.scroll !== false) {
-    teardowns.push(setupScrollTracking(enqueue, getConsent));
+    const scroll = setupScrollTracking(enqueue, getConsent);
+    teardowns.push(scroll.teardown);
+    scrollReset = scroll.reset;
   }
 
-  return () => teardowns.forEach((fn) => fn());
+  return {
+    teardown: () => teardowns.forEach((fn) => fn()),
+    resetScroll: scrollReset,
+  };
 }

--- a/packages/audience/pixel/src/autocapture.ts
+++ b/packages/audience/pixel/src/autocapture.ts
@@ -117,7 +117,7 @@ function setupScrollTracking(
       if (!el) return;
       const scrollPos = el === document.documentElement
         ? window.scrollY
-        : (el as HTMLElement).scrollTop;
+        : el.scrollTop;
       checkAndFire(el, scrollPos);
     });
   };
@@ -140,10 +140,8 @@ function setupScrollTracking(
 
 /**
  * Attach document-level listeners for form submissions, outbound link clicks,
- * and scroll depth milestones.
- * Returns `{ teardown, resetScroll }` — call `teardown()` to remove all
- * listeners, and `resetScroll()` to clear fired milestones (e.g. on SPA
- * route changes).
+ * and scroll depth milestones. `resetScroll()` clears fired scroll milestones
+ * (call from `Pixel.page()` on SPA route changes).
  *
  * - Single document-level listener per event type (event delegation).
  * - Consent is checked at fire time, not at attach time.

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -2,7 +2,11 @@ import { Pixel } from './pixel';
 
 // Mock autocapture module
 const mockTeardownAutocapture = jest.fn();
-const mockSetupAutocapture = jest.fn().mockReturnValue(mockTeardownAutocapture);
+const mockResetScrollDepth = jest.fn();
+const mockSetupAutocapture = jest.fn().mockReturnValue({
+  teardown: mockTeardownAutocapture,
+  resetScroll: mockResetScrollDepth,
+});
 jest.mock('./autocapture', () => ({
   setupAutocapture: (...args: unknown[]) => mockSetupAutocapture(...args),
 }));

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -519,6 +519,33 @@ describe('Pixel', () => {
       );
     });
 
+    it('forwards scroll: false to setupAutocapture', () => {
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({
+        key: 'pk_imapik-test-local',
+        consent: 'anonymous',
+        autocapture: { scroll: false },
+      });
+
+      expect(mockSetupAutocapture).toHaveBeenCalledWith(
+        expect.objectContaining({ scroll: false }),
+        expect.any(Function),
+        expect.any(Function),
+      );
+    });
+
+    it('calls resetScroll when page() is called', () => {
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
+
+      mockResetScrollDepth.mockClear();
+      pixel.page();
+
+      expect(mockResetScrollDepth).toHaveBeenCalledTimes(1);
+    });
+
     it('enqueue callback fires TrackMessage with session', () => {
       mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-xyz', isNew: false });
 

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -61,6 +61,8 @@ export class Pixel {
 
   private teardownAutocapture?: () => void;
 
+  private resetScrollDepth?: () => void;
+
   private teardownCmp?: () => void;
 
   private initialPageViewFired = false;
@@ -119,16 +121,20 @@ export class Pixel {
       this.page();
     }
 
-    // Attach autocapture listeners (forms + outbound clicks)
-    this.teardownAutocapture = setupAutocapture(
-      { forms: autocapture?.forms, clicks: autocapture?.clicks },
+    const autocaptureResult = setupAutocapture(
+      { forms: autocapture?.forms, clicks: autocapture?.clicks, scroll: autocapture?.scroll },
       (eventName, properties) => this.track(eventName, properties),
       () => this.consent!.level,
     );
+    this.teardownAutocapture = autocaptureResult.teardown;
+    this.resetScrollDepth = autocaptureResult.resetScroll;
   }
 
   page(properties?: Record<string, unknown>): void {
     if (!this.isTrackingAllowed()) return;
+
+    // Reset scroll milestones so each page view starts from 0.
+    this.resetScrollDepth?.();
 
     const { sessionId, isNew } = getOrCreateSession(this.domain);
     this.refreshSession(sessionId, isNew);
@@ -173,6 +179,7 @@ export class Pixel {
       this.teardownAutocapture();
       this.teardownAutocapture = undefined;
     }
+    this.resetScrollDepth = undefined;
     if (this.queue) {
       this.queue.destroy();
       this.queue = null;


### PR DESCRIPTION
## Summary

- Replaces the `window` scroll listener with `document.addEventListener('scroll', ..., { capture: true })` so `scroll_depth` milestones fire on SPA pages where `document.documentElement` never scrolls but an internal `overflow: auto` container does (the pattern used on godsunchained.com and most Angular/Vue/React apps)
- Containers smaller than 50% of the viewport height are ignored to filter out noise from dropdowns, tooltips, and autocomplete lists
- `scroll_depth` milestones now reset on each `pixel.page()` call, so SPA route transitions start with a fresh depth counter — without this, milestones would silently do nothing after the first route in a session
- Fixes a pre-existing bug where `autocapture: { scroll: false }` was silently ignored (the `scroll` option was not being passed through to `setupAutocapture`)
- `setupScrollTracking` returns `{ teardown, reset }` and `setupAutocapture` returns `{ teardown, resetScroll }` to support the reset path without tearing down and re-attaching all listeners
- Fixes a race where a scroll event arriving just before `page()` could schedule a rAF that fires milestones against the freshly-cleared set; `reset()` now cancels any pending rAF
- Fixes a case where two large containers scrolling within the same animation frame would drop the first one; replaced `pendingEl: Element | null` with `pending: Set<Element>` so all containers in a frame are processed
- README `scroll_depth` row updated to document SPA support and reset-on-page behaviour

## Test plan

- [x] All 96 tests pass (`pnpm test` in `packages/audience/pixel`)
- [x] Existing document-scroll tests updated to dispatch on `document` (correct for capture-phase listener)
- [x] New: internal container fires milestones
- [x] New: all five milestones fire at 100% in internal container
- [x] New: containers ≤ 50% viewport height are filtered out
- [x] New: global milestone dedup across multiple large containers
- [x] New: detached element (not in DOM) fires nothing
- [x] New: `resetScroll()` allows milestones to re-fire after a simulated SPA route change
- [x] New: stale rAF cancelled on reset so it cannot fire milestones against a fresh page view
- [x] New: all containers that scroll in the same frame are processed (Set-based queue)
- [x] New: `pixel.page()` calls `resetScroll` (regression guard for milestone reset on route changes)
- [x] New: `autocapture: { scroll: false }` is forwarded to `setupAutocapture` (regression guard for the scroll-option bug)

Closes [SDK-276](https://linear.app/imtbl/issue/SDK-276)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scroll auto-capture behavior by moving to capture-phase `document` listeners, adding container filtering, and resetting milestones on `page()`, which could affect analytics event volume/semantics in production. Includes broad test updates/additions to cover new scroll targets and reset/rAF edge cases.
> 
> **Overview**
> **Scroll auto-capture is reworked** so `scroll_depth` milestones fire for both document scrolling and SPA-style internal `overflow` containers by listening on `document` in capture phase and processing multiple scrolled elements per animation frame.
> 
> Milestones are now **reset per page view** via a new `resetScroll` hook that `Pixel.page()` calls (including cancelling pending rAF work), and small scroll containers (≤ 50% viewport height) are ignored to reduce noise; `autocapture.scroll` is also correctly forwarded and the public API now returns `{ teardown, resetScroll }` from `setupAutocapture`.
> 
> Docs and tests are updated/expanded accordingly, and `@imtbl/pixel` version is bumped to `0.2.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0b6d3a822d8b92593af104e635e59e4e6ddef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->