### PR TITLE
feat(orderbook): Add support for creating metadata bids with criteria

### DIFF
--- a/packages/orderbook/src/api-client/api-client.test.ts
+++ b/packages/orderbook/src/api-client/api-client.test.ts
@@ -1,9 +1,10 @@
 import {
-  anything, deepEqual, instance, mock, when,
+  anything, capture, deepEqual, instance, mock, when,
 } from 'ts-mockito';
 import type { OrderComponents } from '../seaport/types';
-import { ListingResult, OrdersService } from '../openapi/sdk';
+import { ListingResult, MetadataBidResult, OrdersService } from '../openapi/sdk';
 import { ItemType, OrderType } from '../seaport';
+import { MetadataFieldFilter } from '../types';
 import { ImmutableApiClient } from './api-client';
 
 const seaportAddress = '0x123';
@@ -204,6 +205,198 @@ describe('ImmutableApiClient', () => {
         expect(orderResult.result.id).toEqual(orderId);
         expect(orderResult.result.chain.name).toEqual(chainName);
       });
+    });
+  });
+
+  describe('createMetadataBid', () => {
+    const validOrderComponents = (): OrderComponents => {
+      const mockedOrderComponents = mock<OrderComponents>();
+      const orderComponents = instance(mockedOrderComponents);
+      orderComponents.offerer = '0xMaker';
+      orderComponents.zone = '0xZone';
+      orderComponents.salt = '12345';
+      orderComponents.counter = BigInt(1);
+      orderComponents.orderType = OrderType.FULL_RESTRICTED;
+      orderComponents.endTime = new Date().getTime() / 1000;
+      orderComponents.startTime = new Date().getTime() / 1000;
+      orderComponents.offer = [
+        {
+          itemType: ItemType.ERC20,
+          endAmount: '1',
+          startAmount: '1',
+          identifierOrCriteria: '0',
+          token: '0xERC20',
+        },
+      ];
+      orderComponents.consideration = [
+        {
+          itemType: ItemType.ERC721_WITH_CRITERIA,
+          endAmount: '1',
+          startAmount: '1',
+          identifierOrCriteria: '0',
+          token: '0xCollection',
+          recipient: '0xMaker',
+        },
+      ];
+      return orderComponents;
+    };
+
+    it('rejects when neither metadataId nor metadataCriteria is provided', async () => {
+      const mockedOpenAPIClient = mock(OrdersService);
+      const client = new ImmutableApiClient(
+        instance(mockedOpenAPIClient),
+        '123',
+        seaportAddress,
+      );
+
+      await expect(
+        client.createMetadataBid({
+          orderComponents: validOrderComponents(),
+          orderHash: '0xHash',
+          orderSignature: '0xSig',
+          makerFees: [],
+        } as never),
+      ).rejects.toThrow('Exactly one of metadataId or metadataCriteria must be provided');
+    });
+
+    it('rejects when both metadataId and metadataCriteria are provided', async () => {
+      const mockedOpenAPIClient = mock(OrdersService);
+      const client = new ImmutableApiClient(
+        instance(mockedOpenAPIClient),
+        '123',
+        seaportAddress,
+      );
+
+      await expect(
+        client.createMetadataBid({
+          orderComponents: validOrderComponents(),
+          orderHash: '0xHash',
+          orderSignature: '0xSig',
+          makerFees: [],
+          metadataId: 'abc',
+          metadataCriteria: [{ fieldName: 'name', values: ['Foo'] }],
+        } as never),
+      ).rejects.toThrow('Exactly one of metadataId or metadataCriteria must be provided, not both');
+    });
+
+    it('rejects an unknown top-level metadata field', async () => {
+      const mockedOpenAPIClient = mock(OrdersService);
+      const client = new ImmutableApiClient(
+        instance(mockedOpenAPIClient),
+        '123',
+        seaportAddress,
+      );
+
+      const badCriteria = [{ fieldName: 'rarity', values: ['Legendary'] }] as unknown as MetadataFieldFilter[];
+
+      await expect(
+        client.createMetadataBid({
+          orderComponents: validOrderComponents(),
+          orderHash: '0xHash',
+          orderSignature: '0xSig',
+          makerFees: [],
+          metadataCriteria: badCriteria,
+        }),
+      ).rejects.toThrow(/metadataCriteria fieldName "rarity" must be one of/);
+    });
+
+    it('rejects duplicate criteria field names', async () => {
+      const mockedOpenAPIClient = mock(OrdersService);
+      const client = new ImmutableApiClient(
+        instance(mockedOpenAPIClient),
+        '123',
+        seaportAddress,
+      );
+
+      await expect(
+        client.createMetadataBid({
+          orderComponents: validOrderComponents(),
+          orderHash: '0xHash',
+          orderSignature: '0xSig',
+          makerFees: [],
+          metadataCriteria: [
+            { fieldName: 'name', values: ['Foo'] },
+            { fieldName: 'name', values: ['Bar'] },
+          ],
+        }),
+      ).rejects.toThrow(/duplicate fieldName "name"/);
+    });
+
+    it('rejects an attribute filter with empty trait_type', async () => {
+      const mockedOpenAPIClient = mock(OrdersService);
+      const client = new ImmutableApiClient(
+        instance(mockedOpenAPIClient),
+        '123',
+        seaportAddress,
+      );
+
+      const badCriteria = [{ fieldName: 'attribute:', values: ['Blue'] }] as unknown as MetadataFieldFilter[];
+
+      await expect(
+        client.createMetadataBid({
+          orderComponents: validOrderComponents(),
+          orderHash: '0xHash',
+          orderSignature: '0xSig',
+          makerFees: [],
+          metadataCriteria: badCriteria,
+        }),
+      ).rejects.toThrow(/metadataCriteria fieldName "attribute:" must be one of/);
+    });
+
+    it('sends metadata_id and omits metadata_criteria when metadataId is provided', async () => {
+      const mockedOpenAPIClient = mock(OrdersService);
+      when(mockedOpenAPIClient.createMetadataBid(anything())).thenReturn(
+        Promise.resolve({ result: { id: 'mb1', chain: { name: '123' } } } as MetadataBidResult),
+      );
+
+      const client = new ImmutableApiClient(
+        instance(mockedOpenAPIClient),
+        '123',
+        seaportAddress,
+      );
+
+      await client.createMetadataBid({
+        orderComponents: validOrderComponents(),
+        orderHash: '0xHash',
+        orderSignature: '0xSig',
+        makerFees: [],
+        metadataId: '018792c9-4ad7-8ec4-4038-9e05c598534b',
+      });
+
+      const [arg] = capture(mockedOpenAPIClient.createMetadataBid).last();
+      expect(arg.requestBody.metadata_id).toBe('018792c9-4ad7-8ec4-4038-9e05c598534b');
+      expect(arg.requestBody.metadata_criteria).toBeUndefined();
+    });
+
+    it('sends metadata_criteria and omits metadata_id when metadataCriteria is provided', async () => {
+      const mockedOpenAPIClient = mock(OrdersService);
+      when(mockedOpenAPIClient.createMetadataBid(anything())).thenReturn(
+        Promise.resolve({ result: { id: 'mb1', chain: { name: '123' } } } as MetadataBidResult),
+      );
+
+      const client = new ImmutableApiClient(
+        instance(mockedOpenAPIClient),
+        '123',
+        seaportAddress,
+      );
+
+      await client.createMetadataBid({
+        orderComponents: validOrderComponents(),
+        orderHash: '0xHash',
+        orderSignature: '0xSig',
+        makerFees: [],
+        metadataCriteria: [
+          { fieldName: 'name', values: ['Cool Dragon'] },
+          { fieldName: 'attribute:Background', values: ['Blue', 'Red'] },
+        ],
+      });
+
+      const [arg] = capture(mockedOpenAPIClient.createMetadataBid).last();
+      expect(arg.requestBody.metadata_id).toBeUndefined();
+      expect(arg.requestBody.metadata_criteria).toEqual([
+        { field_name: 'name', values: ['Cool Dragon'] },
+        { field_name: 'attribute:Background', values: ['Blue', 'Red'] },
+      ]);
     });
   });
 });

--- a/packages/orderbook/src/api-client/api-client.ts
+++ b/packages/orderbook/src/api-client/api-client.ts
@@ -37,7 +37,71 @@ import {
   ListMetadataBidsParams,
   ListTraitBidsParams,
   ListTradesParams,
+  MetadataAttributeField,
+  MetadataFieldFilter,
+  MetadataFieldName,
+  MetadataTopLevelField,
 } from '../types';
+
+const METADATA_TOP_LEVEL_FIELDS = new Set<MetadataTopLevelField>([
+  'name',
+  'image',
+  'description',
+  'animation_url',
+  'external_url',
+  'youtube_url',
+]);
+
+const METADATA_ATTRIBUTE_PREFIX = 'attribute:';
+
+const KNOWN_METADATA_FIELD_NAMES_DESCRIPTION = 'name, image, description, animation_url, '
+  + 'external_url, youtube_url, or "attribute:<trait_type>"';
+
+function isAttributeField(fieldName: string): fieldName is MetadataAttributeField {
+  return fieldName.startsWith(METADATA_ATTRIBUTE_PREFIX)
+    && fieldName.length > METADATA_ATTRIBUTE_PREFIX.length;
+}
+
+function isKnownMetadataFieldName(fieldName: string): fieldName is MetadataFieldName {
+  return METADATA_TOP_LEVEL_FIELDS.has(fieldName as MetadataTopLevelField)
+    || isAttributeField(fieldName);
+}
+
+/**
+ * Validates client-side rules for metadata bid criteria before sending to the
+ * API. The API performs the same checks server-side; this validation is here
+ * to give callers a clear, immediate error.
+ */
+function validateMetadataCriteria(criteria: MetadataFieldFilter[]): void {
+  if (criteria.length === 0) {
+    throw new Error('metadataCriteria must contain at least one filter');
+  }
+
+  const seenFieldNames = new Set<string>();
+  criteria.forEach((filter) => {
+    if (!filter.fieldName) {
+      throw new Error('metadataCriteria entries must have a non-empty fieldName');
+    }
+    if (!isKnownMetadataFieldName(filter.fieldName)) {
+      throw new Error(
+        `metadataCriteria fieldName "${filter.fieldName}" must be one of `
+        + `${KNOWN_METADATA_FIELD_NAMES_DESCRIPTION}`,
+      );
+    }
+    if (!filter.values || filter.values.length === 0) {
+      throw new Error(
+        `metadataCriteria filter "${filter.fieldName}" must have at least one value`,
+      );
+    }
+    if (seenFieldNames.has(filter.fieldName)) {
+      throw new Error(
+        `metadataCriteria contains duplicate fieldName "${filter.fieldName}"; `
+        + 'use a single filter per field with multiple values instead',
+      );
+    }
+    seenFieldNames.add(filter.fieldName);
+  });
+}
 
 export class ImmutableApiClient {
   constructor(
@@ -335,13 +399,16 @@ export class ImmutableApiClient {
     });
   }
 
-  async createMetadataBid({
-    orderHash,
-    orderComponents,
-    orderSignature,
-    makerFees,
-    metadataId,
-  }: CreateMetadataBidParams): Promise<MetadataBidResult> {
+  async createMetadataBid(params: CreateMetadataBidParams): Promise<MetadataBidResult> {
+    const {
+      orderHash,
+      orderComponents,
+      orderSignature,
+      makerFees,
+      metadataId,
+      metadataCriteria,
+    } = params;
+
     if (orderComponents.offer.length !== 1) {
       throw new Error('Only one item can be listed for a metadata bid');
     }
@@ -360,8 +427,18 @@ export class ImmutableApiClient {
       throw new Error('Only ERC721 / ERC1155 collection based tokens can be bid against');
     }
 
-    if (!metadataId) {
-      throw new Error('A metadata_id is required for a metadata bid');
+    const hasMetadataId = !!metadataId;
+    const hasMetadataCriteria = !!metadataCriteria && metadataCriteria.length > 0;
+    if (hasMetadataId && hasMetadataCriteria) {
+      throw new Error(
+        'Exactly one of metadataId or metadataCriteria must be provided, not both',
+      );
+    }
+    if (!hasMetadataId && !hasMetadataCriteria) {
+      throw new Error('Exactly one of metadataId or metadataCriteria must be provided');
+    }
+    if (hasMetadataCriteria) {
+      validateMetadataCriteria(metadataCriteria);
     }
 
     return this.orderbookService.createMetadataBid({
@@ -392,7 +469,10 @@ export class ImmutableApiClient {
         start_at: new Date(
           parseInt(`${orderComponents.startTime.toString()}000`, 10),
         ).toISOString(),
-        metadata_id: metadataId,
+        metadata_id: hasMetadataId ? metadataId : undefined,
+        metadata_criteria: hasMetadataCriteria
+          ? metadataCriteria.map((c) => ({ field_name: c.fieldName, values: c.values }))
+          : undefined,
       },
     });
   }

--- a/packages/orderbook/src/openapi/mapper.test.ts
+++ b/packages/orderbook/src/openapi/mapper.test.ts
@@ -1,7 +1,11 @@
 import { Fee } from './sdk';
 import { Order as OpenApiOrder } from './sdk/models/Order';
 import { ProtocolData } from './sdk/models/ProtocolData';
-import { mapOrderFromOpenApiOrder, mapTraitBidFromOpenApiOrder } from './mapper';
+import {
+  mapMetadataBidFromOpenApiOrder,
+  mapOrderFromOpenApiOrder,
+  mapTraitBidFromOpenApiOrder,
+} from './mapper';
 
 describe('mapTraitBidFromOpenApiOrder', () => {
   const baseOrder: OpenApiOrder = {
@@ -83,6 +87,94 @@ describe('mapTraitBidFromOpenApiOrder', () => {
     expect(mapped.type).toBe('TRAIT_BID');
     if (mapped.type === 'TRAIT_BID') {
       expect(mapped.traitCriteria).toEqual([{ traitType: 'Rarity', values: ['Legendary'] }]);
+    }
+  });
+});
+
+describe('mapMetadataBidFromOpenApiOrder', () => {
+  const baseOrder: OpenApiOrder = {
+    id: '018792c9-4ad7-8ec4-4038-9e05c598534a',
+    type: OpenApiOrder.type.METADATA_BID,
+    account_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    chain: { id: 'eip155:11155111', name: 'imtbl-zkevm-testnet' },
+    created_at: '2022-03-07T07:20:50.52Z',
+    updated_at: '2022-03-07T07:20:50.52Z',
+    start_at: '2022-03-09T05:00:50.52Z',
+    end_at: '2022-03-10T05:00:50.52Z',
+    order_hash: '0xabc',
+    salt: '1',
+    signature: '0x',
+    status: { name: 'ACTIVE' },
+    fill_status: { numerator: '0', denominator: '1' },
+    fees: [],
+    protocol_data: {
+      order_type: ProtocolData.order_type.PARTIAL_RESTRICTED,
+      counter: '0',
+      zone_address: '0x12',
+      seaport_address: '0x34',
+      seaport_version: '1.5',
+    },
+    sell: [
+      {
+        type: 'ERC20',
+        contract_address: '0x0165878a594ca255338adfa4d48449f69242eb8f',
+        amount: '1000',
+      },
+    ],
+    buy: [
+      {
+        type: 'ERC721_COLLECTION',
+        contract_address: '0x692edad005237c7e737bb2c0f3d8cccc10d3479e',
+        amount: '1',
+      },
+    ],
+  };
+
+  it('maps metadataId mode', () => {
+    const order: OpenApiOrder = {
+      ...baseOrder,
+      metadata_id: '018792c9-4ad7-8ec4-4038-9e05c598534b',
+    };
+
+    const mapped = mapMetadataBidFromOpenApiOrder(order);
+
+    expect(mapped.metadataId).toBe('018792c9-4ad7-8ec4-4038-9e05c598534b');
+    expect(mapped.metadataCriteria).toEqual([]);
+  });
+
+  it('maps metadata_criteria from snake_case API fields', () => {
+    const order: OpenApiOrder = {
+      ...baseOrder,
+      metadata_criteria: [
+        { field_name: 'name', values: ['Cool Dragon'] },
+        { field_name: 'attribute:Background', values: ['Blue', 'Red'] },
+      ],
+    };
+
+    const mapped = mapMetadataBidFromOpenApiOrder(order);
+
+    expect(mapped.metadataId).toBeUndefined();
+    expect(mapped.metadataCriteria).toEqual([
+      { fieldName: 'name', values: ['Cool Dragon'] },
+      { fieldName: 'attribute:Background', values: ['Blue', 'Red'] },
+    ]);
+  });
+
+  it('defaults metadataCriteria to empty when omitted', () => {
+    const mapped = mapMetadataBidFromOpenApiOrder(baseOrder);
+    expect(mapped.metadataCriteria).toEqual([]);
+    expect(mapped.metadataId).toBeUndefined();
+  });
+
+  it('routes METADATA_BID through mapOrderFromOpenApiOrder', () => {
+    const order: OpenApiOrder = {
+      ...baseOrder,
+      metadata_criteria: [{ field_name: 'name', values: ['Foo'] }],
+    };
+    const mapped = mapOrderFromOpenApiOrder(order);
+    expect(mapped.type).toBe('METADATA_BID');
+    if (mapped.type === 'METADATA_BID') {
+      expect(mapped.metadataCriteria).toEqual([{ fieldName: 'name', values: ['Foo'] }]);
     }
   });
 });

--- a/packages/orderbook/src/openapi/mapper.ts
+++ b/packages/orderbook/src/openapi/mapper.ts
@@ -9,6 +9,8 @@ import {
   FeeType,
   Listing,
   MetadataBid,
+  MetadataFieldFilter,
+  MetadataFieldName,
   NativeItem,
   Order,
   Page,
@@ -18,6 +20,7 @@ import {
 } from '../types';
 import { exhaustiveSwitch } from '../utils';
 import { Order as OpenApiOrder } from './sdk/models/Order';
+import type { MetadataFieldFilter as OpenApiMetadataFieldFilter } from './sdk/models/MetadataFieldFilter';
 import type { TraitFilter as OpenApiTraitFilter } from './sdk/models/TraitFilter';
 import { Page as OpenApiPage } from './sdk/models/Page';
 import { Trade as OpenApiTrade } from './sdk/models/Trade';
@@ -175,6 +178,20 @@ function mapTraitCriteriaFromOpenApi(
   }
   return criteria.map((c) => ({
     traitType: c.trait_type,
+    values: [...c.values],
+  }));
+}
+
+function mapMetadataCriteriaFromOpenApi(
+  criteria: OpenApiMetadataFieldFilter[] | undefined,
+): MetadataFieldFilter[] {
+  if (!criteria?.length) {
+    return [];
+  }
+  return criteria.map((c) => ({
+    // The API enforces that field_name is either a known top-level metadata
+    // field or starts with `attribute:`, so the cast is sound at runtime.
+    fieldName: c.field_name as MetadataFieldName,
     values: [...c.values],
   }));
 }
@@ -381,7 +398,8 @@ export function mapMetadataBidFromOpenApiOrder(order: OpenApiOrder): MetadataBid
     },
     createdAt: order.created_at,
     updatedAt: order.updated_at,
-    metadataId: order.metadata_id ?? '',
+    metadataId: order.metadata_id,
+    metadataCriteria: mapMetadataCriteriaFromOpenApi(order.metadata_criteria),
   };
 }
 

--- a/packages/orderbook/src/openapi/sdk/index.ts
+++ b/packages/orderbook/src/openapi/sdk/index.ts
@@ -61,6 +61,7 @@ export type { TradeResult } from './models/TradeResult';
 export type { TraitBidResult } from './models/TraitBidResult';
 export type { MetadataBidResult } from './models/MetadataBidResult';
 export type { TraitFilter } from './models/TraitFilter';
+export type { MetadataFieldFilter } from './models/MetadataFieldFilter';
 export type { UnfulfillableOrder } from './models/UnfulfillableOrder';
 
 export { OrdersService } from './services/OrdersService';

--- a/packages/orderbook/src/openapi/sdk/models/CreateMetadataBidRequestBody.ts
+++ b/packages/orderbook/src/openapi/sdk/models/CreateMetadataBidRequestBody.ts
@@ -5,6 +5,7 @@
 import type { AssetCollectionItem } from './AssetCollectionItem';
 import type { ERC20Item } from './ERC20Item';
 import type { Fee } from './Fee';
+import type { MetadataFieldFilter } from './MetadataFieldFilter';
 import type { ProtocolData } from './ProtocolData';
 
 export type CreateMetadataBidRequestBody = {
@@ -40,7 +41,13 @@ export type CreateMetadataBidRequestBody = {
    */
   start_at: string;
   /**
-   * The metadata_id (stack_id) that NFTs must have to fulfil this bid
+   * The metadata_id (stack_id) that NFTs must have to fulfil this bid.
+   * Mutually exclusive with `metadata_criteria`; exactly one must be set.
    */
-  metadata_id: string;
+  metadata_id?: string;
+  /**
+   * Field-level metadata filters that NFTs must satisfy to fulfil this bid.
+   * Mutually exclusive with `metadata_id`; exactly one must be set.
+   */
+  metadata_criteria?: Array<MetadataFieldFilter>;
 };

--- a/packages/orderbook/src/openapi/sdk/models/MetadataFieldFilter.ts
+++ b/packages/orderbook/src/openapi/sdk/models/MetadataFieldFilter.ts
@@ -1,0 +1,18 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type MetadataFieldFilter = {
+  /**
+   * The metadata field name. Either a top-level NFT metadata field
+   * (`name`, `image`, `description`, `animation_url`, `external_url`,
+   * `youtube_url`) or an attribute identified by the `attribute:<trait_type>`
+   * prefix (e.g. `attribute:Background`).
+   */
+  field_name: string;
+  /**
+   * The metadata field values to match against. Matching is case-insensitive
+   * and OR-style within a single filter; multiple filters on a bid AND.
+   */
+  values: Array<string>;
+};

--- a/packages/orderbook/src/openapi/sdk/models/Order.ts
+++ b/packages/orderbook/src/openapi/sdk/models/Order.ts
@@ -6,6 +6,7 @@ import type { Chain } from './Chain';
 import type { Fee } from './Fee';
 import type { FillStatus } from './FillStatus';
 import type { Item } from './Item';
+import type { MetadataFieldFilter } from './MetadataFieldFilter';
 import type { OrderStatus } from './OrderStatus';
 import type { ProtocolData } from './ProtocolData';
 import type { TraitFilter } from './TraitFilter';
@@ -57,9 +58,16 @@ export type Order = {
    */
   trait_criteria?: Array<TraitFilter>;
   /**
-   * Metadata ID (stack ID) for metadata bids when returned by the API
+   * Metadata ID (stack ID) for metadata bids created with a single metadata
+   * stack. Omitted for metadata bids created with `metadata_criteria`.
    */
   metadata_id?: string;
+  /**
+   * Field-level metadata filters for metadata bids created with criteria
+   * instead of a `metadata_id`. Omitted for metadata bids created with a
+   * `metadata_id`.
+   */
+  metadata_criteria?: Array<MetadataFieldFilter>;
 };
 
 export namespace Order {

--- a/packages/orderbook/src/orderbook.ts
+++ b/packages/orderbook/src/orderbook.ts
@@ -704,8 +704,14 @@ export class Orderbook {
   }
 
   /**
-   * Create a metadata bid (collection criteria offer plus metadata ID submitted to the API).
-   * @param {CreateMetadataBidParams} createMetadataBidParams - Signed order and metadata ID.
+   * Create a metadata bid (collection criteria offer plus a metadata matching
+   * spec submitted to the API). The matching spec is either a single
+   * `metadataId` (NFTs whose indexed metadata stack ID equals this UUID) or
+   * a `metadataCriteria` array of field-level filters (NFTs whose metadata
+   * satisfies every filter; AND across filters, OR within a filter's
+   * `values`, case-insensitive). Exactly one of the two must be provided.
+   * @param {CreateMetadataBidParams} createMetadataBidParams - Signed order and
+   *   metadata ID or criteria.
    * @return {MetadataBidResult} The created metadata bid.
    */
   async createMetadataBid(

--- a/packages/orderbook/src/test/metadata-bid.e2e.ts
+++ b/packages/orderbook/src/test/metadata-bid.e2e.ts
@@ -26,19 +26,49 @@ const ERC721_ABI = [
   'function ownerOf(uint256 tokenId) external view returns (address)',
 ];
 
+interface NftAttribute {
+  trait_type: string;
+  value: string;
+}
+
+interface NftMetadataOverrides {
+  name?: string;
+  image?: string;
+  description?: string;
+  animationUrl?: string;
+  externalUrl?: string;
+  youtubeUrl?: string;
+  attributes?: NftAttribute[];
+}
+
+const escapeSqlString = (s: string) => s.replace(/'/g, "''");
+
+const stringLiteralOrNull = (v: string | undefined) => (v === undefined ? 'NULL' : `'${escapeSqlString(v)}'`);
+
 /**
- * Seeds the indexer-mr database so that the given NFT is associated with a metadata_id.
- * This allows the fulfillment endpoint to validate the token against the metadata bid.
+ * Seeds the indexer-mr database so that the given NFT is associated with a
+ * metadata_id and the configured metadata fields. This lets the fulfillment
+ * endpoint validate the token against a metadata bid (either by id or by
+ * field-level criteria).
+ *
+ * Returns the generated metadata_id, which callers using id-based bids should
+ * pass into `createMetadataBid`. Callers using criteria-based bids can ignore
+ * the return value.
  */
 function ensureIndexerNft(
   contractAddress: string,
   tokenId: string,
+  overrides: NftMetadataOverrides = {},
 ): string {
   const port = process.env.INDEXER_MR_POSTGRES_PORT ?? '5434';
   const connStr = `postgres://postgres:postgres@localhost:${port}/indexer-mr`;
   const metadataId = randomUUID();
   const metadataHash = randomBytes(16).toString('hex');
   const nftId = randomUUID();
+
+  const name = overrides.name ?? 'e2e metadata-bid nft';
+  const image = overrides.image ?? 'https://example.com/nft.png';
+  const attributesJson = JSON.stringify(overrides.attributes ?? []);
 
   const sql = `
     BEGIN;
@@ -57,11 +87,17 @@ function ensureIndexerNft(
     ON CONFLICT (chain_id, contract_address) DO NOTHING;
 
     INSERT INTO nft_metadata
-      (id, chain_id, contract_address, hash, name, image, attributes, created_at, updated_at)
+      (id, chain_id, contract_address, hash, name, image,
+       description, animation_url, external_url, youtube_url,
+       attributes, created_at, updated_at)
     VALUES
       ('${metadataId}'::uuid, '${LOCAL_CHAIN_ID}', LOWER('${contractAddress}'),
-       '${metadataHash}', 'e2e metadata-bid nft', 'https://example.com/nft.png',
-       '[]'::jsonb, NOW(), NOW());
+       '${metadataHash}', '${escapeSqlString(name)}', '${escapeSqlString(image)}',
+       ${stringLiteralOrNull(overrides.description)},
+       ${stringLiteralOrNull(overrides.animationUrl)},
+       ${stringLiteralOrNull(overrides.externalUrl)},
+       ${stringLiteralOrNull(overrides.youtubeUrl)},
+       '${escapeSqlString(attributesJson)}'::jsonb, NOW(), NOW());
 
     INSERT INTO nfts
       (id, chain_id, contract_address, token_id, contract_type, indexed_at, updated_at, metadata_id)
@@ -76,7 +112,7 @@ function ensureIndexerNft(
     COMMIT;
   `;
 
-  execSync(`psql "${connStr}" -c "${sql.replace(/\n/g, ' ')}"`, { stdio: 'pipe' });
+  execSync(`psql "${connStr}"`, { input: sql, stdio: ['pipe', 'pipe', 'pipe'] });
   return metadataId;
 }
 
@@ -313,5 +349,210 @@ describe('metadata bid e2e', () => {
 
     expect(filledBid.id).toEqual(createdBid.id);
     expect(filledBid.status.name).toEqual(OrderStatusName.FILLED);
+  }, 120_000);
+
+  it('should prepare, create, and get a metadata bid with criteria', async () => {
+    const metadataCriteria = [
+      { fieldName: 'attribute:Background' as const, values: ['Blue', 'Red'] },
+      { fieldName: 'name' as const, values: ['Cool Dragon'] },
+    ];
+
+    const prepareResult = await sdk.prepareMetadataBid({
+      makerAddress: maker.address,
+      sell: {
+        contractAddress: erc20Address,
+        amount: '750000',
+        type: 'ERC20',
+      },
+      buy: {
+        contractAddress: erc721Address,
+        type: 'ERC721_COLLECTION',
+        amount: '1',
+      },
+    });
+
+    const signatures = await actionAll(prepareResult.actions, maker);
+
+    const { result: createdBid } = await sdk.createMetadataBid({
+      orderComponents: prepareResult.orderComponents,
+      orderHash: prepareResult.orderHash,
+      orderSignature: signatures[0],
+      makerFees: [],
+      metadataCriteria,
+    });
+
+    expect(createdBid.id).toBeDefined();
+    expect(createdBid.type).toEqual('METADATA_BID');
+    expect(createdBid.metadataId).toBeUndefined();
+    expect(createdBid.metadataCriteria).toEqual(metadataCriteria);
+
+    const activeBid = await waitForMetadataBidToBeOfStatus(
+      sdk,
+      createdBid.id,
+      OrderStatusName.ACTIVE,
+    );
+
+    expect(activeBid.id).toEqual(createdBid.id);
+    expect(activeBid.metadataId).toBeUndefined();
+    expect(activeBid.metadataCriteria).toEqual(metadataCriteria);
+    expect(activeBid.status.name).toEqual(OrderStatusName.ACTIVE);
+  }, 60_000);
+
+  it('should fulfill a metadata bid matched by attribute criteria', async () => {
+    const tokenId = getRandomTokenId();
+
+    const erc721 = new Contract(erc721Address, ERC721_ABI, maker);
+    const mintTx = await erc721.safeMint(taker.address, tokenId, GAS_OVERRIDES);
+    await mintTx.wait();
+
+    ensureIndexerNft(erc721Address, tokenId, {
+      attributes: [
+        { trait_type: 'Background', value: 'Blue' },
+        { trait_type: 'Rarity', value: 'Common' },
+      ],
+    });
+
+    const takerErc721 = new Contract(erc721Address, ERC721_ABI, taker);
+    const seaportAddress = process.env.SEAPORT_CONTRACT_ADDRESS!;
+    const approvalTx = await takerErc721.setApprovalForAll(seaportAddress, true, GAS_OVERRIDES);
+    await approvalTx.wait();
+
+    const blockTime = await provider.getBlock('latest');
+
+    const prepareResult = await sdk.prepareMetadataBid({
+      makerAddress: maker.address,
+      sell: {
+        contractAddress: erc20Address,
+        amount: '100000',
+        type: 'ERC20',
+      },
+      buy: {
+        contractAddress: erc721Address,
+        type: 'ERC721_COLLECTION',
+        amount: '1',
+      },
+      orderStart: new Date(blockTime!.timestamp - 1000),
+    });
+
+    const signatures = await actionAll(prepareResult.actions, maker);
+
+    const { result: createdBid } = await sdk.createMetadataBid({
+      orderComponents: prepareResult.orderComponents,
+      orderHash: prepareResult.orderHash,
+      orderSignature: signatures[0],
+      makerFees: [],
+      // OR within values ("Blue" matches), case-insensitive on both sides.
+      metadataCriteria: [
+        { fieldName: 'attribute:Background', values: ['blue', 'red'] },
+      ],
+    });
+
+    await waitForMetadataBidToBeOfStatus(
+      sdk,
+      createdBid.id,
+      OrderStatusName.ACTIVE,
+    );
+
+    const fulfillment = await sdk.fulfillOrder(
+      createdBid.id,
+      taker.address,
+      [],
+      undefined,
+      tokenId,
+    );
+
+    await actionAll(fulfillment.actions, taker);
+
+    const filledBid = await waitForMetadataBidToBeOfStatus(
+      sdk,
+      createdBid.id,
+      OrderStatusName.FILLED,
+    );
+
+    expect(filledBid.id).toEqual(createdBid.id);
+    expect(filledBid.status.name).toEqual(OrderStatusName.FILLED);
+    expect(filledBid.metadataId).toBeUndefined();
+    expect(filledBid.metadataCriteria).toEqual([
+      { fieldName: 'attribute:Background', values: ['blue', 'red'] },
+    ]);
+  }, 120_000);
+
+  it('should fulfill a metadata bid matched by mixed top-level + attribute criteria', async () => {
+    const tokenId = getRandomTokenId();
+
+    const erc721 = new Contract(erc721Address, ERC721_ABI, maker);
+    const mintTx = await erc721.safeMint(taker.address, tokenId, GAS_OVERRIDES);
+    await mintTx.wait();
+
+    ensureIndexerNft(erc721Address, tokenId, {
+      name: 'Cool Dragon',
+      attributes: [
+        { trait_type: 'Background', value: 'Blue' },
+      ],
+    });
+
+    const takerErc721 = new Contract(erc721Address, ERC721_ABI, taker);
+    const seaportAddress = process.env.SEAPORT_CONTRACT_ADDRESS!;
+    const approvalTx = await takerErc721.setApprovalForAll(seaportAddress, true, GAS_OVERRIDES);
+    await approvalTx.wait();
+
+    const blockTime = await provider.getBlock('latest');
+
+    const prepareResult = await sdk.prepareMetadataBid({
+      makerAddress: maker.address,
+      sell: {
+        contractAddress: erc20Address,
+        amount: '100000',
+        type: 'ERC20',
+      },
+      buy: {
+        contractAddress: erc721Address,
+        type: 'ERC721_COLLECTION',
+        amount: '1',
+      },
+      orderStart: new Date(blockTime!.timestamp - 1000),
+    });
+
+    const signatures = await actionAll(prepareResult.actions, maker);
+
+    // AND across filters: NFT must have name="Cool Dragon" AND attribute:Background in {Blue}.
+    const metadataCriteria = [
+      { fieldName: 'name' as const, values: ['Cool Dragon'] },
+      { fieldName: 'attribute:Background' as const, values: ['Blue'] },
+    ];
+
+    const { result: createdBid } = await sdk.createMetadataBid({
+      orderComponents: prepareResult.orderComponents,
+      orderHash: prepareResult.orderHash,
+      orderSignature: signatures[0],
+      makerFees: [],
+      metadataCriteria,
+    });
+
+    await waitForMetadataBidToBeOfStatus(
+      sdk,
+      createdBid.id,
+      OrderStatusName.ACTIVE,
+    );
+
+    const fulfillment = await sdk.fulfillOrder(
+      createdBid.id,
+      taker.address,
+      [],
+      undefined,
+      tokenId,
+    );
+
+    await actionAll(fulfillment.actions, taker);
+
+    const filledBid = await waitForMetadataBidToBeOfStatus(
+      sdk,
+      createdBid.id,
+      OrderStatusName.FILLED,
+    );
+
+    expect(filledBid.id).toEqual(createdBid.id);
+    expect(filledBid.status.name).toEqual(OrderStatusName.FILLED);
+    expect(filledBid.metadataCriteria).toEqual(metadataCriteria);
   }, 120_000);
 });

--- a/packages/orderbook/src/types.ts
+++ b/packages/orderbook/src/types.ts
@@ -83,14 +83,56 @@ export interface TraitBid extends OrderFields {
   traitCriteria: TraitFilter[];
 }
 
+/**
+ * Top-level NFT metadata fields a metadata bid criterion may target.
+ * Mirrors the ERC-721 / OpenSea metadata schema indexed by Immutable.
+ */
+export type MetadataTopLevelField =
+  | 'name'
+  | 'image'
+  | 'description'
+  | 'animation_url'
+  | 'external_url'
+  | 'youtube_url';
+
+/**
+ * An attribute-style field name. The portion after `attribute:` is the
+ * attribute's `trait_type` (e.g. `attribute:Background`).
+ */
+export type MetadataAttributeField = `attribute:${string}`;
+
+/**
+ * Field name a single metadata bid criterion can target. Either a known
+ * top-level metadata field, or an attribute-prefixed name.
+ */
+export type MetadataFieldName = MetadataTopLevelField | MetadataAttributeField;
+
+/**
+ * A single metadata bid criterion: a field name plus the acceptable values
+ * for that field. Within a filter values are OR'd; across filters they AND.
+ * Comparisons are case-insensitive.
+ */
+export interface MetadataFieldFilter {
+  fieldName: MetadataFieldName;
+  values: string[];
+}
+
 export interface MetadataBid extends OrderFields {
   type: 'METADATA_BID';
   sell: ERC20Item[];
   buy: (ERC721CollectionItem | ERC1155CollectionItem)[];
   /**
    * The metadata ID (stack ID) that NFTs must match to fulfil this bid.
+   * Set when the bid was created with a single metadata stack identifier.
+   * Mutually exclusive with `metadataCriteria`.
    */
-  metadataId: string;
+  metadataId?: string;
+  /**
+   * Field-level metadata filters that NFTs must match to fulfil this bid.
+   * Set when the bid was created with criteria instead of a metadata ID.
+   * Empty when the bid was created with a `metadataId`.
+   */
+  metadataCriteria: MetadataFieldFilter[];
 }
 
 interface OrderFields {
@@ -401,9 +443,20 @@ export type PrepareMetadataBidParams = PrepareCollectionBidParams;
 
 export type PrepareMetadataBidResponse = PrepareOrderResponse;
 
-export interface CreateMetadataBidParams extends CreateCollectionBidParams {
-  metadataId: string;
-}
+/**
+ * Parameters for creating a metadata bid. Exactly one of `metadataId` or
+ * `metadataCriteria` must be provided.
+ *
+ * - `metadataId` mode: matches NFTs whose indexed metadata stack ID equals
+ *   the supplied UUID.
+ * - `metadataCriteria` mode: matches NFTs whose metadata satisfies every
+ *   filter (AND across filters, OR within a filter's `values`,
+ *   case-insensitive).
+ */
+export type CreateMetadataBidParams = CreateCollectionBidParams & (
+  | { metadataId: string; metadataCriteria?: never }
+  | { metadataId?: never; metadataCriteria: MetadataFieldFilter[] }
+);
 
 /* Fulfilment Ops */
 


### PR DESCRIPTION
### Hi👋, please ensure the PR title follows the below standards:
<!-- This will allow for auto-generated changelog entries in Github releases -->
<!-- Valid types: feat, fix, refactor, style, test, docs, build, ops, chore -->
<!-- refactor, style, test, docs, build, ops, chore types won't be included in changelogs -->
- [ ] PR is titled with conventional commit style naming: `type(scope): message`. For example: `feat(passport): my new feature`
- [ ] If you have introduced modification that necessitates immediate adjustments by this SDK's users to their applications, clients, or integrations to avert disruptions to existing features or functionalities, add a `!` after the `type(scope)`, for example `feat(passport)!: my new breaking feature`

# Summary

Updates the parameters for creating metadata bids to allow specifying either a `metadata-id` or a set of  metadata criteria filters.

# Detail and impact of the change
<!-- Remove any sub-sections below that are not applicable -->
## Added 
<!-- Section for new features. -->

## Changed

- Update orderbook
- Update e2e tests for metadata bids with criteria

<!-- Section for changes in existing functionality. -->

## Deprecated
<!-- Section for soon-to-be removed features. -->

## Removed
<!-- Section for now removed features. -->

## Fixed
<!-- Section for any bug fixes. -->

## Security
<!-- Section in case of vulnerabilities. -->

# Anything else worth calling out?
<!-- Useful tips, gotchas, trade-offs made to the reviewers. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the public `CreateMetadataBidParams` shape and request payload for metadata bids, which could break callers and affect bid creation/mapping if criteria validation or mapping is incorrect.
> 
> **Overview**
> Adds support for creating metadata bids using *either* a single `metadataId` or a new `metadataCriteria` array of field-level filters, enforcing **mutual exclusivity** and performing client-side validation of allowed field names, non-empty values, and duplicate filters.
> 
> Extends the OpenAPI SDK types and mappers to handle `metadata_criteria` (and optional `metadata_id`) in both request and response mapping, and updates unit + e2e tests to cover criteria-based creation and fulfillment paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2d80d9f13146f301bf1af281b781482c7ff7211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->