### PR TITLE
feat(audience): rename event property keys to snake_case [SDK-412]

### DIFF
--- a/packages/audience/pixel/README.md
+++ b/packages/audience/pixel/README.md
@@ -81,10 +81,10 @@ All events fire automatically with no instrumentation required.
 | Event | When it fires | Key properties |
 |-------|--------------|----------------|
 | `page` | Every page load | UTMs, click IDs (`gclid`, `fbclid`, `ttclid`, `msclkid`, `dclid`, `li_fat_id`), `referral_code`, `landing_page` |
-| `session_start` | New session (no active `_imtbl_sid` cookie) | `sessionId` |
-| `session_end` | Page unload (`visibilitychange` / `pagehide`) | `sessionId`, `duration` (seconds) |
-| `form_submitted` | HTML form submission | `formAction`, `formId`, `formName`, `fieldNames`. `emailHash` at `full` consent only. |
-| `link_clicked` | Outbound link click (external domains only) | `linkUrl`, `linkText`, `elementId`, `outbound: true` |
+| `session_start` | New session (no active `_imtbl_sid` cookie) | `session_id` |
+| `session_end` | Page unload (`visibilitychange` / `pagehide`) | `session_id`, `duration` (seconds) |
+| `form_submitted` | HTML form submission | `form_action`, `form_id`, `form_name`, `field_names`. `email_hash` at `full` consent only. |
+| `link_clicked` | Outbound link click (external domains only) | `link_url`, `link_text`, `element_id`, `outbound: true` |
 | `scroll_depth` | Scroll milestone reached (25%, 50%, 75%, 90%, 100%) | `depth` (integer). Fires on standard document scroll or on any internal scroll container larger than half the viewport. Milestones reset on each `page` call. |
 
 ### Disabling specific auto-capture

--- a/packages/audience/pixel/package.json
+++ b/packages/audience/pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@imtbl/pixel",
   "description": "Immutable Tracking Pixel — drop-in JavaScript snippet for device fingerprint, page view, and attribution data",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Immutable",
   "private": true,
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",

--- a/packages/audience/pixel/src/autocapture.test.ts
+++ b/packages/audience/pixel/src/autocapture.test.ts
@@ -80,16 +80,16 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'form_submitted',
         expect.objectContaining({
-          formAction: expect.stringContaining('/signup'),
-          formId: 'signup-form',
-          formName: 'newsletter',
-          fieldNames: ['email'],
+          form_action: expect.stringContaining('/signup'),
+          form_id: 'signup-form',
+          form_name: 'newsletter',
+          field_names: ['email'],
         }),
       );
 
-      // At anonymous consent, no emailHash
+      // At anonymous consent, no email_hash
       const props = enqueue.mock.calls[0][1];
-      expect(props.emailHash).toBeUndefined();
+      expect(props.email_hash).toBeUndefined();
     });
 
     it('fires form_submitted with email hash at full consent', async () => {
@@ -114,8 +114,8 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'form_submitted',
         expect.objectContaining({
-          formAction: expect.stringContaining('/register'),
-          emailHash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          form_action: expect.stringContaining('/register'),
+          email_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
         }),
       );
     });
@@ -140,7 +140,7 @@ describe('autocapture', () => {
         .update(new TextEncoder().encode('test@example.com'))
         .digest('hex');
 
-      expect(enqueue.mock.calls[0][1].emailHash).toBe(`sha256:${expected}`);
+      expect(enqueue.mock.calls[0][1].email_hash).toBe(`sha256:${expected}`);
     });
 
     it('detects email inputs by name containing "email"', () => {
@@ -166,7 +166,7 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'form_submitted',
         expect.objectContaining({
-          fieldNames: ['user_email_address'],
+          field_names: ['user_email_address'],
         }),
       );
     });
@@ -202,7 +202,7 @@ describe('autocapture', () => {
       document.body.appendChild(form);
       form.dispatchEvent(new Event('submit', { bubbles: true }));
 
-      expect(enqueue.mock.calls[0][1].fieldNames).toEqual([
+      expect(enqueue.mock.calls[0][1].field_names).toEqual([
         'first_name',
         'email',
         'country',
@@ -237,11 +237,11 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'form_submitted',
         expect.objectContaining({
-          formAction: expect.stringContaining('/search'),
-          fieldNames: ['query'],
+          form_action: expect.stringContaining('/search'),
+          field_names: ['query'],
         }),
       );
-      expect(enqueue.mock.calls[0][1].emailHash).toBeUndefined();
+      expect(enqueue.mock.calls[0][1].email_hash).toBeUndefined();
     });
 
     it('enqueues without emailHash when crypto.subtle is unavailable', async () => {
@@ -271,9 +271,9 @@ describe('autocapture', () => {
       // Event should still be enqueued, just without emailHash
       expect(enqueue).toHaveBeenCalledWith(
         'form_submitted',
-        expect.objectContaining({ formAction: expect.stringContaining('/signup') }),
+        expect.objectContaining({ form_action: expect.stringContaining('/signup') }),
       );
-      expect(enqueue.mock.calls[0][1].emailHash).toBeUndefined();
+      expect(enqueue.mock.calls[0][1].email_hash).toBeUndefined();
 
       // Restore crypto
       Object.defineProperty(global, 'crypto', { value: saved, configurable: true });
@@ -293,9 +293,9 @@ describe('autocapture', () => {
 
       form.dispatchEvent(new Event('submit', { bubbles: true }));
 
-      // Should fire synchronously (no hash), no emailHash
+      // Should fire synchronously (no hash), no email_hash
       expect(enqueue).toHaveBeenCalledTimes(1);
-      expect(enqueue.mock.calls[0][1].emailHash).toBeUndefined();
+      expect(enqueue.mock.calls[0][1].email_hash).toBeUndefined();
     });
   });
 
@@ -316,9 +316,9 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'link_clicked',
         {
-          linkUrl: 'https://store.steampowered.com/app/12345',
-          linkText: 'Wishlist on Steam',
-          elementId: 'steam-link',
+          link_url: 'https://store.steampowered.com/app/12345',
+          link_text: 'Wishlist on Steam',
+          element_id: 'steam-link',
           outbound: true,
         },
       );
@@ -362,7 +362,7 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'link_clicked',
         expect.objectContaining({
-          linkUrl: 'https://discord.gg/invite',
+          link_url: 'https://discord.gg/invite',
           outbound: true,
         }),
       );
@@ -392,7 +392,7 @@ describe('autocapture', () => {
       link.dispatchEvent(new Event('click', { bubbles: true }));
 
       const props = enqueue.mock.calls[0][1];
-      expect(props.linkText).toHaveLength(256);
+      expect(props.link_text).toHaveLength(256);
     });
 
     it('resolves clicks on child elements to nearest anchor', () => {
@@ -412,8 +412,8 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'link_clicked',
         expect.objectContaining({
-          linkUrl: 'https://store.steampowered.com/app/12345',
-          linkText: 'Click me',
+          link_url: 'https://store.steampowered.com/app/12345',
+          link_text: 'Click me',
           outbound: true,
         }),
       );
@@ -441,7 +441,7 @@ describe('autocapture', () => {
 
       link.dispatchEvent(new Event('click', { bubbles: true }));
 
-      expect(enqueue.mock.calls[0][1].elementId).toBeUndefined();
+      expect(enqueue.mock.calls[0][1].element_id).toBeUndefined();
     });
 
     it('ignores clicks on non-link elements', () => {
@@ -1017,8 +1017,8 @@ describe('autocapture', () => {
       await new Promise((r) => { setTimeout(r, 0); });
 
       expect(enqueue).toHaveBeenCalledTimes(2);
-      const hash1 = enqueue.mock.calls[0][1].emailHash;
-      const hash2 = enqueue.mock.calls[1][1].emailHash;
+      const hash1 = enqueue.mock.calls[0][1].email_hash;
+      const hash2 = enqueue.mock.calls[1][1].email_hash;
       expect(hash1).toBe(hash2);
       expect(hash1).toMatch(/^sha256:[a-f0-9]{64}$/);
     });

--- a/packages/audience/pixel/src/autocapture.ts
+++ b/packages/audience/pixel/src/autocapture.ts
@@ -174,10 +174,10 @@ export function setupAutocapture(
       if (!form || form.tagName !== 'FORM') return;
 
       const properties: Record<string, unknown> = {
-        formAction: form.action || undefined,
-        formId: form.id || undefined,
-        formName: form.getAttribute('name') || undefined,
-        fieldNames: getFieldNames(form),
+        form_action: form.action || undefined,
+        form_id: form.id || undefined,
+        form_name: form.getAttribute('name') || undefined,
+        field_names: getFieldNames(form),
       };
 
       const consent = getConsent();
@@ -189,7 +189,7 @@ export function setupAutocapture(
           // enqueue without emailHash rather than losing the event entirely.
           hashSHA256(email).then(
             (hash) => {
-              properties.emailHash = hash;
+              properties.email_hash = hash;
               enqueue('form_submitted', properties);
             },
             () => {
@@ -220,9 +220,9 @@ export function setupAutocapture(
         if (linkHost === window.location.hostname) return;
 
         enqueue('link_clicked', {
-          linkUrl: anchor.href,
-          linkText: (anchor.textContent || '').trim().slice(0, 256),
-          elementId: anchor.id || undefined,
+          link_url: anchor.href,
+          link_text: (anchor.textContent || '').trim().slice(0, 256),
+          element_id: anchor.id || undefined,
           outbound: true,
         });
       } catch {

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -115,7 +115,7 @@ describe('Pixel', () => {
       expect((pageCall!.properties as Record<string, unknown>).utm_source).toBe('google');
 
       expect(sessionStartCall).toBeDefined();
-      expect((sessionStartCall!.properties as Record<string, unknown>).sessionId).toBe('session-abc');
+      expect((sessionStartCall!.properties as Record<string, unknown>).session_id).toBe('session-abc');
     });
 
     it('does not fire page view or session_start when consent is none', () => {
@@ -171,7 +171,7 @@ describe('Pixel', () => {
           surface: 'pixel',
           properties: expect.objectContaining({
             utm_source: 'google',
-            sessionId: 'session-abc',
+            session_id: 'session-abc',
             custom: 'prop',
           }),
         }),
@@ -206,9 +206,9 @@ describe('Pixel', () => {
       const pageCall = calls.find((c) => c.type === 'page');
       const props = pageCall!.properties as Record<string, unknown>;
 
-      expect(props.gaClientId).toBe('GA1.2.123456.789012');
-      expect(props.fbClickId).toBe('fb.1.1234567890.AbCdEf');
-      expect(props.fbBrowserId).toBe('fb.1.1234567890.987654321');
+      expect(props.ga_client_id).toBe('GA1.2.123456.789012');
+      expect(props.fb_click_id).toBe('fb.1.1234567890.AbCdEf');
+      expect(props.fb_browser_id).toBe('fb.1.1234567890.987654321');
     });
 
     it('omits third-party IDs when cookies are not set', () => {
@@ -223,9 +223,9 @@ describe('Pixel', () => {
       const pageCall = calls.find((c) => c.type === 'page');
       const props = pageCall!.properties as Record<string, unknown>;
 
-      expect(props.gaClientId).toBeUndefined();
-      expect(props.fbClickId).toBeUndefined();
-      expect(props.fbBrowserId).toBeUndefined();
+      expect(props.ga_client_id).toBeUndefined();
+      expect(props.fb_click_id).toBeUndefined();
+      expect(props.fb_browser_id).toBeUndefined();
     });
   });
 
@@ -244,7 +244,7 @@ describe('Pixel', () => {
           type: 'track',
           eventName: 'session_end',
           properties: expect.objectContaining({
-            sessionId: 'session-abc',
+            session_id: 'session-abc',
           }),
         }),
       );
@@ -559,7 +559,7 @@ describe('Pixel', () => {
         eventName: string,
         properties: Record<string, unknown>,
       ) => void;
-      enqueueCallback('form_submitted', { formAction: '/signup' });
+      enqueueCallback('form_submitted', { form_action: '/signup' });
 
       expect(mockEnqueue).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -567,8 +567,8 @@ describe('Pixel', () => {
           eventName: 'form_submitted',
           surface: 'pixel',
           properties: expect.objectContaining({
-            formAction: '/signup',
-            sessionId: 'session-xyz',
+            form_action: '/signup',
+            session_id: 'session-xyz',
           }),
         }),
       );

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -152,7 +152,7 @@ export class Pixel {
       properties: {
         ...attribution,
         ...thirdPartyIds,
-        sessionId,
+        session_id: sessionId,
         ...properties,
       },
       userId: undefined,
@@ -230,7 +230,7 @@ export class Pixel {
       ...this.buildBase(),
       type: 'track',
       eventName,
-      properties: { ...properties, sessionId },
+      properties: { ...properties, session_id: sessionId },
       userId: undefined,
     };
 
@@ -254,7 +254,7 @@ export class Pixel {
       ...this.buildBase(),
       type: 'track',
       eventName: 'session_start',
-      properties: { sessionId },
+      properties: { session_id: sessionId },
       userId: undefined,
     };
 
@@ -273,7 +273,7 @@ export class Pixel {
       type: 'track',
       eventName: 'session_end',
       properties: {
-        sessionId: this.sessionId,
+        session_id: this.sessionId,
         duration,
       },
       userId: undefined,
@@ -315,11 +315,11 @@ export class Pixel {
   private collectThirdPartyIds(): Record<string, string> {
     const ids: Record<string, string> = {};
     const ga = getCookie('_ga');
-    if (ga) ids.gaClientId = ga;
+    if (ga) ids.ga_client_id = ga;
     const fbc = getCookie('_fbc');
-    if (fbc) ids.fbClickId = fbc;
+    if (fbc) ids.fb_click_id = fbc;
     const fbp = getCookie('_fbp');
-    if (fbp) ids.fbBrowserId = fbp;
+    if (fbp) ids.fb_browser_id = fbp;
     return ids;
   }
 

--- a/packages/audience/sdk-sample-app/README.md
+++ b/packages/audience/sdk-sample-app/README.md
@@ -16,11 +16,11 @@ Every other sample app in this monorepo (`packages/passport/sdk-sample-app`,
 `packages/internal/bridge/bridge-sample-app`) is React + Next.js with the
 `@biom3` design system. This one is plain ES2020 served by a ~90-line Node
 stdlib HTTP server. Intentional: the whole point is to demonstrate how
-`@imtbl/audience` loads via a plain `<script>` tag — the pattern real
+`@imtbl/audience` loads via a plain `<script>` tag - the pattern real
 studios use when they drop the SDK into existing pages. A React wrapper
 would hide `window.ImmutableAudience` behind JSX abstractions and require
 a build step, obscuring the loading pattern we're demonstrating. The SDK
-itself is framework-agnostic — wrap these calls in your framework of
+itself is framework-agnostic - wrap these calls in your framework of
 choice when you ship.
 
 ## Run it
@@ -35,7 +35,7 @@ this package's files plus the CDN bundle over a small Node server.
 
 ## Publishable keys
 
-You need a real publishable key from [Immutable Hub](https://hub.immutable.com/) —
+You need a real publishable key from [Immutable Hub](https://hub.immutable.com/) -
 there is no shared fixture key. Test keys start with `pk_imapik-test-` and
 route to `api.sandbox.immutable.com`; any other prefix routes to
 `api.immutable.com` (prod).
@@ -72,8 +72,8 @@ const { AudienceEvents } = window.ImmutableAudience;
 audience.track(AudienceEvents.PURCHASE, {
   currency: 'USD',
   value: 9.99,
-  itemId: 'sword',
-  transactionId: 'tx_123',
+  item_id: 'sword',
+  transaction_id: 'tx_123',
 });
 ```
 
@@ -84,17 +84,17 @@ picked up yet, the event log shows a `drift warn` entry.
 
 | Event | Required props | Optional props |
 |---|---|---|
-| `sign_up` | — | `method` |
-| `sign_in` | — | `method` |
-| `wishlist_add` | `gameId` | `source`, `platform` |
-| `wishlist_remove` | `gameId` | — |
-| `purchase` | `currency`, `value` | `itemId`, `itemName`, `quantity`, `transactionId` |
-| `game_launch` | — | `platform`, `version`, `buildId` |
-| `progression` | `status: 'start' \| 'complete' \| 'fail'` | `world`, `level`, `stage`, `score`, `durationSec` |
-| `resource` | `flow: 'sink' \| 'source'`, `currency`, `amount` | `itemType`, `itemId` |
-| `email_acquired` | — | `source` |
-| `game_page_viewed` | `gameId` | `gameName`, `slug` |
-| `link_clicked` | `url` | `label`, `source`, `gameId` |
+| `sign_up` | - | `method` |
+| `sign_in` | - | `method` |
+| `wishlist_add` | `game_id` | `source`, `platform` |
+| `wishlist_remove` | `game_id` | - |
+| `purchase` | `currency`, `value` | `item_id`, `item_name`, `quantity`, `transaction_id` |
+| `game_launch` | - | `platform`, `version`, `build_id` |
+| `progression` | `status: 'start' \| 'complete' \| 'fail'` | `world`, `level`, `stage`, `score`, `duration_sec` |
+| `resource` | `flow: 'sink' \| 'source'`, `currency`, `amount` | `item_type`, `item_id` |
+| `email_acquired` | - | `source` |
+| `game_page_viewed` | `game_id` | `game_name`, `slug` |
+| `link_clicked` | `url` | `label`, `source`, `game_id` |
 
 Pass anything else as a custom event with the `string & {}` escape hatch:
 
@@ -129,7 +129,7 @@ The rules themselves are simple:
 The sample app's Identity and Alias buttons stay enabled whenever the SDK
 is initialised, but the handlers call `canIdentify(currentConsent)` before
 invoking `identify()` / `alias()`. When it returns `false`, the handler
-logs a `skipped — canIdentify(...) is false` line and returns without
+logs a `skipped - canIdentify(...) is false` line and returns without
 calling the SDK. This mirrors how the SDK itself handles these calls at
 lower consent levels: it no-ops rather than throwing, so the sample app
 avoids a misleading "ok" log entry for a call that did nothing.
@@ -157,7 +157,7 @@ const audience = window.ImmutableAudience.init({
 
 The sample app's **Lifecycle → Simulate error** dropdown fires `onError`
 with the documented shape for any of the four codes. These are client-side
-simulations — they don't go through the SDK — so you can verify your
+simulations - they don't go through the SDK - so you can verify your
 error-handling UI renders correctly for all four without needing a
 broken backend.
 
@@ -173,5 +173,5 @@ connect-src https://api.dev.immutable.com https://api.sandbox.immutable.com http
 ```
 
 No inline scripts, no inline styles, no third-party origins. If you
-adapt this sample app for a studio-owned page, keep the same posture —
+adapt this sample app for a studio-owned page, keep the same posture -
 `@imtbl/audience` is designed to run under a strict CSP.

--- a/packages/audience/sdk-sample-app/sample-app.js
+++ b/packages/audience/sdk-sample-app/sample-app.js
@@ -21,23 +21,23 @@
     { name: 'sign_in',          fields: [{ key: 'method', type: 'string', optional: true }] },
     { name: 'email_acquired',   fields: [{ key: 'source', type: 'string', optional: true }] },
     { name: 'wishlist_add',     fields: [
-      { key: 'gameId', type: 'string' },
+      { key: 'game_id', type: 'string' },
       { key: 'source', type: 'string', optional: true },
       { key: 'platform', type: 'string', optional: true },
     ] },
-    { name: 'wishlist_remove',  fields: [{ key: 'gameId', type: 'string' }] },
+    { name: 'wishlist_remove',  fields: [{ key: 'game_id', type: 'string' }] },
     { name: 'purchase',         fields: [
       { key: 'currency', type: 'string' },
       { key: 'value', type: 'number' },
-      { key: 'itemId', type: 'string', optional: true },
-      { key: 'itemName', type: 'string', optional: true },
+      { key: 'item_id', type: 'string', optional: true },
+      { key: 'item_name', type: 'string', optional: true },
       { key: 'quantity', type: 'number', optional: true },
-      { key: 'transactionId', type: 'string', optional: true },
+      { key: 'transaction_id', type: 'string', optional: true },
     ] },
     { name: 'game_launch',      fields: [
       { key: 'platform', type: 'string', optional: true },
       { key: 'version', type: 'string', optional: true },
-      { key: 'buildId', type: 'string', optional: true },
+      { key: 'build_id', type: 'string', optional: true },
     ] },
     { name: 'progression',      fields: [
       { key: 'status', type: 'enum', values: ['start', 'complete', 'fail'] },
@@ -45,25 +45,25 @@
       { key: 'level', type: 'string', optional: true },
       { key: 'stage', type: 'string', optional: true },
       { key: 'score', type: 'number', optional: true },
-      { key: 'durationSec', type: 'number', optional: true },
+      { key: 'duration_sec', type: 'number', optional: true },
     ] },
     { name: 'resource',         fields: [
       { key: 'flow', type: 'enum', values: ['sink', 'source'] },
       { key: 'currency', type: 'string' },
       { key: 'amount', type: 'number' },
-      { key: 'itemType', type: 'string', optional: true },
-      { key: 'itemId', type: 'string', optional: true },
+      { key: 'item_type', type: 'string', optional: true },
+      { key: 'item_id', type: 'string', optional: true },
     ] },
     { name: 'game_page_viewed', fields: [
-      { key: 'gameId', type: 'string' },
-      { key: 'gameName', type: 'string', optional: true },
+      { key: 'game_id', type: 'string' },
+      { key: 'game_name', type: 'string', optional: true },
       { key: 'slug', type: 'string', optional: true },
     ] },
     { name: 'link_clicked',     fields: [
       { key: 'url', type: 'string' },
       { key: 'label', type: 'string', optional: true },
       { key: 'source', type: 'string', optional: true },
-      { key: 'gameId', type: 'string', optional: true },
+      { key: 'game_id', type: 'string', optional: true },
     ] },
   ];
 
@@ -269,7 +269,7 @@
         currentAnonId = payload.anonymousId;
         changed = true;
       }
-      var sid = payload.properties && payload.properties.sessionId;
+      var sid = payload.properties && payload.properties.session_id;
       if (typeof sid === 'string' && sid && currentSessionId !== sid) {
         currentSessionId = sid;
         changed = true;

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -23,28 +23,28 @@ export interface SignInProperties {
 }
 
 export interface WishlistAddProperties {
-  gameId: string;
+  game_id: string;
   source?: string;
   platform?: string;
 }
 
 export interface WishlistRemoveProperties {
-  gameId: string;
+  game_id: string;
 }
 
 export interface PurchaseProperties {
   currency: string;
   value: number;
-  itemId?: string;
-  itemName?: string;
+  item_id?: string;
+  item_name?: string;
   quantity?: number;
-  transactionId?: string;
+  transaction_id?: string;
 }
 
 export interface GameLaunchProperties {
   platform?: string;
   version?: string;
-  buildId?: string;
+  build_id?: string;
 }
 
 export type ProgressionStatus = 'start' | 'complete' | 'fail';
@@ -55,7 +55,7 @@ export interface ProgressionProperties {
   level?: string;
   stage?: string;
   score?: number;
-  durationSec?: number;
+  duration_sec?: number;
 }
 
 export type ResourceFlow = 'sink' | 'source';
@@ -64,8 +64,8 @@ export interface ResourceProperties {
   flow: ResourceFlow;
   currency: string;
   amount: number;
-  itemType?: string;
-  itemId?: string;
+  item_type?: string;
+  item_id?: string;
 }
 
 export interface EmailAcquiredProperties {
@@ -73,8 +73,8 @@ export interface EmailAcquiredProperties {
 }
 
 export interface GamePageViewedProperties {
-  gameId: string;
-  gameName?: string;
+  game_id: string;
+  game_name?: string;
   slug?: string;
 }
 
@@ -82,7 +82,7 @@ export interface LinkClickedProperties {
   url: string;
   label?: string;
   source?: string;
-  gameId?: string;
+  game_id?: string;
 }
 
 interface EventPropsMap {

--- a/packages/audience/sdk/src/sdk.test-d.ts
+++ b/packages/audience/sdk/src/sdk.test-d.ts
@@ -6,20 +6,20 @@ sdk.track('sign_up');
 sdk.track('sign_up', { method: 'email' });
 sdk.track('sign_in');
 sdk.track('sign_in', { method: 'passport' });
-sdk.track('wishlist_add', { gameId: 'abc' });
-sdk.track('wishlist_add', { gameId: 'abc', source: 'game_page', platform: 'steam' });
-sdk.track('wishlist_remove', { gameId: 'abc' });
+sdk.track('wishlist_add', { game_id: 'abc' });
+sdk.track('wishlist_add', { game_id: 'abc', source: 'game_page', platform: 'steam' });
+sdk.track('wishlist_remove', { game_id: 'abc' });
 sdk.track('purchase', { currency: 'USD', value: 9.99 });
 sdk.track('purchase', {
   currency: 'USD',
   value: 9.99,
-  itemId: 'sku_1',
-  itemName: 'Gold Pack',
+  item_id: 'sku_1',
+  item_name: 'Gold Pack',
   quantity: 2,
-  transactionId: 'txn_42',
+  transaction_id: 'txn_42',
 });
 sdk.track('game_launch');
-sdk.track('game_launch', { platform: 'webgl', version: '1.2.0', buildId: 'ci-42' });
+sdk.track('game_launch', { platform: 'webgl', version: '1.2.0', build_id: 'ci-42' });
 sdk.track('progression', { status: 'start' });
 sdk.track('progression', { status: 'complete', world: 'tutorial' });
 sdk.track('progression', {
@@ -28,26 +28,26 @@ sdk.track('progression', {
   level: '5',
   stage: 'boss',
   score: 420,
-  durationSec: 87,
+  duration_sec: 87,
 });
 sdk.track('resource', { flow: 'sink', currency: 'gold', amount: 50 });
 sdk.track('resource', {
   flow: 'source',
   currency: 'USD',
   amount: 9.99,
-  itemType: 'iap',
-  itemId: 'sku_1',
+  item_type: 'iap',
+  item_id: 'sku_1',
 });
 sdk.track('email_acquired');
 sdk.track('email_acquired', { source: 'linked_account_steam' });
-sdk.track('game_page_viewed', { gameId: 'abc' });
-sdk.track('game_page_viewed', { gameId: 'abc', gameName: 'Devilfish', slug: 'devilfish' });
+sdk.track('game_page_viewed', { game_id: 'abc' });
+sdk.track('game_page_viewed', { game_id: 'abc', game_name: 'Devilfish', slug: 'devilfish' });
 sdk.track('link_clicked', { url: 'https://example.com' });
 sdk.track('link_clicked', {
   url: 'https://example.com',
   label: 'Play Now',
   source: 'game_page',
-  gameId: 'abc',
+  game_id: 'abc',
 });
 
 sdk.track(AudienceEvents.SIGN_UP, { method: 'email' });
@@ -57,19 +57,19 @@ sdk.track(AudienceEvents.PROGRESSION, { status: 'complete' });
 // @ts-expect-error — missing required 'value'
 sdk.track('purchase', { currency: 'USD' });
 
-// @ts-expect-error — missing required 'gameId'
+// @ts-expect-error — missing required 'game_id'
 sdk.track('wishlist_add', {});
 
 // @ts-expect-error — missing required 'status'
 sdk.track('progression', { world: 'tutorial' });
 
 // @ts-expect-error — missing required 'flow', 'currency', 'amount'
-sdk.track('resource', { itemType: 'iap' });
+sdk.track('resource', { item_type: 'iap' });
 
 // @ts-expect-error — missing required 'url'
 sdk.track('link_clicked', { label: 'Play Now' });
 
-// @ts-expect-error — missing required 'gameId'
+// @ts-expect-error — missing required 'game_id'
 sdk.track('game_page_viewed', {});
 
 // @ts-expect-error — purchase requires properties

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -131,7 +131,7 @@ describe('Audience', () => {
         (m: any) => m.type === 'track' && m.eventName === SESSION_START,
       );
       expect(msg).toBeDefined();
-      expect(msg.properties).toHaveProperty('sessionId');
+      expect(msg.properties).toHaveProperty('session_id');
 
       sdk.shutdown();
     });
@@ -157,7 +157,7 @@ describe('Audience', () => {
         (m: any) => m.type === 'track' && m.eventName === SESSION_START,
       );
       expect(msg).toBeDefined();
-      expect(msg.properties).toHaveProperty('sessionId');
+      expect(msg.properties).toHaveProperty('session_id');
       expect(msg.properties).toHaveProperty('utm_source', 'youtube');
       expect(msg.properties).toHaveProperty('utm_campaign', 'launch');
 
@@ -172,7 +172,7 @@ describe('Audience', () => {
       sdk.track('purchase', {
         currency: 'USD',
         value: 9.99,
-        itemId: 'sword_01',
+        item_id: 'sword_01',
       });
 
       await sdk.flush();
@@ -184,10 +184,10 @@ describe('Audience', () => {
 
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         currency: 'USD',
         value: 9.99,
-        itemId: 'sword_01',
+        item_id: 'sword_01',
       });
       expect(msg.surface).toBe('web');
       expect(msg.context.library).toBe(LIBRARY_NAME);
@@ -247,7 +247,7 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         method: 'email',
       });
 
@@ -260,7 +260,7 @@ describe('Audience', () => {
       sdk.track('game_launch', {
         platform: 'webgl',
         version: '1.2.0',
-        buildId: 'ci-42',
+        build_id: 'ci-42',
       });
       await sdk.flush();
 
@@ -269,10 +269,10 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         platform: 'webgl',
         version: '1.2.0',
-        buildId: 'ci-42',
+        build_id: 'ci-42',
       });
 
       sdk.shutdown();
@@ -287,7 +287,7 @@ describe('Audience', () => {
         level: '5',
         stage: 'boss',
         score: 420,
-        durationSec: 87,
+        duration_sec: 87,
       });
       await sdk.flush();
 
@@ -296,13 +296,13 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         status: 'complete',
         world: 'forest',
         level: '5',
         stage: 'boss',
         score: 420,
-        durationSec: 87,
+        duration_sec: 87,
       });
 
       sdk.shutdown();
@@ -315,8 +315,8 @@ describe('Audience', () => {
         flow: 'source',
         currency: 'gold',
         amount: 50,
-        itemType: 'quest_reward',
-        itemId: 'quest_42',
+        item_type: 'quest_reward',
+        item_id: 'quest_42',
       });
       await sdk.flush();
 
@@ -325,12 +325,12 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         flow: 'source',
         currency: 'gold',
         amount: 50,
-        itemType: 'quest_reward',
-        itemId: 'quest_42',
+        item_type: 'quest_reward',
+        item_id: 'quest_42',
       });
 
       sdk.shutdown();
@@ -340,7 +340,7 @@ describe('Audience', () => {
       const sdk = createSDK();
 
       sdk.track('wishlist_add', {
-        gameId: 'devilfish',
+        game_id: 'devilfish',
         source: 'game_page',
         platform: 'steam',
       });
@@ -351,8 +351,8 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
-        gameId: 'devilfish',
+        session_id: expect.any(String),
+        game_id: 'devilfish',
         source: 'game_page',
         platform: 'steam',
       });
@@ -383,7 +383,7 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         utm_source: 'google',
         utm_campaign: 'spring',
         touchpoint_type: 'click',
@@ -416,7 +416,7 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         utm_source: 'twitter',
         touchpoint_type: 'click',
         url: 'https://store.com',
@@ -449,7 +449,7 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         currency: 'USD',
         value: 9.99,
       });
@@ -468,7 +468,7 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         platform: 'webgl',
       });
 
@@ -487,7 +487,7 @@ describe('Audience', () => {
       expect(msg).toBeDefined();
       // First page merges session-cached attribution (includes landing_page)
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         landing_page: expect.any(String),
         section: 'shop',
       });
@@ -576,7 +576,7 @@ describe('Audience', () => {
       const msg = sentMessages().find((m: any) => m.type === 'page');
       expect(msg).toBeDefined();
       expect(msg.properties).toEqual({
-        sessionId: expect.any(String),
+        session_id: expect.any(String),
         landing_page: expect.any(String),
       });
 
@@ -778,7 +778,7 @@ describe('Audience', () => {
         (m: any) => m.type === 'track' && m.eventName === SESSION_START,
       );
       expect(sessionStart).toBeDefined();
-      expect(sessionStart.properties).toHaveProperty('sessionId');
+      expect(sessionStart.properties).toHaveProperty('session_id');
 
       const signUp = msgs.find(
         (m: any) => m.type === 'track' && m.eventName === 'sign_up',
@@ -899,7 +899,7 @@ describe('Audience', () => {
         (m: any) => m.type === 'track' && m.eventName === SESSION_END,
       );
       expect(msg).toBeDefined();
-      expect(msg.properties).toHaveProperty('sessionId');
+      expect(msg.properties).toHaveProperty('session_id');
       expect(msg.properties.duration).toBe(5);
     });
 

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -194,7 +194,7 @@ export class Audience {
       type: 'track',
       eventName: SESSION_START,
       properties: {
-        sessionId: this.sessionId,
+        session_id: this.sessionId,
         ...this.attribution,
       },
     });
@@ -207,7 +207,7 @@ export class Audience {
       type: 'track',
       eventName: SESSION_END,
       properties: {
-        sessionId: this.sessionId,
+        session_id: this.sessionId,
         ...(this.sessionStartTime && {
           duration: Math.round((Date.now() - this.sessionStartTime) / 1000),
         }),
@@ -228,7 +228,7 @@ export class Audience {
     getOrCreateSession(this.cookieDomain);
 
     const mergedProps: Record<string, unknown> = {
-      sessionId: this.sessionId,
+      session_id: this.sessionId,
       ...properties,
     };
     if (this.isFirstPage) {
@@ -268,7 +268,7 @@ export class Audience {
 
     const [properties] = args;
     const mergedProps: Record<string, unknown> = {
-      sessionId: this.sessionId,
+      session_id: this.sessionId,
       ...(UTM_EVENTS.has(event) ? collectPageAttribution() : {}),
       ...properties as Record<string, unknown> | undefined,
     };


### PR DESCRIPTION
Renames all multi-word Audience event property keys from camelCase to snake_case to align with industry standard (Segment, GA4). Event names were already snake_case; this makes properties consistent.

UTM params and click IDs (`utm_source`, `gclid`, etc.) are unchanged — they were already snake_case.

Fixes SDK-412.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking schema change: event payload property names emitted by both `@imtbl/audience` and `@imtbl/pixel` are renamed, which can break downstream analytics pipelines and integrator code expecting camelCase.
> 
> **Overview**
> Standardizes **all multi-word event property keys** from camelCase to snake_case across the web SDK and pixel (e.g. `session_id`, `game_id`, `item_id`, `duration_sec`, `email_hash`, `ga_client_id`).
> 
> Updates pixel autocapture payloads (forms/links/sessions/3rd-party IDs), SDK typed event interfaces and compile-time tests, and aligns sample-app/docs; bumps `@imtbl/pixel` to `0.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c9b7817b23d7fd45d52a5090e7e0bfdddcc6fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->