### PR TITLE
fix(checkout-widgets): Fix WalletConnect NETWORK_ERROR on chain switch

### DIFF
--- a/packages/checkout/widgets-lib/src/widgets/connect/components/WalletList.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/connect/components/WalletList.tsx
@@ -227,7 +227,9 @@ export function WalletList(props: WalletListProps) {
 
   const connectCallback = async (ethereumProvider: EthereumProvider) => {
     if (ethereumProvider.connected && ethereumProvider.session) {
-      const browserProvider = new WrappedBrowserProvider(ethereumProvider);
+      // Pass 'any' so ethers doesn't pin the provider to the initial WC chain.
+      // Without 'any', the subsequent getNetwork() throws NETWORK_ERROR ("network changed: ...").
+      const browserProvider = new WrappedBrowserProvider(ethereumProvider, 'any');
       selectBrowserProvider(browserProvider, 'walletconnect');
 
       const { chainId } = await ((await browserProvider.getSigner()).provider.getNetwork());


### PR DESCRIPTION
### Summary
Fix `WEB3_PROVIDER_ERROR: network changed` when connecting via WalletConnect to wallets that require a chain switch (e.g. Fireblocks vaults).

### Detail and impact of the change
The WC connect callback in `WalletList.tsx` constructed `WrappedBrowserProvider(ethereumProvider)` without the `'any'` network arg. Ethers pins the provider to the initial chain and throws `NETWORK_ERROR` on the next `getNetwork()` call once `switchEthereumChain` flips the underlying chain. Adding `'any'` lets the provider track the live chain- the documented idiom for changeable networks ([ethers v6 BrowserProvider docs](https://docs.ethers.org/v6/api/providers/#BrowserProvider)).

### Anything else worth calling out?
The pattern is already applied elsewhere in widgets-lib (`convertToNetworkChangeableProvider`, bridge's `WalletAndNetworkSelector`)
