### PR TITLE
chore(pixel): bump version to 0.4.0 (SDK-468)

### DIFF
--- a/packages/audience/pixel/package.json
+++ b/packages/audience/pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@imtbl/pixel",
   "description": "Immutable Tracking Pixel — drop-in JavaScript snippet for device fingerprint, page view, and attribution data",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Immutable",
   "private": true,
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",


### PR DESCRIPTION
SDK-468
https://linear.app/imtbl/issue/SDK-468/expand-pixel-autocapture-for-internal-links-and-buttons

## Summary

- Bumps `@imtbl/pixel` from `0.3.0` → `0.4.0` following the merge of #2879
- The prior PR added internal link tracking (`internalClicks`) and button click tracking (`buttons`) — new opt-in capabilities warrant a minor version bump per semver

## Test plan

- [x] Confirm `packages/audience/pixel/package.json` version is `0.4.0`
- [x] No functional changes — version number only

🤖 Generated with [Claude Code](https://claude.com/claude-code)