### PR TITLE
feat(audience-sdk): add getAnonymousId() and imtbl_aid URL param support

### DIFF
--- a/packages/audience/core/package.json
+++ b/packages/audience/core/package.json
@@ -19,17 +19,33 @@
     "typescript": "^5.6.2"
   },
   "exports": {
-    "development": {
-      "types": "./src/index.ts",
-      "browser": "./dist/browser/index.js",
-      "require": "./dist/node/index.cjs",
-      "default": "./dist/node/index.js"
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "browser": "./dist/browser/index.js",
+        "require": "./dist/node/index.cjs",
+        "default": "./dist/node/index.js"
+      },
+      "default": {
+        "types": "./dist/types/index.d.ts",
+        "browser": "./dist/browser/index.js",
+        "require": "./dist/node/index.cjs",
+        "default": "./dist/node/index.js"
+      }
     },
-    "default": {
-      "types": "./dist/types/index.d.ts",
-      "browser": "./dist/browser/index.js",
-      "require": "./dist/node/index.cjs",
-      "default": "./dist/node/index.js"
+    "./internal": {
+      "development": {
+        "types": "./src/internal.ts",
+        "browser": "./dist/browser/internal.js",
+        "require": "./dist/node/internal.cjs",
+        "default": "./dist/node/internal.js"
+      },
+      "default": {
+        "types": "./dist/types/internal.d.ts",
+        "browser": "./dist/browser/internal.js",
+        "require": "./dist/node/internal.cjs",
+        "default": "./dist/node/internal.js"
+      }
     }
   },
   "files": ["dist"],
@@ -40,7 +56,7 @@
   "repository": "immutable/ts-immutable-sdk.git",
   "scripts": {
     "build": "pnpm transpile && pnpm typegen",
-    "transpile": "tsup src/index.ts --config ../../../tsup.config.js",
+    "transpile": "tsup src/index.ts src/internal.ts --config ../../../tsup.config.js",
     "typegen": "tsc --customConditions default --emitDeclarationOnly --outDir dist/types",
     "lint": "eslint ./src --ext .ts --max-warnings=0",
     "test": "jest --passWithNoTests",

--- a/packages/audience/core/src/cookie.ts
+++ b/packages/audience/core/src/cookie.ts
@@ -37,6 +37,10 @@ export function getAnonymousId(): string | undefined {
   return getCookie(COOKIE_NAME);
 }
 
+/**
+ * Writes an externally carried anonymous ID to the tracking cookie, replacing any existing value.
+ * Intended for use by the Audience SDK only — callers are responsible for enforcing consent before calling.
+ */
 export function adoptAnonymousId(id: string, domain?: string): void {
   setCookie(COOKIE_NAME, id, COOKIE_MAX_AGE_SECONDS, domain);
 }

--- a/packages/audience/core/src/cookie.ts
+++ b/packages/audience/core/src/cookie.ts
@@ -37,10 +37,7 @@ export function getAnonymousId(): string | undefined {
   return getCookie(COOKIE_NAME);
 }
 
-/**
- * Writes an externally carried anonymous ID to the tracking cookie, replacing any existing value.
- * Intended for use by the Audience SDK only — callers are responsible for enforcing consent before calling.
- */
+/** Writes an externally carried anonymous ID to the tracking cookie, replacing any existing value. */
 export function adoptAnonymousId(id: string, domain?: string): void {
   setCookie(COOKIE_NAME, id, COOKIE_MAX_AGE_SECONDS, domain);
 }

--- a/packages/audience/core/src/cookie.ts
+++ b/packages/audience/core/src/cookie.ts
@@ -36,3 +36,7 @@ export function getOrCreateAnonymousId(domain?: string): string {
 export function getAnonymousId(): string | undefined {
   return getCookie(COOKIE_NAME);
 }
+
+export function adoptAnonymousId(id: string, domain?: string): void {
+  setCookie(COOKIE_NAME, id, COOKIE_MAX_AGE_SECONDS, domain);
+}

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -17,6 +17,7 @@ export { IdentityType } from './types';
 
 export {
   getOrCreateAnonymousId,
+  adoptAnonymousId,
   getCookie,
   deleteCookie,
 } from './cookie';

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -17,7 +17,6 @@ export { IdentityType } from './types';
 
 export {
   getOrCreateAnonymousId,
-  adoptAnonymousId,
   getCookie,
   deleteCookie,
 } from './cookie';

--- a/packages/audience/core/src/internal.ts
+++ b/packages/audience/core/src/internal.ts
@@ -1,0 +1,1 @@
+export { adoptAnonymousId } from './cookie';

--- a/packages/audience/sdk/jest.config.ts
+++ b/packages/audience/sdk/jest.config.ts
@@ -9,6 +9,7 @@ const config: Config = {
   },
   moduleNameMapper: {
     '^@imtbl/audience-core$': '<rootDir>/../core/src/index.ts',
+    '^@imtbl/audience-core/internal$': '<rootDir>/../core/src/internal.ts',
     // The core source code imports other @imtbl packages (e.g. metrics).
     // This tells jest where to find them so we can run tests without
     // building the whole monorepo first.

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -127,7 +127,7 @@ describe('Audience', () => {
       Object.defineProperty(window, 'location', {
         value: {
           ...window.location,
-          search: '?imtbl_aid=incoming-anon-id&foo=bar',
+          search: '?imtbl_aid=a1b2c3d4-e5f6-7890-abcd-ef1234567890&foo=bar',
           pathname: '/games/devilfish',
           hash: '',
         },
@@ -136,7 +136,7 @@ describe('Audience', () => {
       });
 
       const sdk = createSDK({ consent: 'anonymous' });
-      expect(sdk.getAnonymousId()).toBe('incoming-anon-id');
+      expect(sdk.getAnonymousId()).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
       sdk.shutdown();
     });
 
@@ -144,7 +144,7 @@ describe('Audience', () => {
       Object.defineProperty(window, 'location', {
         value: {
           ...window.location,
-          search: '?imtbl_aid=incoming-anon-id',
+          search: '?imtbl_aid=a1b2c3d4-e5f6-7890-abcd-ef1234567890',
           pathname: '/games/devilfish',
           hash: '',
         },
@@ -156,8 +156,8 @@ describe('Audience', () => {
       sdk.page();
       await sdk.flush();
 
-      const msg = sentMessages().find((m: any) => m.type === 'page');
-      expect(msg?.anonymousId).toBe('incoming-anon-id');
+      const msg = sentMessages().find((m) => m.type === 'page');
+      expect(msg?.anonymousId).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
       sdk.shutdown();
     });
 
@@ -166,7 +166,7 @@ describe('Audience', () => {
       Object.defineProperty(window, 'location', {
         value: {
           ...window.location,
-          search: '?imtbl_aid=incoming-anon-id&foo=bar',
+          search: '?imtbl_aid=a1b2c3d4-e5f6-7890-abcd-ef1234567890&foo=bar',
           pathname: '/games/devilfish',
           hash: '',
         },
@@ -185,7 +185,7 @@ describe('Audience', () => {
       Object.defineProperty(window, 'location', {
         value: {
           ...window.location,
-          search: '?imtbl_aid=incoming-anon-id',
+          search: '?imtbl_aid=a1b2c3d4-e5f6-7890-abcd-ef1234567890',
           pathname: '/games/devilfish',
           hash: '',
         },
@@ -204,7 +204,7 @@ describe('Audience', () => {
       Object.defineProperty(window, 'location', {
         value: {
           ...window.location,
-          search: '?imtbl_aid=incoming-anon-id',
+          search: '?imtbl_aid=a1b2c3d4-e5f6-7890-abcd-ef1234567890',
           pathname: '/games/devilfish',
           hash: '',
         },
@@ -218,11 +218,35 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
+    it.each([
+      ['empty string', '?imtbl_aid='],
+      ['non-UUID string', '?imtbl_aid=not-a-uuid'],
+      ['excessively long string', `?imtbl_aid=${'a'.repeat(300)}`],
+    ])('strips but does not adopt invalid imtbl_aid: %s', (_, search) => {
+      const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search,
+          pathname: '/games/devilfish',
+          hash: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const sdk = createSDK({ consent: 'anonymous' });
+      expect(sdk.getAnonymousId()).not.toMatch(/^not-a-uuid$|^a{300}$/);
+      expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/games/devilfish');
+      replaceStateSpy.mockRestore();
+      sdk.shutdown();
+    });
+
     it('ignores imtbl_aid at none consent', () => {
       Object.defineProperty(window, 'location', {
         value: {
           ...window.location,
-          search: '?imtbl_aid=incoming-anon-id',
+          search: '?imtbl_aid=a1b2c3d4-e5f6-7890-abcd-ef1234567890',
           pathname: '/games/devilfish',
           hash: '',
         },
@@ -231,7 +255,7 @@ describe('Audience', () => {
       });
 
       const sdk = createSDK({ consent: 'none' });
-      expect(sdk.getAnonymousId()).not.toBe('incoming-anon-id');
+      expect(sdk.getAnonymousId()).not.toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
       sdk.shutdown();
     });
 
@@ -292,7 +316,7 @@ describe('Audience', () => {
       sdk.page();
       await sdk.flush();
 
-      const msg = sentMessages().find((m: any) => m.type === 'page');
+      const msg = sentMessages().find((m) => m.type === 'page');
       expect(msg?.anonymousId).toBe(aid);
       sdk.shutdown();
     });

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -161,7 +161,7 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('strips imtbl_aid from the URL after init', () => {
+    it('strips imtbl_aid from the URL after init, preserving other params', () => {
       const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
       Object.defineProperty(window, 'location', {
         value: {
@@ -176,6 +176,44 @@ describe('Audience', () => {
 
       const sdk = createSDK({ consent: 'anonymous' });
       expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/games/devilfish?foo=bar');
+      replaceStateSpy.mockRestore();
+      sdk.shutdown();
+    });
+
+    it('strips imtbl_aid with no trailing ? when it is the only param', () => {
+      const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search: '?imtbl_aid=incoming-anon-id',
+          pathname: '/games/devilfish',
+          hash: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const sdk = createSDK({ consent: 'anonymous' });
+      expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/games/devilfish');
+      replaceStateSpy.mockRestore();
+      sdk.shutdown();
+    });
+
+    it('strips imtbl_aid at none consent too', () => {
+      const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search: '?imtbl_aid=incoming-anon-id',
+          pathname: '/games/devilfish',
+          hash: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const sdk = createSDK({ consent: 'none' });
+      expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/games/devilfish');
       replaceStateSpy.mockRestore();
       sdk.shutdown();
     });

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -123,6 +123,80 @@ describe('Audience', () => {
       second.shutdown();
     });
 
+    it('adopts imtbl_aid from URL and uses it as the anonymous ID', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search: '?imtbl_aid=incoming-anon-id&foo=bar',
+          pathname: '/games/devilfish',
+          hash: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const sdk = createSDK({ consent: 'anonymous' });
+      expect(sdk.getAnonymousId()).toBe('incoming-anon-id');
+      sdk.shutdown();
+    });
+
+    it('adopted imtbl_aid is used in outgoing events', async () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search: '?imtbl_aid=incoming-anon-id',
+          pathname: '/games/devilfish',
+          hash: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const sdk = createSDK({ consent: 'anonymous' });
+      sdk.page();
+      await sdk.flush();
+
+      const msg = sentMessages().find((m: any) => m.type === 'page');
+      expect(msg?.anonymousId).toBe('incoming-anon-id');
+      sdk.shutdown();
+    });
+
+    it('strips imtbl_aid from the URL after init', () => {
+      const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search: '?imtbl_aid=incoming-anon-id&foo=bar',
+          pathname: '/games/devilfish',
+          hash: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const sdk = createSDK({ consent: 'anonymous' });
+      expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/games/devilfish?foo=bar');
+      replaceStateSpy.mockRestore();
+      sdk.shutdown();
+    });
+
+    it('ignores imtbl_aid at none consent', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search: '?imtbl_aid=incoming-anon-id',
+          pathname: '/games/devilfish',
+          hash: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const sdk = createSDK({ consent: 'none' });
+      expect(sdk.getAnonymousId()).not.toBe('incoming-anon-id');
+      sdk.shutdown();
+    });
+
     it('emits session_start on new session', async () => {
       const sdk = createSDK({ consent: 'full' });
       await sdk.flush();
@@ -161,6 +235,27 @@ describe('Audience', () => {
       expect(msg.properties).toHaveProperty('utm_source', 'youtube');
       expect(msg.properties).toHaveProperty('utm_campaign', 'launch');
 
+      sdk.shutdown();
+    });
+  });
+
+  describe('getAnonymousId', () => {
+    it('returns the anonymous ID after init', () => {
+      const sdk = createSDK({ consent: 'anonymous' });
+      expect(typeof sdk.getAnonymousId()).toBe('string');
+      expect(sdk.getAnonymousId().length).toBeGreaterThan(0);
+      sdk.shutdown();
+    });
+
+    it('returns the same ID used in outgoing events', async () => {
+      const sdk = createSDK({ consent: 'anonymous' });
+      const aid = sdk.getAnonymousId();
+
+      sdk.page();
+      await sdk.flush();
+
+      const msg = sentMessages().find((m: any) => m.type === 'page');
+      expect(msg?.anonymousId).toBe(aid);
       sdk.shutdown();
     });
   });

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -12,6 +12,7 @@ import {
   MessageQueue,
   httpSend,
   getOrCreateAnonymousId,
+  adoptAnonymousId,
   getCookie,
   deleteCookie,
   generateId,
@@ -26,6 +27,7 @@ import {
   createConsentManager,
   canTrack,
   canIdentify,
+  isBrowser,
   SESSION_START,
   SESSION_END,
 } from '@imtbl/audience-core';
@@ -74,6 +76,18 @@ export class Audience {
 
   private destroyed = false;
 
+  private static readAndStripAidParam(): string | null {
+    if (!isBrowser()) return null;
+    const params = new URLSearchParams(window.location.search);
+    const aid = params.get('imtbl_aid');
+    if (!aid) return null;
+    params.delete('imtbl_aid');
+    const search = params.toString();
+    const newUrl = `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`;
+    window.history.replaceState(null, '', newUrl);
+    return aid;
+  }
+
   private constructor(config: AudienceConfig) {
     const {
       cookieDomain,
@@ -88,7 +102,13 @@ export class Audience {
 
     let isNewSession = false;
     if (canTrack(consentLevel)) {
-      this.anonymousId = getOrCreateAnonymousId(cookieDomain);
+      const incomingAid = Audience.readAndStripAidParam();
+      if (incomingAid) {
+        adoptAnonymousId(incomingAid, cookieDomain);
+        this.anonymousId = incomingAid;
+      } else {
+        this.anonymousId = getOrCreateAnonymousId(cookieDomain);
+      }
       isNewSession = this.startSession();
     } else {
       this.anonymousId = getCookie(COOKIE_NAME) ?? generateId();
@@ -147,6 +167,11 @@ export class Audience {
   }
 
   // --- Helpers ---
+
+  /** Returns the anonymous ID for the current browser session. */
+  getAnonymousId(): string {
+    return this.anonymousId;
+  }
 
   /** True when the current consent level does not permit tracking. */
   private isTrackingDisabled(): boolean {

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -76,16 +76,19 @@ export class Audience {
 
   private destroyed = false;
 
+  private static readonly UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
   private static readAndStripAidParam(): string | null {
     if (!isBrowser()) return null;
     const params = new URLSearchParams(window.location.search);
     const aid = params.get('imtbl_aid');
-    if (!aid) return null;
-    params.delete('imtbl_aid');
-    const search = params.toString();
-    const newUrl = `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`;
-    window.history.replaceState(null, '', newUrl);
-    return aid;
+    if (aid !== null) {
+      params.delete('imtbl_aid');
+      const search = params.toString();
+      const newUrl = `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`;
+      window.history.replaceState(window.history.state, '', newUrl);
+    }
+    return aid && Audience.UUID_RE.test(aid) ? aid : null;
   }
 
   private constructor(config: AudienceConfig) {

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -12,7 +12,6 @@ import {
   MessageQueue,
   httpSend,
   getOrCreateAnonymousId,
-  adoptAnonymousId,
   getCookie,
   deleteCookie,
   generateId,
@@ -31,6 +30,7 @@ import {
   SESSION_START,
   SESSION_END,
 } from '@imtbl/audience-core';
+import { adoptAnonymousId } from '@imtbl/audience-core/internal';
 import { DebugLogger } from './debug';
 import type { AudienceEventName, PropsFor } from './events';
 import type { AudienceConfig } from './types';

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -100,9 +100,10 @@ export class Audience {
     this.testMode = config.testMode ?? false;
     this.debug = new DebugLogger(config.debug ?? false);
 
+    const incomingAid = Audience.readAndStripAidParam();
+
     let isNewSession = false;
     if (canTrack(consentLevel)) {
-      const incomingAid = Audience.readAndStripAidParam();
       if (incomingAid) {
         adoptAnonymousId(incomingAid, cookieDomain);
         this.anonymousId = incomingAid;


### PR DESCRIPTION
## Summary

When a user clicks a social login option inside an in-app browser (e.g. Facebook), they get booted to the OS browser to complete OAuth — and the Audience SDK mints a fresh anonymous ID in that new context, orphaning all pre-login attribution from the in-app session. This PR fixes that by giving callers the tools to carry the anonymous ID across the browser switch.

- **`getAnonymousId()`** — exposes the current anonymous ID as a public method so integrators can append it to OAuth redirect URLs as `?imtbl_aid=<id>`
- **`?imtbl_aid=` on init** — the SDK reads this param on startup, adopts it as the canonical anonymous ID (writing it to the cookie), and strips it from the URL via `history.replaceState`

Mirrors the same pattern Segment uses (`?ajs_aid=`) and what the `play` repo already implements for Segment. No changes needed to the Pixel — it shares the same cookie and inherits the corrected ID automatically.

Closes [SDK-478](https://linear.app/imtbl/issue/SDK-478)

## Test plan

- [ ] New SDK unit tests cover: `imtbl_aid` adoption, URL stripping, `getAnonymousId()` return value matching outgoing event `anonymousId`, and that `imtbl_aid` is ignored at `none` consent
- [ ] All existing SDK tests pass (59 total)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)