### PR TITLE
fix(ops): ci publish using ref and nx release github authentication

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
           token: ${{ github.token }}
           persist-credentials: true # required: git tag push after version bump
 
@@ -114,6 +115,7 @@ jobs:
         if: ${{ !startsWith(env.RELEASE_TYPE, 'pre') }}
         env:
           SDK_VERSION: ${{ steps.sdk_version.outputs.SDK_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           args=("$SDK_VERSION")


### PR DESCRIPTION
# Summary
checkout branch tip instead of triggering SHA, nx github release authentication

The publish workflow checks out the exact commit SHA that triggered it. When a run waits at the npm-publish approval gate for an extended period, new commits can land on main. On approval the run attempts to push a version bump and changelog on top of a stale base, resulting in a non-fast-forward rejection.

Changing the checkout ref from the default (triggering SHA) to `github.ref` (branch tip at execution time) means every run, regardless of when it was triggered or approved, always publishes from the current state of main.

Impact on queued runs: with `cancel-in-progress: false`, the concurrency group allows one active run and one queued. If multiple runs accumulate while approvals are slow, each will publish from the same current main state, incrementing the prerelease counter. These extra alpha versions are harmless. A queued run can be manually cancelled to avoid the redundant bump.
