### PR TITLE
fix(ops): explicitly set latest tag for non alpha releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -132,7 +132,7 @@ jobs:
         run: |
           args=()
           [[ "$DRY_RUN" == "true" ]] && args+=(--dry-run)
-          [[ "$IS_ALPHA" == "true" ]] && args+=(--tag alpha)
+          [[ "$IS_ALPHA" == "true" ]] && args+=(--tag alpha) || args+=(--tag latest)
           pnpm nx release publish "${args[@]}"
 
       - name: Tag Git Pre-Release


### PR DESCRIPTION
# Summary
by default, pnpm nx release publish  uses npm config get tag  to resolve the tag, which should resolve to latest  but some incorrect config values in .npmrc  are causing warning messages to be outputted, stopping tag resolution. Explicitly set tag as latest when IS_ALPHA is false

# Anything else worth calling out?
If `IS_ALPHA` is empty then it will also publish latest tag