### PR TITLE
feat(audience): add achievement_unlocked standard event

### DIFF
--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -13,6 +13,7 @@ export const AudienceEvents = {
   GAME_PAGE_VIEWED: 'game_page_viewed',
   LINK_CLICKED: 'link_clicked',
   BUTTON_CLICKED: 'button_clicked',
+  ACHIEVEMENT_UNLOCKED: 'achievement_unlocked',
 } as const;
 
 export interface SignUpProperties {
@@ -92,6 +93,14 @@ export interface ButtonClickedProperties {
   element_type?: string;
 }
 
+export type AchievementType = 'onboarding' | 'progression' | 'mastery' | 'social' | 'collection';
+
+export interface AchievementUnlockedProperties {
+  achievement_id: string;
+  achievement_name: string;
+  achievement_type?: AchievementType;
+}
+
 interface EventPropsMap {
   sign_up: SignUpProperties;
   sign_in: SignInProperties;
@@ -105,6 +114,7 @@ interface EventPropsMap {
   game_page_viewed: GamePageViewedProperties;
   link_clicked: LinkClickedProperties;
   button_clicked: ButtonClickedProperties;
+  achievement_unlocked: AchievementUnlockedProperties;
 }
 
 export type AudienceEventName = keyof EventPropsMap;

--- a/packages/audience/sdk/src/index.ts
+++ b/packages/audience/sdk/src/index.ts
@@ -10,6 +10,8 @@ export type { ImmutableAudienceGlobal } from './cdn';
 export type { AudienceConfig } from './types';
 export type { AudienceErrorCode } from '@imtbl/audience-core';
 export type {
+  AchievementType,
+  AchievementUnlockedProperties,
   AudienceEventName,
   EmailAcquiredProperties,
   GameLaunchProperties,

--- a/packages/audience/sdk/src/sdk.test-d.ts
+++ b/packages/audience/sdk/src/sdk.test-d.ts
@@ -53,6 +53,13 @@ sdk.track('link_clicked', {
 sdk.track(AudienceEvents.SIGN_UP, { method: 'email' });
 sdk.track(AudienceEvents.PURCHASE, { currency: 'USD', value: 9.99 });
 sdk.track(AudienceEvents.PROGRESSION, { status: 'complete' });
+sdk.track(AudienceEvents.ACHIEVEMENT_UNLOCKED, { achievement_id: 'first_win', achievement_name: 'First Win' });
+sdk.track('achievement_unlocked', { achievement_id: 'first_win', achievement_name: 'First Win' });
+sdk.track('achievement_unlocked', {
+  achievement_id: 'first_win',
+  achievement_name: 'First Win',
+  achievement_type: 'progression',
+});
 
 // @ts-expect-error — missing required 'value'
 sdk.track('purchase', { currency: 'USD' });
@@ -110,6 +117,18 @@ sdk.track('progression', { status: 'done' });
 
 // @ts-expect-error — 'flow' must be a ResourceFlow
 sdk.track('resource', { flow: 'both', currency: 'gold', amount: 1 });
+
+// @ts-expect-error — missing required 'achievement_id'
+sdk.track('achievement_unlocked', { achievement_name: 'First Win' });
+
+// @ts-expect-error — missing required 'achievement_name'
+sdk.track('achievement_unlocked', { achievement_id: 'first_win' });
+
+// @ts-expect-error — achievement_unlocked requires properties
+sdk.track('achievement_unlocked');
+
+// @ts-expect-error — 'achievement_type' must be a valid AchievementType
+sdk.track('achievement_unlocked', { achievement_id: 'x', achievement_name: 'X', achievement_type: 'invalid' });
 
 sdk.track('beta_key_redeemed', { source: 'influencer' });
 sdk.track('discord_joined');

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -465,6 +465,52 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
+    it('enqueues achievement_unlocked with required fields', async () => {
+      const sdk = createSDK();
+
+      sdk.track('achievement_unlocked', {
+        achievement_id: 'first_win',
+        achievement_name: 'First Win',
+      });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'achievement_unlocked',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.properties).toEqual({
+        session_id: expect.any(String),
+        achievement_id: 'first_win',
+        achievement_name: 'First Win',
+      });
+
+      sdk.shutdown();
+    });
+
+    it('enqueues achievement_unlocked with optional achievement_type', async () => {
+      const sdk = createSDK();
+
+      sdk.track('achievement_unlocked', {
+        achievement_id: 'tutorial_done',
+        achievement_name: 'Tutorial Complete',
+        achievement_type: 'onboarding',
+      });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'achievement_unlocked',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.properties).toEqual({
+        session_id: expect.any(String),
+        achievement_id: 'tutorial_done',
+        achievement_name: 'Tutorial Complete',
+        achievement_type: 'onboarding',
+      });
+
+      sdk.shutdown();
+    });
+
     it('enqueues resource with flow, currency, and amount', async () => {
       const sdk = createSDK();
 


### PR DESCRIPTION
Adds `achievement_unlocked` to the web audience SDK as a standard semantic event per the CDP contract. The event takes required `achievement_id` and `achievement_name`, with an optional `achievement_type` (onboarding, progression, mastery, social) for categorisation.

Closes https://linear.app/imtbl/issue/SDK-551/add-achievement-unlocked-standard-event-to-web-audience-sdk

## Test plan
- [x] `pnpm typecheck` passes (type tests in `sdk.test-d.ts` cover required field enforcement and invalid `achievement_type` rejection)
- [x] `pnpm test` passes (73 tests)
- [x] `pnpm lint` passes
- [ ] Update `docs/products/audience/data-dictionary.mdx` in the documentation repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)