### PR TITLE
feat(audience): add deleteData to web SDK

### DIFF
--- a/packages/audience/core/src/config.ts
+++ b/packages/audience/core/src/config.ts
@@ -2,6 +2,7 @@ export const BASE_URL = 'https://api.immutable.com';
 
 export const INGEST_PATH = '/v1/audience/messages';
 export const CONSENT_PATH = '/v1/audience/tracking-consent';
+export const DATA_PATH = '/v1/audience/data';
 
 export const FLUSH_INTERVAL_MS = 5_000;
 export const FLUSH_SIZE = 20;

--- a/packages/audience/core/src/errors.ts
+++ b/packages/audience/core/src/errors.ts
@@ -76,13 +76,16 @@ export interface TransportResult {
  * - `'RATE_LIMITED'`:server returned 429. The batch is retained and will
  *                       be retried after the backoff window (honoring
  *                       `Retry-After` when present).
+ * - `'DATA_DELETE_FAILED'`:DELETE to `/v1/audience/data` returned non-2xx
+ *                       or the fetch itself rejected.
  */
 export type AudienceErrorCode =
   | 'FLUSH_FAILED'
   | 'CONSENT_SYNC_FAILED'
   | 'NETWORK_ERROR'
   | 'VALIDATION_REJECTED'
-  | 'RATE_LIMITED';
+  | 'RATE_LIMITED'
+  | 'DATA_DELETE_FAILED';
 
 /**
  * Public error type passed to the SDK's `onError` callback. Wraps the

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -22,10 +22,12 @@ export {
 } from './cookie';
 
 export {
+  BASE_URL,
   COOKIE_NAME,
   SESSION_COOKIE,
   SESSION_START,
   SESSION_END,
+  DATA_PATH,
 } from './config';
 
 export { generateId, getTimestamp, isBrowser } from './utils';

--- a/packages/audience/core/src/transport.ts
+++ b/packages/audience/core/src/transport.ts
@@ -22,7 +22,7 @@ export interface TransportOptions {
 export type HttpSend = (
   url: string,
   publishableKey: string,
-  payload: BatchPayload | ConsentUpdatePayload,
+  payload?: BatchPayload | ConsentUpdatePayload,
   options?: TransportOptions,
 ) => Promise<TransportResult>;
 
@@ -75,13 +75,14 @@ export const httpSend: HttpSend = async (
   const startTime = Date.now();
 
   try {
+    const hasBody = payload !== undefined;
     const response = await fetch(url, {
       method: options?.method ?? 'POST',
       headers: {
-        'Content-Type': 'application/json',
+        ...(hasBody && { 'Content-Type': 'application/json' }),
         'x-immutable-publishable-key': publishableKey,
       },
-      body: JSON.stringify(payload),
+      ...(hasBody && { body: JSON.stringify(payload) }),
       keepalive: options?.keepalive,
       signal: controller.signal,
     });

--- a/packages/audience/sdk-sample-app/index.html
+++ b/packages/audience/sdk-sample-app/index.html
@@ -249,6 +249,25 @@
             </div>
           </div>
         </details>
+
+        <details class="accordion-item">
+          <summary class="accordion-header">
+            <span class="accordion-title">Delete data</span>
+          </summary>
+          <div class="accordion-content">
+            <p class="helper-text">Request erasure of all event data for an identity. Leave User ID blank to erase by anonymous ID.</p>
+            <div class="field">
+              <label for="delete-data-user-id">User ID (optional)</label>
+              <input id="delete-data-user-id" type="text" placeholder="Leave blank to use anonymous ID">
+            </div>
+            <div class="actions">
+              <button id="btn-delete-data" disabled>
+                Delete data
+                <small class="btn-sig">deleteData(userId?)</small>
+              </button>
+            </div>
+          </div>
+        </details>
       </section>
     </div>
 

--- a/packages/audience/sdk-sample-app/sample-app.js
+++ b/packages/audience/sdk-sample-app/sample-app.js
@@ -349,6 +349,7 @@
     'btn-consent-none', 'btn-consent-anon', 'btn-consent-full',
     'btn-custom-event',
     'btn-identify',
+    'btn-delete-data',
   ];
 
   function setInitState(on) {
@@ -563,6 +564,7 @@
     $('btn-consent-full').addEventListener('click', function () { onSetConsent('full'); });
     $('btn-identify').addEventListener('click', onIdentify);
     $('btn-alias').addEventListener('click', onAlias);
+    $('btn-delete-data').addEventListener('click', onDeleteData);
     ['alias-from-id', 'alias-to-id', 'alias-from-type', 'alias-to-type'].forEach(function (id) {
       $(id).addEventListener('input', syncAliasButton);
     });
@@ -846,6 +848,17 @@
     } catch (err) {
       log('alias()', errMsg(err), 'err');
     }
+  }
+
+  function onDeleteData() {
+    if (!audience) return;
+    var userId = $('delete-data-user-id').value.trim() || undefined;
+    var label = 'deleteData(' + (userId ? JSON.stringify(userId) : '') + ')';
+    audience.deleteData(userId).then(function () {
+      log(label, userId ? { userId: userId } : { anonymousId: 'current' }, 'ok');
+    }).catch(function (err) {
+      log(label, errMsg(err), 'err');
+    });
   }
 
   function syncAliasButton() {

--- a/packages/audience/sdk/src/sdk.test-d.ts
+++ b/packages/audience/sdk/src/sdk.test-d.ts
@@ -137,3 +137,7 @@ sdk.track('trailer_watched', { duration: 45, platform: 'youtube' });
 declare const dynamicName: string;
 sdk.track(dynamicName, { anything: 'goes' });
 sdk.track(dynamicName);
+
+// deleteData type checks
+sdk.deleteData() satisfies Promise<void>;
+sdk.deleteData('user-123') satisfies Promise<void>;

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -6,6 +6,7 @@ import { LIBRARY_NAME } from './config';
 
 const INGEST_PATH = '/v1/audience/messages';
 const CONSENT_PATH = '/v1/audience/tracking-consent';
+const DATA_PATH = '/v1/audience/data';
 
 // --- Test fixtures ---
 const TEST_USER = { id: 'user@example.com', identityType: 'email' } as const;
@@ -1262,6 +1263,98 @@ describe('Audience', () => {
       expect(errors[0].code).toBe('CONSENT_SYNC_FAILED');
       expect(errors[0].status).toBe(503);
       expect(errors[0].endpoint).toContain(CONSENT_PATH);
+
+      sdk.shutdown();
+    });
+  });
+
+  describe('deleteData', () => {
+    it('sends DELETE to /v1/audience/data?userId=... when userId is supplied', async () => {
+      const sdk = createSDK({ consent: 'full' });
+      await sdk.deleteData('user-123');
+
+      const deleteCalls = fetchCalls.filter((c) => c.init.method === 'DELETE');
+      expect(deleteCalls).toHaveLength(1);
+      expect(deleteCalls[0].url).toContain(DATA_PATH);
+      expect(deleteCalls[0].url).toContain('userId=user-123');
+      expect(deleteCalls[0].init.headers).toMatchObject({
+        'x-immutable-publishable-key': 'pk_imapik-test-local',
+      });
+
+      sdk.shutdown();
+    });
+
+    it('sends DELETE to /v1/audience/data?anonymousId=... when no userId is supplied', async () => {
+      const sdk = createSDK({ consent: 'anonymous' });
+      const anon = sdk.getAnonymousId();
+
+      await sdk.deleteData();
+
+      const deleteCalls = fetchCalls.filter((c) => c.init.method === 'DELETE');
+      expect(deleteCalls).toHaveLength(1);
+      expect(deleteCalls[0].url).toContain(DATA_PATH);
+      expect(deleteCalls[0].url).toContain(`anonymousId=${encodeURIComponent(anon)}`);
+
+      sdk.shutdown();
+    });
+
+    it('is a no-op when no userId supplied and no anonymousId cookie exists', async () => {
+      // consent: none means no cookie is ever written
+      const sdk = createSDK({ consent: 'none' });
+      await sdk.deleteData();
+
+      const deleteCalls = fetchCalls.filter((c) => c.init.method === 'DELETE');
+      expect(deleteCalls).toHaveLength(0);
+
+      sdk.shutdown();
+    });
+
+    it('fires onError with DATA_DELETE_FAILED when the request returns non-2xx', async () => {
+      mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+        fetchCalls.push({ url, init: init ?? {} });
+        if (url.includes(DATA_PATH)) {
+          return { ok: false, status: 500, json: async () => ({}) };
+        }
+        return { ok: true, json: async () => ({}) };
+      });
+
+      const errors: any[] = [];
+      const sdk = createSDK({
+        consent: 'full',
+        onError: (err: any) => errors.push(err),
+      });
+
+      await sdk.deleteData('user-123');
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].name).toBe('AudienceError');
+      expect(errors[0].code).toBe('DATA_DELETE_FAILED');
+      expect(errors[0].status).toBe(500);
+      expect(errors[0].endpoint).toContain(DATA_PATH);
+
+      sdk.shutdown();
+    });
+
+    it('fires onError with DATA_DELETE_FAILED on network error', async () => {
+      mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+        fetchCalls.push({ url, init: init ?? {} });
+        if (url.includes(DATA_PATH)) throw new TypeError('Failed to fetch');
+        return { ok: true, json: async () => ({}) };
+      });
+
+      const errors: any[] = [];
+      const sdk = createSDK({
+        consent: 'full',
+        onError: (err: any) => errors.push(err),
+      });
+
+      await sdk.deleteData('user-123');
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].name).toBe('AudienceError');
+      expect(errors[0].code).toBe('DATA_DELETE_FAILED');
+      expect(errors[0].status).toBe(0);
+      expect(errors[0].cause).toBeInstanceOf(TypeError);
 
       sdk.shutdown();
     });

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -7,7 +7,10 @@ import type {
   UserTraits,
 } from '@imtbl/audience-core';
 import {
+  AudienceError,
+  BASE_URL,
   COOKIE_NAME,
+  DATA_PATH,
   SESSION_COOKIE,
   MessageQueue,
   httpSend,
@@ -62,6 +65,12 @@ export class Audience {
 
   private readonly cookieDomain?: string;
 
+  private readonly publishableKey: string;
+
+  private readonly baseUrl: string | undefined;
+
+  private readonly onError: AudienceConfig['onError'];
+
   private readonly testMode: boolean;
 
   private anonymousId: string;
@@ -100,6 +109,9 @@ export class Audience {
     const consentSource = DEFAULT_CONSENT_SOURCE;
 
     this.cookieDomain = cookieDomain;
+    this.publishableKey = publishableKey;
+    this.baseUrl = config.baseUrl;
+    this.onError = config.onError;
     this.testMode = config.testMode ?? false;
     this.debug = new DebugLogger(config.debug ?? false);
 
@@ -419,6 +431,48 @@ export class Audience {
       const isNewSession = this.startSession();
       this.queue.start();
       if (isNewSession) this.trackSessionStart();
+    }
+  }
+
+  // --- Data erasure ---
+
+  /**
+   * Ask the backend to erase a player's event data.
+   *
+   * - When `userId` is supplied: deletes records tied to that user ID.
+   * - When omitted: deletes records tied to this device's anonymous ID.
+   *   No-op on a fresh install where no anonymous ID has been created yet.
+   *
+   * Failures are surfaced via `config.onError` with code `'DATA_DELETE_FAILED'`.
+   * The returned promise always resolves (never rejects).
+   */
+  async deleteData(userId?: string): Promise<void> {
+    if (this.destroyed) return;
+
+    let query: string;
+    if (userId) {
+      query = `userId=${encodeURIComponent(userId)}`;
+    } else {
+      const anon = getCookie(COOKIE_NAME);
+      if (!anon) return;
+      query = `anonymousId=${encodeURIComponent(anon)}`;
+    }
+
+    const url = `${this.baseUrl ?? BASE_URL}${DATA_PATH}?${query}`;
+    const result = await httpSend(url, this.publishableKey, undefined, { method: 'DELETE' });
+    if (!result.ok && result.error && this.onError) {
+      const { error } = result;
+      try {
+        this.onError(new AudienceError({
+          code: 'DATA_DELETE_FAILED',
+          message: error.status
+            ? `Data delete failed with status ${error.status}`
+            : 'Data delete failed: network error',
+          status: error.status,
+          endpoint: url,
+          ...(error.cause !== undefined && { cause: error.cause }),
+        }));
+      } catch { /* swallow */ }
     }
   }
 


### PR DESCRIPTION
Studios shipping a \"delete my data\" flow previously had to hit `DELETE /v1/audience/data` directly — the web SDK had no method for it. This adds `sdk.deleteData(userId?)` to close that gap.

When `userId` is supplied the call targets that user's records; when omitted it uses the device's persistent anonymous ID. The call is skipped entirely on a fresh install where no anonymous ID has been created yet (nothing to erase). Failures route through the existing `onError` callback with the new `DATA_DELETE_FAILED` error code — useful so studios can filter or handle erasure failures distinctly in their error handler without matching on the endpoint URL.

Also makes `payload` optional in `HttpSend` / `httpSend` so bodyless requests go through the shared transport and get the same `transport_send_failed` metric coverage as flush and consent calls. Adds `DATA_PATH` and `BASE_URL` constants to `@imtbl/audience-core` exports.

## Test plan

- [x] `deleteData('user-123')` sends `DELETE /v1/audience/data?userId=user-123` with publishable key header
- [x] `deleteData()` sends `DELETE /v1/audience/data?anonymousId=<value>` using the persisted cookie
- [x] `deleteData()` is a no-op on a fresh install (no cookie, no request sent)
- [x] Non-2xx response fires `onError` with `AudienceError { code: 'DATA_DELETE_FAILED', status: 500 }`
- [x] Network error fires `onError` with `AudienceError { code: 'DATA_DELETE_FAILED', status: 0, cause: TypeError }`
- [x] Lint and typecheck pass; all 78 SDK tests + 170 core tests pass; CDN artifact tests pass