### PR TITLE
feat(audience-core): wire up GPC/DNT compliance in consent manager

### DIFF
--- a/packages/audience/core/src/consent.test.ts
+++ b/packages/audience/core/src/consent.test.ts
@@ -1,8 +1,13 @@
+import { track } from '@imtbl/metrics';
 import {
-  createConsentManager, canTrack, canIdentify,
+  createConsentManager, canTrack, canIdentify, detectDoNotTrack,
 } from './consent';
 import type { HttpSend } from './transport';
 import { TransportError } from './errors';
+
+jest.mock('@imtbl/metrics', () => ({
+  track: jest.fn(),
+}));
 
 function createMockSend() {
   return jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue({ ok: true });
@@ -42,6 +47,26 @@ describe('consent capability queries', () => {
     ['full', true],
   ] as const)('canIdentify(%s) returns %s', (level, expected) => {
     expect(canIdentify(level)).toBe(expected);
+  });
+});
+
+describe('detectDoNotTrack', () => {
+  it('returns false when neither DNT nor GPC is set', () => {
+    Object.defineProperty(navigator, 'doNotTrack', { value: '0', configurable: true });
+    Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
+    expect(detectDoNotTrack()).toBe(false);
+  });
+
+  it('returns true when doNotTrack is 1', () => {
+    Object.defineProperty(navigator, 'doNotTrack', { value: '1', configurable: true });
+    expect(detectDoNotTrack()).toBe(true);
+    Object.defineProperty(navigator, 'doNotTrack', { value: '0', configurable: true });
+  });
+
+  it('returns true when globalPrivacyControl is true', () => {
+    Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
+    expect(detectDoNotTrack()).toBe(true);
+    Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
   });
 });
 
@@ -128,15 +153,77 @@ describe('createConsentManager', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it('respects DNT by defaulting to none', () => {
+  it('forces none when DNT is set even if initialLevel is not none', () => {
     Object.defineProperty(navigator, 'doNotTrack', { value: '1', configurable: true });
-
     const queue = createMockQueue();
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel');
+    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
     expect(manager.level).toBe('none');
-
     Object.defineProperty(navigator, 'doNotTrack', { value: '0', configurable: true });
+  });
+
+  it('forces none when GPC is set even if initialLevel is not none', () => {
+    Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
+    const queue = createMockQueue();
+    const send = createMockSend();
+    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
+    expect(manager.level).toBe('none');
+    Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
+  });
+
+  it('tracks gpc_consent_override metric with signal and configured level when GPC fires', () => {
+    Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
+    const queue = createMockQueue();
+    const send = createMockSend();
+    createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
+    const expected = { signal: 'gpc', requestedLevel: 'full', context: 'init' };
+    expect(track).toHaveBeenCalledWith('audience', 'gpc_consent_overridden', expected);
+    Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
+  });
+
+  it('tracks gpc_consent_override metric with dnt signal when DNT fires', () => {
+    Object.defineProperty(navigator, 'doNotTrack', { value: '1', configurable: true });
+    const queue = createMockQueue();
+    const send = createMockSend();
+    createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
+    const expected = { signal: 'dnt', requestedLevel: 'anonymous', context: 'init' };
+    expect(track).toHaveBeenCalledWith('audience', 'gpc_consent_overridden', expected);
+    Object.defineProperty(navigator, 'doNotTrack', { value: '0', configurable: true });
+  });
+
+  describe('setLevel GPC enforcement', () => {
+    it('caps setLevel to none when GPC is active', () => {
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
+      const queue = createMockQueue();
+      const send = createMockSend();
+      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+      manager.setLevel('anonymous');
+      expect(manager.level).toBe('none');
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
+    });
+
+    it('tracks gpc_consent_overridden when setLevel is blocked by GPC', () => {
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
+      const queue = createMockQueue();
+      const send = createMockSend();
+      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+      (track as jest.Mock).mockClear();
+      manager.setLevel('full');
+      const expected = { signal: 'gpc', requestedLevel: 'full', context: 'runtime' };
+      expect(track).toHaveBeenCalledWith('audience', 'gpc_consent_overridden', expected);
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
+    });
+
+    it('does not track gpc_consent_overridden when setting none while GPC is active', () => {
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
+      const queue = createMockQueue();
+      const send = createMockSend();
+      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+      (track as jest.Mock).mockClear();
+      manager.setLevel('none');
+      expect(track).not.toHaveBeenCalled();
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
+    });
   });
 
   describe('onError callback', () => {

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -1,3 +1,4 @@
+import { track } from '@imtbl/metrics';
 import type {
   ConsentLevel, ConsentUpdatePayload, Message,
 } from './types';
@@ -19,20 +20,26 @@ export function canIdentify(level: ConsentLevel): boolean {
   return level === 'full';
 }
 
+/**
+ * Detect browser-level privacy opt-out signals.
+ *
+ * Returns `true` if the user has set GPC (Global Privacy Control) or DNT
+ * (Do Not Track). GPC is checked first as it carries legal weight under
+ * CCPA/CPRA in California.
+ */
 export function detectDoNotTrack(): boolean {
   if (typeof navigator === 'undefined') return false;
-  // DNT header
-  if (navigator.doNotTrack === '1') return true;
-  // Global Privacy Control
   if ((navigator as unknown as Record<string, unknown>).globalPrivacyControl === true) return true;
-  return false;
+  return navigator.doNotTrack === '1';
 }
 
 /**
  * Create a consent state machine.
  *
  * - Default level is `'none'` (no collection).
- * - If DNT or GPC is detected and no explicit consent is provided, stays `'none'`.
+ * - If GPC or DNT is detected, consent is forced to `'none'` regardless of
+ *   `initialLevel`. Studios using a CMP that has already obtained explicit
+ *   user consent can upgrade via `setLevel` after init.
  * - On downgrade (e.g. full -> anonymous), strips `userId` from queued messages.
  * - On downgrade to `'none'`, purges the queue entirely.
  * - Fires PUT to `/v1/audience/tracking-consent` on every state change via
@@ -53,8 +60,16 @@ export function createConsentManager(
   onError?: (err: AudienceError) => void,
   baseUrl?: string,
 ): ConsentManager {
-  const dntDetected = detectDoNotTrack();
-  let current: ConsentLevel = initialLevel ?? (dntDetected ? 'none' : 'none');
+  const gpcActive = detectDoNotTrack();
+  if (gpcActive) {
+    const nav = navigator as unknown as Record<string, unknown>;
+    track('audience', 'gpc_consent_overridden', {
+      signal: nav.globalPrivacyControl === true ? 'gpc' : 'dnt',
+      requestedLevel: initialLevel ?? 'none',
+      context: 'init',
+    });
+  }
+  let current: ConsentLevel = gpcActive ? 'none' : (initialLevel ?? 'none');
 
   const LEVELS: Record<ConsentLevel, number> = { none: 0, anonymous: 1, full: 2 };
 
@@ -76,16 +91,26 @@ export function createConsentManager(
     },
 
     setLevel(next: ConsentLevel): void {
-      if (next === current) return;
+      const gpcBlocked = detectDoNotTrack();
+      const effective = gpcBlocked ? 'none' : next;
 
-      const isDowngrade = LEVELS[next] < LEVELS[current];
+      if (gpcBlocked && effective !== next) {
+        const nav = navigator as unknown as Record<string, unknown>;
+        track('audience', 'gpc_consent_overridden', {
+          signal: nav.globalPrivacyControl === true ? 'gpc' : 'dnt',
+          requestedLevel: next,
+          context: 'runtime',
+        });
+      }
+
+      if (effective === current) return;
+
+      const isDowngrade = LEVELS[effective] < LEVELS[current];
 
       if (isDowngrade) {
-        if (next === 'none') {
-          // Purge all queued messages
+        if (effective === 'none') {
           queue.purge(() => true);
-        } else if (next === 'anonymous') {
-          // Remove identify/alias messages and strip userId from the rest
+        } else if (effective === 'anonymous') {
           queue.purge((msg: Message) => msg.type === 'identify' || msg.type === 'alias');
           queue.transform((msg: Message) => {
             if ('userId' in msg) {
@@ -97,8 +122,8 @@ export function createConsentManager(
         }
       }
 
-      current = next;
-      notifyBackend(next);
+      current = effective;
+      notifyBackend(effective);
     },
   };
 

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -71,6 +71,7 @@ jest.mock('@imtbl/audience-core', () => ({
     },
   ),
   canTrack: jest.fn().mockImplementation((level: string) => level !== 'none'),
+  detectDoNotTrack: jest.fn().mockReturnValue(false),
 }));
 
 // Mock fetch globally
@@ -487,6 +488,54 @@ describe('Pixel', () => {
       pixel.setConsent('full');
       const calls = mockEnqueue.mock.calls.map((c: unknown[]) => (c[0] as Record<string, unknown>));
       expect(calls.find((c) => c.type === 'page')).toBeUndefined();
+    });
+  });
+
+  describe('GPC/DNT debug warning', () => {
+    const mockDetectDoNotTrack = jest.requireMock('@imtbl/audience-core').detectDoNotTrack as jest.Mock;
+
+    beforeEach(() => {
+      mockDetectDoNotTrack.mockReturnValue(false);
+    });
+
+    it('logs a console warning when debug is true and GPC overrides a non-none consent level', () => {
+      mockDetectDoNotTrack.mockReturnValue(true);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous', debug: true });
+      expect(warnSpy).toHaveBeenCalledWith('[imtbl/pixel] GPC or DNT detected — consent overridden to none.');
+      warnSpy.mockRestore();
+    });
+
+    it('does not log when debug is false', () => {
+      mockDetectDoNotTrack.mockReturnValue(true);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('does not log when consent is already none', () => {
+      mockDetectDoNotTrack.mockReturnValue(true);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consent: 'none', debug: true });
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('does not log when consentMode is auto', () => {
+      mockDetectDoNotTrack.mockReturnValue(true);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consentMode: 'auto', debug: true });
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -18,6 +18,7 @@ import {
   getOrCreateSession,
   createConsentManager,
   canTrack,
+  detectDoNotTrack,
   startCmpDetection,
 } from '@imtbl/audience-core';
 import { setupAutocapture } from './autocapture';
@@ -40,6 +41,8 @@ export interface PixelInitOptions {
   baseUrl?: string;
   /** When true, all events are marked test: true and can be filtered from production analytics. */
   testMode?: boolean;
+  /** When true, logs warnings to the console (e.g. GPC/DNT overrides). */
+  debug?: boolean;
 }
 
 export class Pixel {
@@ -97,6 +100,13 @@ export class Pixel {
     // Resolve initial consent level.
     // 'auto' starts at 'none' until a CMP is detected.
     const isAutoConsent = consentMode === 'auto';
+
+    if (!isAutoConsent && consentLevel != null && consentLevel !== 'none' && detectDoNotTrack()) {
+      if (options.debug) {
+        // eslint-disable-next-line no-console
+        console.warn('[imtbl/pixel] GPC or DNT detected — consent overridden to none.');
+      }
+    }
 
     this.consent = createConsentManager(
       this.queue,

--- a/packages/audience/sdk/package.json
+++ b/packages/audience/sdk/package.json
@@ -5,7 +5,8 @@
   "author": "Immutable",
   "bugs": "https://github.com/immutable/ts-immutable-sdk/issues",
   "dependencies": {
-    "@imtbl/audience-core": "workspace:*"
+    "@imtbl/audience-core": "workspace:*",
+    "@imtbl/metrics": "workspace:*"
   },
   "devDependencies": {
     "@swc/core": "^1.4.2",

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -1,8 +1,14 @@
 import {
   COOKIE_NAME, SESSION_COOKIE, SESSION_START, SESSION_END,
 } from '@imtbl/audience-core';
+import { track } from '@imtbl/metrics';
 import { Audience } from './sdk';
 import { LIBRARY_NAME } from './config';
+
+jest.mock('@imtbl/metrics', () => ({
+  track: jest.fn(),
+  trackError: jest.fn(),
+}));
 
 const INGEST_PATH = '/v1/audience/messages';
 const CONSENT_PATH = '/v1/audience/tracking-consent';
@@ -1356,6 +1362,51 @@ describe('Audience', () => {
       expect(errors[0].status).toBe(0);
       expect(errors[0].cause).toBeInstanceOf(TypeError);
 
+      sdk.shutdown();
+    });
+  });
+
+  describe('GPC/DNT enforcement', () => {
+    afterEach(() => {
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
+      Object.defineProperty(navigator, 'doNotTrack', { value: '0', configurable: true });
+    });
+
+    it('blocks setConsent upgrade and tracks gpc_consent_overridden when GPC is active', () => {
+      const sdk = createSDK({ consent: 'none' });
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
+
+      sdk.setConsent('anonymous');
+
+      expect(sdk.getAnonymousId()).toBeDefined();
+      // Consent stays at none — no events should be sent
+      sdk.page();
+      expect(sentMessages()).toHaveLength(0);
+      const expected = { signal: 'gpc', requestedLevel: 'anonymous', context: 'runtime' };
+      expect(track).toHaveBeenCalledWith('audience', 'gpc_consent_overridden', expected);
+
+      sdk.shutdown();
+    });
+
+    it('logs a console warning via debug when GPC blocks setConsent', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const sdk = createSDK({ consent: 'none', debug: true });
+      Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
+
+      sdk.setConsent('full');
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('GPC or DNT detected'));
+      warnSpy.mockRestore();
+      sdk.shutdown();
+    });
+
+    it('does not block setConsent when GPC is not active', async () => {
+      const sdk = createSDK({ consent: 'none' });
+      sdk.setConsent('anonymous');
+      sdk.track('sign_up', { method: 'email' });
+      await sdk.flush();
+      const msg = sentMessages().find((m: any) => m.eventName === 'sign_up');
+      expect(msg).toBeDefined();
       sdk.shutdown();
     });
   });

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -29,11 +29,13 @@ import {
   createConsentManager,
   canTrack,
   canIdentify,
+  detectDoNotTrack,
   isBrowser,
   SESSION_START,
   SESSION_END,
 } from '@imtbl/audience-core';
 import { adoptAnonymousId } from '@imtbl/audience-core/internal';
+import { track } from '@imtbl/metrics';
 import { DebugLogger } from './debug';
 import type { AudienceEventName, PropsFor } from './events';
 import type { AudienceConfig } from './types';
@@ -114,6 +116,10 @@ export class Audience {
     this.onError = config.onError;
     this.testMode = config.testMode ?? false;
     this.debug = new DebugLogger(config.debug ?? false);
+
+    if (detectDoNotTrack() && consentLevel !== 'none') {
+      this.debug.logWarning('GPC or DNT detected — consent overridden to none.');
+    }
 
     const incomingAid = Audience.readAndStripAidParam();
 
@@ -395,34 +401,40 @@ export class Audience {
    * - 'full': track everything including player identity.
    */
   setConsent(level: ConsentLevel): void {
+    const gpcActive = detectDoNotTrack();
+    const effective: ConsentLevel = gpcActive ? 'none' : level;
+
+    if (gpcActive && effective !== level) {
+      const nav = navigator as unknown as Record<string, unknown>;
+      track('audience', 'gpc_consent_overridden', {
+        signal: nav.globalPrivacyControl === true ? 'gpc' : 'dnt',
+        requestedLevel: level,
+        context: 'runtime',
+      });
+      this.debug.logWarning('GPC or DNT detected — consent upgrade blocked.');
+    }
+
     const previous = this.consent.level;
-    if (level === previous) return;
+    if (effective === previous) return;
 
-    this.debug.logConsent(previous, level);
+    this.debug.logConsent(previous, effective);
 
-    const isUpgradeFromNone = !canTrack(previous) && canTrack(level);
+    const isUpgradeFromNone = !canTrack(previous) && canTrack(effective);
 
-    // When upgrading from none, create the persisted anonymousId first
-    // so the consent sync sends the correct ID to the server.
     if (isUpgradeFromNone) {
       this.anonymousId = getOrCreateAnonymousId(this.cookieDomain);
     }
 
-    // Web-specific cleanup before core handles queue purge/transform and server sync.
-    // session_end is intentionally not emitted — no events should be sent after opt-out.
-    if (!canTrack(level)) {
+    if (!canTrack(effective)) {
       this.queue.stop();
     }
 
-    // Core handles: queue purge on →none, identify/alias purge + userId strip
-    // on →anonymous, server sync.
-    this.consent.setLevel(level);
+    this.consent.setLevel(effective);
 
-    // Web-specific cleanup after core's transition.
-    if (!canTrack(level)) {
+    if (!canTrack(effective)) {
       deleteCookie(COOKIE_NAME, this.cookieDomain);
       deleteCookie(SESSION_COOKIE, this.cookieDomain);
-    } else if (canIdentify(previous) && !canIdentify(level)) {
+    } else if (canIdentify(previous) && !canIdentify(effective)) {
       this.userId = undefined;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 17.1.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-react-refresh:
         specifier: latest
-        version: 0.5.2(eslint@8.57.0)
+        version: 0.5.3(eslint@8.57.0)
       events:
         specifier: ^3.3.0
         version: 3.3.0
@@ -120,13 +120,13 @@ importers:
         version: 29.7.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.14.13)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.23.1)(jest@29.7.0(@types/node@20.14.13)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2)))(typescript@5.6.2)
+        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2)))(typescript@5.6.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2)
+        version: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2)
       typescript:
         specifier: ^5
         version: 5.6.2
@@ -138,7 +138,7 @@ importers:
         version: 0.25.21(@emotion/react@11.11.3(@types/react@18.3.12)(react@18.3.1))(@rive-app/react-canvas-lite@4.9.0(react@18.3.1))(embla-carousel-react@8.1.5(react@18.3.1))(framer-motion@11.18.2(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@imtbl/sdk':
         specifier: latest
-        version: 2.14.3(bufferutil@4.0.8)(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)
+        version: 2.20.1(bufferutil@4.0.8)(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)
       next:
         specifier: 14.2.25
         version: 14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -347,7 +347,7 @@ importers:
     dependencies:
       '@imtbl/contracts':
         specifier: latest
-        version: 2.2.18(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
+        version: 3.1.1(@openzeppelin/contracts@5.0.2)
       '@imtbl/sdk':
         specifier: workspace:*
         version: link:../../sdk
@@ -940,7 +940,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -971,7 +971,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -987,6 +987,9 @@ importers:
       '@imtbl/audience-core':
         specifier: workspace:*
         version: link:../core
+      '@imtbl/metrics':
+        specifier: workspace:*
+        version: link:../../internal/metrics
     devDependencies:
       '@swc/core':
         specifier: ^1.4.2
@@ -1011,7 +1014,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -1023,7 +1026,7 @@ importers:
         version: 6.4.1(rollup@4.28.0)(typescript@5.6.2)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2))(typescript@5.6.2)
+        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2)))(typescript@5.6.2)
       tsup:
         specifier: ^8.3.0
         version: 8.3.0(@swc/core@1.15.3(@swc/helpers@0.5.15))(jiti@1.21.0)(postcss@8.4.49)(typescript@5.6.2)(yaml@2.5.0)
@@ -1118,13 +1121,13 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       next:
         specifier: ^15.2.6
         version: 15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^5.0.0-beta.30
-        version: 5.0.0-beta.30(next@15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 5.0.0-beta.30(next@15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1154,7 +1157,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       next:
         specifier: ^15.2.6
         version: 15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
@@ -1194,7 +1197,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -1273,7 +1276,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -1370,7 +1373,7 @@ importers:
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.23.1)(eslint@9.16.0(jiti@1.21.0))(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(type-fest@2.19.0)(typescript@5.6.2)(utf-8-validate@5.0.10)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.23.1)(eslint@9.16.0(jiti@1.21.0))(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(type-fest@2.19.0)(typescript@5.6.2)(utf-8-validate@5.0.10)
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1536,7 +1539,7 @@ importers:
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.23.1)(eslint@8.57.0)(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(type-fest@2.19.0)(typescript@5.6.2)(utf-8-validate@5.0.10)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.23.1)(eslint@8.57.0)(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(type-fest@2.19.0)(typescript@5.6.2)(utf-8-validate@5.0.10)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -1548,7 +1551,7 @@ importers:
         version: 0.13.0(rollup@4.28.0)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2)))(typescript@5.6.2)
+        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2)))(typescript@5.6.2)
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1973,7 +1976,7 @@ importers:
         version: 22.19.7
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -2010,13 +2013,13 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2))(typescript@5.6.2)
+        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2)))(typescript@5.6.2)
       tsup:
         specifier: ^8.3.0
         version: 8.3.0(@swc/core@1.15.3(@swc/helpers@0.5.15))(jiti@1.21.0)(postcss@8.4.49)(typescript@5.6.2)(yaml@2.5.0)
@@ -2148,7 +2151,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -2206,7 +2209,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -2489,7 +2492,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.4.3
         version: 29.6.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -4154,11 +4157,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  '@ethereumjs/rlp@5.0.2':
-    resolution: {integrity: sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   '@ethereumjs/tx@4.2.0':
     resolution: {integrity: sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==}
     engines: {node: '>=14'}
@@ -4166,14 +4164,6 @@ packages:
   '@ethereumjs/util@8.1.0':
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
     engines: {node: '>=14'}
-
-  '@ethereumjs/util@9.1.0':
-    resolution: {integrity: sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==}
-    engines: {node: '>=18'}
-
-  '@ethereumjs/wallet@2.0.4':
-    resolution: {integrity: sha512-XPX9sUhIXdPjA5FpOmPD0weCAz+9OvCA10OdntJGOXVHtQQZRbncPokxkotDFWopExU/Vj+qZZSHqu+jWK5nkw==}
-    engines: {node: '>=18'}
 
   '@ethersproject/abi@5.7.0':
     resolution: {integrity: sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==}
@@ -4441,8 +4431,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@imtbl/auth-next-client@2.14.3':
-    resolution: {integrity: sha512-QrAEQG7Nhw0BmzUydeXHydIzBiZvAoYJYcdwc7cX6HeTAwIqRejFWmsvkGZckmgReXCjblvhfQzeQi0WIr2phw==}
+  '@imtbl/auth-next-client@2.20.1':
+    resolution: {integrity: sha512-spoCdsUVGhwkNFXp1RoSPoHVHJgxR1tSh4nSdkCYd4m/b8q6n2PqtfP+wPjsGlBTDVgUu/JJd7/0XncydizS4w==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0
       next-auth: ^5.0.0-beta.25
@@ -4455,8 +4445,8 @@ packages:
       react:
         optional: true
 
-  '@imtbl/auth-next-server@2.14.3':
-    resolution: {integrity: sha512-xdBS+8oicbNx0dXjKbDyEiN0dKd4L/n2ToN7Yx2saoBNHu0QFitS6W0asw/5Q1e27G7MWhR1lflZPThdFhWyYw==}
+  '@imtbl/auth-next-server@2.20.1':
+    resolution: {integrity: sha512-gixsLtJLu51x3lC9mDdql+cyi7VpQPoVovBUj2rra9+iVrM1qNE1gfQuiO/yYiF51oDZv9q8O5m4uRkZsZNQcw==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0
       next-auth: ^5.0.0-beta.25
@@ -4466,59 +4456,62 @@ packages:
       next-auth:
         optional: true
 
-  '@imtbl/auth@2.14.3':
-    resolution: {integrity: sha512-0Pu0hym1NwHGReR8TiIrPRrIUmw2/7bm27MuwOGcBgMrQDbNvjbejxPF/O2zuEE0H7JNC87DFOFL+dmh5sfhyQ==}
+  '@imtbl/auth@2.20.1':
+    resolution: {integrity: sha512-7pxe15/AsoV24ot5K6oNETU1exUW4+4iU1oDKKVoDtu9OvXyFaK1xPmAWevaAj0Bm1QNTxY6iY6Ot14EmZrKAg==}
 
-  '@imtbl/blockchain-data@2.14.3':
-    resolution: {integrity: sha512-5a2GhR3pkXcxPgy7Tj7YpkKX/WoF3PkmTAZ8PCHJ6uzvhr/7gyv0FK5SerovgVoUdckWtMX2Bu0q9P4Do1jpPw==}
+  '@imtbl/blockchain-data@2.20.1':
+    resolution: {integrity: sha512-7k1PTXt8TPU6MEis8gvrKZod5eIgCzj7d/CwEwx05pDXFOtb+EMUQS3wwmA/Tcigt4o84jU4OLTKuP8/LfmUYQ==}
 
-  '@imtbl/bridge-sdk@2.14.3':
-    resolution: {integrity: sha512-kof0gLwK9UHG1kNYVCnx2m2rZoQfimFLvbSKa9yznK6hrydzSmMcps3JuYn00NJ9LyVVJnpqYtgjMytbiJWVyg==}
+  '@imtbl/bridge-sdk@2.20.1':
+    resolution: {integrity: sha512-4IX/UFIk4QKd8FntP3E1QSptkg796Vjw6eue+NqMJIt1sdkFhqep+NBmLST2vIPxPMR7//+IkZYvz8JpjYzaFA==}
     engines: {node: '>=20.11.0'}
 
-  '@imtbl/checkout-sdk@2.14.3':
-    resolution: {integrity: sha512-a2k/iZIndsgM7rSeUxjj2F+JQh+03wm4DTEV81bTDVtTdAGCdXz9mZvT2WSWjelM24a02Vfjrpc/0edZ4CGzHQ==}
+  '@imtbl/checkout-sdk@2.20.1':
+    resolution: {integrity: sha512-9B26rMEM44QfG7d6wjNq2jNFx+4+9YhR6KOv2G4WEdSb/oh9rvUIJGHtsdBSVszE7k9nDfvK6w16jb520YQBig==}
 
-  '@imtbl/config@2.14.3':
-    resolution: {integrity: sha512-8HMf9jlINIhDZCQYVdVI9B9Mt4hXz+MnsoZ6guCtLKxQli5Tqa5c/uvhgB+IKdxmdqnLndzezzHsR94KjV3CQg==}
+  '@imtbl/config@2.20.1':
+    resolution: {integrity: sha512-P7qRLFLG/WbFC2veFfYCGN0GtTQ/6J71UDwa0ST/QW00s2swyAUNS54ttHFQnepphimbOTilgUpc/O/VANnbAg==}
     engines: {node: '>=20.11.0'}
-
-  '@imtbl/contracts@2.2.18':
-    resolution: {integrity: sha512-wxjfE32t9jzEs4PswKwZDMlBO6wqCfSpVxseyFADFVG+Y2oFBrf1lK4eA0e81BbrXTGAbR+snSnSjPS305JoIQ==}
 
   '@imtbl/contracts@2.2.6':
     resolution: {integrity: sha512-2cfE3Tojfp4GnxwVKSwoZY1CWd+/drCIbCKawyH9Nh2zASXd7VC71lo27aD5RnCweXHkZVhPzjqwQf/xrtnmIQ==}
 
-  '@imtbl/dex-sdk@2.14.3':
-    resolution: {integrity: sha512-L9mrM8cMO2mvZV3gwltvNix2P3O3NszXvOdJgjJG/Dgkt01BzakDSnCnDrAvcAceWFXnhQHmJ8WRlgfqvBGe9w==}
+  '@imtbl/contracts@3.1.1':
+    resolution: {integrity: sha512-MCabKdiKLKWySLx1rvsHbaXJ2eK0knYTRbFUb5uthRrKsqLbdfXI7NNJcETVwkxQnju3B6npTN3sOxGYBH08ww==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@openzeppelin/contracts': ^4.9.3 || ^5.0.0
+
+  '@imtbl/dex-sdk@2.20.1':
+    resolution: {integrity: sha512-vfdcpSoSzujRAhfJzgdf0q9v3ewlANEFiWqsZvECVhpdoP2Roo5KhXL3A+cHtyIjQU62gqxKgN5knkdlcoASPQ==}
     engines: {node: '>=20.11.0'}
 
-  '@imtbl/generated-clients@2.14.3':
-    resolution: {integrity: sha512-ExTBNcPIV/mxEmpECaY94oES+bClmS73/0BSJ/lLlJU4oUKFESvY1+473lIomBtKXuASoHJtOO5Hl2Tq560qGA==}
+  '@imtbl/generated-clients@2.20.1':
+    resolution: {integrity: sha512-pqZHyjjJZwNkPYOtQynO3I/zgq4Ed71F0hnGaw2F+9VyvWFP7+rNU4rTMliS0dNaNhPMpIH9OFBbxyBa2BSYOw==}
     engines: {node: '>=20.11.0'}
 
   '@imtbl/image-resizer-utils@0.0.3':
     resolution: {integrity: sha512-/EOJKMJF4gD/Dv0qNhpUTpp2AgWeQ7XgYK9Xjl+xP2WWgaarNv1SHe1aeqSb8aZT5W7wSXdUGzn6TIxNsuCWGw==}
 
-  '@imtbl/metrics@2.14.3':
-    resolution: {integrity: sha512-AjiYEtdDzYqJ9Aba+XbCAw/qYTIOPzHC3Bhods+bcb97Iz4JHhUnHAKqaZSRChjpewd2Md6+gyCb/MZhVPQ8xQ==}
+  '@imtbl/metrics@2.20.1':
+    resolution: {integrity: sha512-kugCCz8e1oWTeE5T0yh2DmcgDGSUY4zO9TgbJsiRnbB8H86D7sPQEiMPpt+cmDUEEh4Xdlgz2oD9jxtLpPVYWQ==}
     engines: {node: '>=20.11.0'}
 
-  '@imtbl/minting-backend@2.14.3':
-    resolution: {integrity: sha512-OerMKE+jSCyg/X/obJeUlL2IcoVQv6C6F5CkleaNVjKzMavx4B8RIlu6xopcxDNDxfe6XrOUa7SmQH71kqsuWw==}
+  '@imtbl/minting-backend@2.20.1':
+    resolution: {integrity: sha512-H2qpQjg5BRq1UG025oP5do0aoM90Z4XWK49UrVSzIDO3pBGELMoWNtI61N2hFZAPSBYsiFX0r4AgNd5FeUlaZA==}
 
-  '@imtbl/orderbook@2.14.3':
-    resolution: {integrity: sha512-/sIogHCf8xzFubp3euRxBBI1F+i10TCBVWZHUDggpd7EoCfhdrRYWegbmmDEXx80RnXR0ZXIZiwP6EwXyVm2LQ==}
+  '@imtbl/orderbook@2.20.1':
+    resolution: {integrity: sha512-oflTDkOFXAGYZgFFsIWvVUJhxEYDSl8zLtVUp+q3c716PPIAT5Vi8PbkWTolIp2DvVzzjNL3EviYRVSKrRkkgQ==}
 
-  '@imtbl/passport@2.14.3':
-    resolution: {integrity: sha512-v86T14+HwuaNcli0TB7r4iDv2QIGBmif0T4vWkK1b+Mch9HN2/2C8T1/W4pG0rwMqMxybDKs45CzIedbfhGL1g==}
+  '@imtbl/passport@2.20.1':
+    resolution: {integrity: sha512-qqB9KooeqL69jGptTvtjRsiLJf1QielP7GXOs+vDL7fPAP3y8hyz1QNwYVnc0UFxLKNd3yy1OnJqkpgkL7Q77w==}
     engines: {node: '>=20.11.0'}
 
   '@imtbl/react-analytics@0.3.4-alpha':
     resolution: {integrity: sha512-4VWvfm8RZtpLub7+x2D2wNQ507nIVBCSAPA7B5lxdb0cKrHEujM6Y/HScMImHZHvgjUFQT1jiD9b2BL/DS43Pg==}
 
-  '@imtbl/sdk@2.14.3':
-    resolution: {integrity: sha512-ewZx3Fgm9ebVSfgTjkemnovTNjYAKPJHYMQCrI16rh3AQeGSo830/dd+g7gJ1Y7MJms2llmbXAh4F6Fv/9jxrQ==}
+  '@imtbl/sdk@2.20.1':
+    resolution: {integrity: sha512-5nQRlxh14lKb+LVOoiv2mDzaAcsofCKl3UaiS2UjS2p0Rek/C2daDPRiUjSCr8pNIhpFL71t8Q71kkIBQaVB4Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       next: ^14.2.0 || ^15.0.0
@@ -4532,23 +4525,15 @@ packages:
       react:
         optional: true
 
-  '@imtbl/toolkit@2.14.3':
-    resolution: {integrity: sha512-1jMRwjQkAHa5uoJHfhrrrgM3TghrzhjehuaGIH+ezi3ajjOP9JBljnM3ne5P3OJ5CeRU5UV0F8U11NCiTFKWzA==}
+  '@imtbl/toolkit@2.20.1':
+    resolution: {integrity: sha512-LtTy4CpX6hSSSDNOFWTG6Ny78VWx52HhKMTQRo19ETCFcW0lEH5UTEfAjjrXVGakQgbk8+fuapkFxFG+rMxJVg==}
     engines: {node: '>=20.11.0'}
 
-  '@imtbl/wallet@2.14.3':
-    resolution: {integrity: sha512-2nBz38j75hBNLCiGd1jbkz/18qFEB0weMTZi6aoB5haEe1GsuSuK3eF1wgjLSUDTeM3lcnLnV43IEma+IJfgiw==}
+  '@imtbl/wallet@2.20.1':
+    resolution: {integrity: sha512-Qh95lsj+xBvTQSXken4PQp05WECW+2E7OiqJalxZbIzGtewAIXb/tWCrcww8JUEclctD32tZueG5sTjM2uWL6Q==}
 
-  '@imtbl/webhook@2.14.3':
-    resolution: {integrity: sha512-gpdn5mQhrd49veiYmxSnu0Vr9f/rC4sXCpH67S/H3MCsLWmtI+rG08ku1Y+P3xpcOw389FZZgBF0iKPqjNH0nA==}
-
-  '@imtbl/x-client@2.14.3':
-    resolution: {integrity: sha512-5e09vlEcRQYlbMabf+3G30CzcZecqy+hdroBM76OJBWUzogBEmdiKrWFXpfedF4qgQD82z5Q3y2thDa45LT3lQ==}
-    engines: {node: '>=20.11.0'}
-
-  '@imtbl/x-provider@2.14.3':
-    resolution: {integrity: sha512-67plb5nlfUDEyBFRITDQvvC6EGLRwO9CbDtwDQbiHW9ar/mNXk7augmoo0dDlhR6tr61Y3wI1TaT6/94BXEAug==}
-    engines: {node: '>=20.11.0'}
+  '@imtbl/webhook@2.20.1':
+    resolution: {integrity: sha512-uGeyiSsZX+rLeSK3rk2lGE2CvJdw/1wKP0vsfGRd0KugFnxv8gBPGoY6+a+22vqO/7T4uaIMhNMMzUlVNVIblw==}
 
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
@@ -4798,12 +4783,6 @@ packages:
 
   '@lezer/lr@1.4.5':
     resolution: {integrity: sha512-/YTRKP5yPPSo1xImYQk7AZZMAgap0kegzqCSYHjAL9x1AZ0ZQW+IpcEzMKagCsbTsLnVeWkxYrCNeXG8xEPrjg==}
-
-  '@limitbreak/creator-token-standards@5.0.0':
-    resolution: {integrity: sha512-BhrD3SMCq8YrGbJildBbu4BpHia7uby60XpGYVyFnb4xEvFey7bRbnOeVQ2mrTx07y02KvTWS5gESIPj5O4Mtg==}
-
-  '@limitbreak/permit-c@1.0.0':
-    resolution: {integrity: sha512-7BooxTklXlCPzfdccfKL7Tt2Cm4MntOHR51dHqjKePn7AynMKsUtaKH75ZXHzWRPZSmyixFNzQ7tIJDdPxF2MA==}
 
   '@lit-labs/ssr-dom-shim@1.2.0':
     resolution: {integrity: sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==}
@@ -5490,9 +5469,6 @@ packages:
 
   '@openzeppelin/contracts@3.4.2':
     resolution: {integrity: sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==}
-
-  '@openzeppelin/contracts@4.8.3':
-    resolution: {integrity: sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==}
 
   '@openzeppelin/contracts@4.9.6':
     resolution: {integrity: sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==}
@@ -10113,9 +10089,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  erc721a@4.2.3:
-    resolution: {integrity: sha512-0deF0hOOK1XI1Vxv3NKDh2E9sgzRlENuOoexjXRJIRfYCsLlqi9ejl2RF6Wcd9HfH0ldqC03wleQ2WDjxoOUvA==}
-
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -10391,8 +10364,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
 
-  eslint-plugin-react-refresh@0.5.2:
-    resolution: {integrity: sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==}
+  eslint-plugin-react-refresh@0.5.3:
+    resolution: {integrity: sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==}
     peerDependencies:
       eslint: ^9 || ^10
 
@@ -12432,9 +12405,6 @@ packages:
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
-
-  js-md5@0.8.3:
-    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
@@ -15344,30 +15314,15 @@ packages:
   seaport-core@0.0.1:
     resolution: {integrity: sha512-fgdSIC0ru8xK+fdDfF4bgTFH8ssr6EwbPejC2g/JsWzxy+FvG7JfaX57yn/eIv6hoscgZL87Rm+kANncgwLH3A==}
 
-  seaport-core@1.6.5:
-    resolution: {integrity: sha512-jpGOpaKpH1B49oOYqAYAAVXN8eGlI/NjE6fYHPYlQaDVx325NS5dpiDDgGLtQZNgQ3EbqrfhfB5KyIbg7owyFg==}
-
   seaport-core@https://codeload.github.com/immutable/seaport-core/tar.gz/0633350ec34f21fcede657ff812f11cf7d19144e:
     resolution: {tarball: https://codeload.github.com/immutable/seaport-core/tar.gz/0633350ec34f21fcede657ff812f11cf7d19144e}
     version: 1.5.0
-
-  seaport-core@https://codeload.github.com/immutable/seaport-core/tar.gz/f9b2e50267862570d0df3ed7e3e32d1ff2cd9813:
-    resolution: {tarball: https://codeload.github.com/immutable/seaport-core/tar.gz/f9b2e50267862570d0df3ed7e3e32d1ff2cd9813}
-    version: 1.6.6
 
   seaport-sol@1.6.0:
     resolution: {integrity: sha512-a1FBK1jIeEQXZ9CmQvtmfG0w7CE8nIad89btGg7qrrrtF4j1S0Ilmzpe2Hderap05Uvf3EWS9P/aghDQCNAwkA==}
 
   seaport-types@0.0.1:
     resolution: {integrity: sha512-m7MLa7sq3YPwojxXiVvoX1PM9iNVtQIn7AdEtBnKTwgxPfGRWUlbs/oMgetpjT/ZYTmv3X5/BghOcstWYvKqRA==}
-
-  seaport-types@1.6.3:
-    resolution: {integrity: sha512-Rm9dTTEUKmXqMgc5TiRtfX/sFOX6SjKkT9l/spTdRknplYh5tmJ0fMJzbE60pCzV1/Izq0cCua6uvWszo6zOAQ==}
-
-  seaport@https://codeload.github.com/immutable/seaport/tar.gz/8345d291c69b7777a77bd81996ce46b28183586c:
-    resolution: {tarball: https://codeload.github.com/immutable/seaport/tar.gz/8345d291c69b7777a77bd81996ce46b28183586c}
-    version: 1.6.0
-    engines: {node: '>=18.15.0'}
 
   seaport@https://codeload.github.com/immutable/seaport/tar.gz/ae061dc008105dd8d05937df9ad9a676f878cbf9:
     resolution: {tarball: https://codeload.github.com/immutable/seaport/tar.gz/ae061dc008105dd8d05937df9ad9a676f878cbf9}
@@ -19958,8 +19913,6 @@ snapshots:
 
   '@ethereumjs/rlp@4.0.1': {}
 
-  '@ethereumjs/rlp@5.0.2': {}
-
   '@ethereumjs/tx@4.2.0':
     dependencies:
       '@ethereumjs/common': 3.2.0
@@ -19972,19 +19925,6 @@ snapshots:
       '@ethereumjs/rlp': 4.0.1
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
-
-  '@ethereumjs/util@9.1.0':
-    dependencies:
-      '@ethereumjs/rlp': 5.0.2
-      ethereum-cryptography: 2.2.1
-
-  '@ethereumjs/wallet@2.0.4':
-    dependencies:
-      '@ethereumjs/util': 9.1.0
-      '@scure/base': 1.2.6
-      ethereum-cryptography: 2.2.1
-      js-md5: 0.8.3
-      uuid: 9.0.1
 
   '@ethersproject/abi@5.7.0':
     dependencies:
@@ -20369,10 +20309,10 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@imtbl/auth-next-client@2.14.3(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@imtbl/auth-next-client@2.20.1(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@imtbl/auth': 2.14.3
-      '@imtbl/auth-next-server': 2.14.3(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@imtbl/auth': 2.20.1
+      '@imtbl/auth-next-server': 2.20.1(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
     optionalDependencies:
       next: 14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth: 5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -20380,31 +20320,31 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@imtbl/auth-next-server@2.14.3(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@imtbl/auth-next-server@2.20.1(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     optionalDependencies:
       next: 14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth: 5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
 
-  '@imtbl/auth@2.14.3':
+  '@imtbl/auth@2.20.1':
     dependencies:
-      '@imtbl/generated-clients': 2.14.3
-      '@imtbl/metrics': 2.14.3
+      '@imtbl/generated-clients': 2.20.1
+      '@imtbl/metrics': 2.20.1
       localforage: 1.10.0
       oidc-client-ts: 3.4.1
     transitivePeerDependencies:
       - debug
 
-  '@imtbl/blockchain-data@2.14.3':
+  '@imtbl/blockchain-data@2.20.1':
     dependencies:
-      '@imtbl/config': 2.14.3
-      '@imtbl/generated-clients': 2.14.3
+      '@imtbl/config': 2.20.1
+      '@imtbl/generated-clients': 2.20.1
       axios: 1.7.7
     transitivePeerDependencies:
       - debug
 
-  '@imtbl/bridge-sdk@2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@imtbl/bridge-sdk@2.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@imtbl/config': 2.14.3
+      '@imtbl/config': 2.20.1
       '@jest/globals': 29.7.0
       axios: 1.7.7
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -20414,16 +20354,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@imtbl/checkout-sdk@2.14.3(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)':
+  '@imtbl/checkout-sdk@2.20.1(bufferutil@4.0.8)(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@imtbl/blockchain-data': 2.14.3
-      '@imtbl/bridge-sdk': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@imtbl/config': 2.14.3
-      '@imtbl/dex-sdk': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@imtbl/generated-clients': 2.14.3
-      '@imtbl/metrics': 2.14.3
-      '@imtbl/orderbook': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@imtbl/passport': 2.14.3(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
+      '@imtbl/blockchain-data': 2.20.1
+      '@imtbl/bridge-sdk': 2.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@imtbl/config': 2.20.1
+      '@imtbl/dex-sdk': 2.20.1(bufferutil@4.0.8)(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+      '@imtbl/generated-clients': 2.20.1
+      '@imtbl/metrics': 2.20.1
+      '@imtbl/orderbook': 2.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@imtbl/passport': 2.20.1(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
       '@metamask/detect-provider': 2.0.0
       axios: 1.7.7
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -20438,31 +20378,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@imtbl/config@2.14.3':
+  '@imtbl/config@2.20.1':
     dependencies:
-      '@imtbl/metrics': 2.14.3
-
-  '@imtbl/contracts@2.2.18(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@axelar-network/axelar-gmp-sdk-solidity': 5.10.0
-      '@limitbreak/creator-token-standards': 5.0.0
-      '@openzeppelin/contracts': 4.9.6
-      '@openzeppelin/contracts-upgradeable': 4.9.6
-      openzeppelin-contracts-5.0.2: '@openzeppelin/contracts@5.0.2'
-      openzeppelin-contracts-upgradeable-4.9.3: '@openzeppelin/contracts-upgradeable@4.9.6'
-      seaport: https://codeload.github.com/immutable/seaport/tar.gz/ae061dc008105dd8d05937df9ad9a676f878cbf9(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
-      seaport-16: seaport@https://codeload.github.com/immutable/seaport/tar.gz/8345d291c69b7777a77bd81996ce46b28183586c(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
-      seaport-core-16: seaport-core@https://codeload.github.com/immutable/seaport-core/tar.gz/f9b2e50267862570d0df3ed7e3e32d1ff2cd9813
-      seaport-types-16: seaport-types@1.6.3
-      solidity-bits: 0.4.0
-      solidity-bytes-utils: 0.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - c-kzg
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
+      '@imtbl/metrics': 2.20.1
 
   '@imtbl/contracts@2.2.6(bufferutil@4.0.8)(eslint@9.16.0(jiti@1.21.0))(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
@@ -20485,19 +20403,23 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@imtbl/dex-sdk@2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@imtbl/contracts@3.1.1(@openzeppelin/contracts@5.0.2)':
     dependencies:
-      '@imtbl/config': 2.14.3
+      '@openzeppelin/contracts': 5.0.2
+
+  '@imtbl/dex-sdk@2.20.1(bufferutil@4.0.8)(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
+    dependencies:
+      '@imtbl/config': 2.20.1
       '@uniswap/sdk-core': 3.2.3
-      '@uniswap/swap-router-contracts': 1.3.1(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
-      '@uniswap/v3-sdk': 3.10.0(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
+      '@uniswap/swap-router-contracts': 1.3.1(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
+      '@uniswap/v3-sdk': 3.10.0(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - hardhat
       - utf-8-validate
 
-  '@imtbl/generated-clients@2.14.3':
+  '@imtbl/generated-clients@2.20.1':
     dependencies:
       axios: 1.7.7
     transitivePeerDependencies:
@@ -20507,18 +20429,18 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@imtbl/metrics@2.14.3':
+  '@imtbl/metrics@2.20.1':
     dependencies:
       global-const: 0.1.2
       lru-memorise: 0.3.0
 
-  '@imtbl/minting-backend@2.14.3':
+  '@imtbl/minting-backend@2.20.1':
     dependencies:
-      '@imtbl/blockchain-data': 2.14.3
-      '@imtbl/config': 2.14.3
-      '@imtbl/generated-clients': 2.14.3
-      '@imtbl/metrics': 2.14.3
-      '@imtbl/webhook': 2.14.3
+      '@imtbl/blockchain-data': 2.20.1
+      '@imtbl/config': 2.20.1
+      '@imtbl/generated-clients': 2.20.1
+      '@imtbl/metrics': 2.20.1
+      '@imtbl/webhook': 2.20.1
       uuid: 9.0.1
     optionalDependencies:
       pg: 8.11.5
@@ -20527,10 +20449,10 @@ snapshots:
       - debug
       - pg-native
 
-  '@imtbl/orderbook@2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@imtbl/orderbook@2.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@imtbl/config': 2.14.3
-      '@imtbl/metrics': 2.14.3
+      '@imtbl/config': 2.20.1
+      '@imtbl/metrics': 2.20.1
       '@opensea/seaport-js': 4.0.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       axios: 1.7.7
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -20541,16 +20463,14 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@imtbl/passport@2.14.3(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)':
+  '@imtbl/passport@2.20.1(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@imtbl/auth': 2.14.3
-      '@imtbl/config': 2.14.3
-      '@imtbl/generated-clients': 2.14.3
-      '@imtbl/metrics': 2.14.3
-      '@imtbl/toolkit': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@imtbl/wallet': 2.14.3(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
-      '@imtbl/x-client': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@imtbl/x-provider': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@imtbl/auth': 2.20.1
+      '@imtbl/config': 2.20.1
+      '@imtbl/generated-clients': 2.20.1
+      '@imtbl/metrics': 2.20.1
+      '@imtbl/toolkit': 2.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@imtbl/wallet': 2.20.1(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
       ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       localforage: 1.10.0
       oidc-client-ts: 3.4.1
@@ -20569,21 +20489,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@imtbl/sdk@2.14.3(bufferutil@4.0.8)(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)':
+  '@imtbl/sdk@2.20.1(bufferutil@4.0.8)(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@imtbl/auth': 2.14.3
-      '@imtbl/auth-next-client': 2.14.3(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@imtbl/auth-next-server': 2.14.3(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@imtbl/blockchain-data': 2.14.3
-      '@imtbl/checkout-sdk': 2.14.3(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
-      '@imtbl/config': 2.14.3
-      '@imtbl/minting-backend': 2.14.3
-      '@imtbl/orderbook': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@imtbl/passport': 2.14.3(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
-      '@imtbl/wallet': 2.14.3(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
-      '@imtbl/webhook': 2.14.3
-      '@imtbl/x-client': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@imtbl/x-provider': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@imtbl/auth': 2.20.1
+      '@imtbl/auth-next-client': 2.20.1(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@imtbl/auth-next-server': 2.20.1(next-auth@5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@imtbl/blockchain-data': 2.20.1
+      '@imtbl/checkout-sdk': 2.20.1(bufferutil@4.0.8)(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))(typescript@5.6.2)(utf-8-validate@5.0.10)
+      '@imtbl/config': 2.20.1
+      '@imtbl/minting-backend': 2.20.1
+      '@imtbl/orderbook': 2.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@imtbl/passport': 2.20.1(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
+      '@imtbl/wallet': 2.20.1(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
+      '@imtbl/webhook': 2.20.1
     optionalDependencies:
       next: 14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth: 5.0.0-beta.30(next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -20598,9 +20516,8 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@imtbl/toolkit@2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@imtbl/toolkit@2.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@imtbl/x-client': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@metamask/detect-provider': 2.0.0
       axios: 1.7.7
       bn.js: 5.2.1
@@ -20612,11 +20529,11 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@imtbl/wallet@2.14.3(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)':
+  '@imtbl/wallet@2.20.1(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@imtbl/auth': 2.14.3
-      '@imtbl/generated-clients': 2.14.3
-      '@imtbl/metrics': 2.14.3
+      '@imtbl/auth': 2.20.1
+      '@imtbl/generated-clients': 2.20.1
+      '@imtbl/metrics': 2.20.1
       viem: 2.18.2(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -20625,45 +20542,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@imtbl/webhook@2.14.3':
+  '@imtbl/webhook@2.20.1':
     dependencies:
-      '@imtbl/config': 2.14.3
-      '@imtbl/generated-clients': 2.14.3
+      '@imtbl/config': 2.20.1
+      '@imtbl/generated-clients': 2.20.1
       sns-validator: 0.3.5
     transitivePeerDependencies:
       - debug
-
-  '@imtbl/x-client@2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@ethereumjs/wallet': 2.0.4
-      '@imtbl/config': 2.14.3
-      '@imtbl/generated-clients': 2.14.3
-      axios: 1.7.7
-      bn.js: 5.2.1
-      elliptic: 6.6.1
-      enc-utils: 3.0.0
-      ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      hash.js: 1.1.7
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-
-  '@imtbl/x-provider@2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@imtbl/config': 2.14.3
-      '@imtbl/generated-clients': 2.14.3
-      '@imtbl/toolkit': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@imtbl/x-client': 2.14.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@metamask/detect-provider': 2.0.0
-      axios: 1.7.7
-      enc-utils: 3.0.0
-      ethers: 6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      oidc-client-ts: 3.4.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
 
   '@ioredis/commands@1.2.0': {}
 
@@ -21280,16 +21165,6 @@ snapshots:
     dependencies:
       '@lezer/common': 1.4.0
 
-  '@limitbreak/creator-token-standards@5.0.0':
-    dependencies:
-      '@limitbreak/permit-c': 1.0.0
-      '@openzeppelin/contracts': 4.8.3
-      erc721a: 4.2.3
-
-  '@limitbreak/permit-c@1.0.0':
-    dependencies:
-      '@openzeppelin/contracts': 4.8.3
-
   '@lit-labs/ssr-dom-shim@1.2.0': {}
 
   '@lit/reactive-element@1.6.3':
@@ -21821,11 +21696,6 @@ snapshots:
       ethereumjs-util: 7.1.5
       hardhat: 2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
 
-  '@nomicfoundation/hardhat-network-helpers@1.0.11(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))':
-    dependencies:
-      ethereumjs-util: 7.1.5
-      hardhat: 2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
-
   '@nomicfoundation/hardhat-toolbox@3.0.0(psd3grcaa6tu47tsyrqa7gq7oq)':
     dependencies:
       '@nomicfoundation/hardhat-chai-matchers': 2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
@@ -22101,8 +21971,6 @@ snapshots:
   '@openzeppelin/contracts-upgradeable@4.9.6': {}
 
   '@openzeppelin/contracts@3.4.2': {}
-
-  '@openzeppelin/contracts@4.8.3': {}
 
   '@openzeppelin/contracts@4.9.6': {}
 
@@ -25224,6 +25092,17 @@ snapshots:
       tiny-invariant: 1.3.1
       toformat: 2.0.0
 
+  '@uniswap/swap-router-contracts@1.3.1(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@openzeppelin/contracts': 3.4.2
+      '@uniswap/v2-core': 1.0.1
+      '@uniswap/v3-core': 1.0.0
+      '@uniswap/v3-periphery': 1.4.4
+      dotenv: 14.3.2
+      hardhat-watcher: 2.5.0(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
+    transitivePeerDependencies:
+      - hardhat
+
   '@uniswap/swap-router-contracts@1.3.1(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))':
     dependencies:
       '@openzeppelin/contracts': 3.4.2
@@ -25254,6 +25133,19 @@ snapshots:
       '@uniswap/v2-core': 1.0.1
       '@uniswap/v3-core': 1.0.0
       base64-sol: 1.0.1
+
+  '@uniswap/v3-sdk@3.10.0(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/solidity': 5.7.0
+      '@uniswap/sdk-core': 4.0.6
+      '@uniswap/swap-router-contracts': 1.3.1(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
+      '@uniswap/v3-periphery': 1.4.3
+      '@uniswap/v3-staker': 1.0.0
+      tiny-invariant: 1.3.1
+      tiny-warning: 1.0.3
+    transitivePeerDependencies:
+      - hardhat
 
   '@uniswap/v3-sdk@3.10.0(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))':
     dependencies:
@@ -26259,6 +26151,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.7.0(@babel/core@7.26.9):
+    dependencies:
+      '@babel/core': 7.26.9
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.26.9)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-loader@8.3.0(@babel/core@7.26.9)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1)):
     dependencies:
       '@babel/core': 7.26.9
@@ -26450,6 +26356,13 @@ snapshots:
       '@babel/core': 7.26.10
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.26.10)
+
+  babel-preset-jest@29.6.3(@babel/core@7.26.9):
+    dependencies:
+      '@babel/core': 7.26.9
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.26.9)
+    optional: true
 
   babel-preset-react-app@10.0.1:
     dependencies:
@@ -28121,8 +28034,6 @@ snapshots:
 
   envinfo@7.14.0: {}
 
-  erc721a@4.2.3: {}
-
   err-code@2.0.3: {}
 
   error-ex@1.3.2:
@@ -28347,7 +28258,7 @@ snapshots:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.57.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
       object.assign: 4.1.5
       object.entries: 1.1.8
       semver: 6.3.1
@@ -28358,13 +28269,13 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
 
   eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.9.0(eslint@8.57.0))(eslint-plugin-react-hooks@5.0.0(eslint@8.57.0))(eslint-plugin-react@7.35.0(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0(eslint@8.57.0)
@@ -28378,8 +28289,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
@@ -28398,7 +28309,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.0)
@@ -28415,8 +28326,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.0)
@@ -28433,8 +28344,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.0)
@@ -28444,23 +28355,23 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@8.57.0)(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@9.16.0(jiti@1.21.0))(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2):
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/eslint-parser': 7.22.9(@babel/core@7.26.10)(eslint@8.57.0)
+      '@babel/eslint-parser': 7.22.9(@babel/core@7.26.10)(eslint@9.16.0(jiti@1.21.0))
       '@rushstack/eslint-patch': 1.10.4
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 8.57.0
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2)
-      eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
-      eslint-plugin-react: 7.35.0(eslint@8.57.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
-      eslint-plugin-testing-library: 5.11.0(eslint@8.57.0)(typescript@5.6.2)
+      eslint: 9.16.0(jiti@1.21.0)
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@9.16.0(jiti@1.21.0))
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2)
+      eslint-plugin-jsx-a11y: 6.9.0(eslint@9.16.0(jiti@1.21.0))
+      eslint-plugin-react: 7.35.0(eslint@9.16.0(jiti@1.21.0))
+      eslint-plugin-react-hooks: 4.6.0(eslint@9.16.0(jiti@1.21.0))
+      eslint-plugin-testing-library: 5.11.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)
     optionalDependencies:
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -28471,23 +28382,23 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(eslint@9.16.0(jiti@1.21.0))(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(eslint@8.57.0)(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2):
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/eslint-parser': 7.22.9(@babel/core@7.26.10)(eslint@9.16.0(jiti@1.21.0))
+      '@babel/eslint-parser': 7.22.9(@babel/core@7.26.10)(eslint@8.57.0)
       '@rushstack/eslint-patch': 1.10.4
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 9.16.0(jiti@1.21.0)
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(eslint@9.16.0(jiti@1.21.0))
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2)
-      eslint-plugin-jsx-a11y: 6.9.0(eslint@9.16.0(jiti@1.21.0))
-      eslint-plugin-react: 7.35.0(eslint@9.16.0(jiti@1.21.0))
-      eslint-plugin-react-hooks: 4.6.0(eslint@9.16.0(jiti@1.21.0))
-      eslint-plugin-testing-library: 5.11.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)
+      eslint: 8.57.0
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2)
+      eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
+      eslint-plugin-react: 7.35.0(eslint@8.57.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
+      eslint-plugin-testing-library: 5.11.0(eslint@8.57.0)(typescript@5.6.2)
     optionalDependencies:
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -28512,25 +28423,7 @@ snapshots:
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      get-tsconfig: 4.6.2
-      globby: 13.2.2
-      is-core-module: 2.15.0
-      is-glob: 4.0.3
-      synckit: 0.8.5
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
-    dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
-      enhanced-resolve: 5.15.0
-      eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
       get-tsconfig: 4.6.2
       globby: 13.2.2
       is-core-module: 2.15.0
@@ -28553,17 +28446,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.16.0(jiti@1.21.0)):
     dependencies:
       debug: 3.2.7
@@ -28574,23 +28456,50 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@8.57.0):
+  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@9.16.0(jiti@1.21.0)):
     dependencies:
       '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.10)
-      eslint: 8.57.0
-      lodash: 4.17.21
-      string-natural-compare: 3.0.1
-
-  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(eslint@9.16.0(jiti@1.21.0)):
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.26.9)
-      '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.9)
       eslint: 9.16.0(jiti@1.21.0)
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(eslint@8.57.0):
+    dependencies:
+      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.26.9)
+      '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.9)
+      eslint: 8.57.0
+      lodash: 4.17.21
+      string-natural-compare: 3.0.1
+
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0):
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      hasown: 2.0.2
+      is-core-module: 2.15.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -28655,12 +28564,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2):
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2):
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)
       eslint: 9.16.0(jiti@1.21.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
       jest: 27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
@@ -28729,7 +28638,7 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-react-refresh@0.5.2(eslint@8.57.0):
+  eslint-plugin-react-refresh@0.5.3(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
 
@@ -30001,6 +29910,11 @@ snapshots:
       - debug
       - utf-8-validate
 
+  hardhat-watcher@2.5.0(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)):
+    dependencies:
+      chokidar: 3.6.0
+      hardhat: 2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
+
   hardhat-watcher@2.5.0(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)):
     dependencies:
       chokidar: 3.6.0
@@ -30990,27 +30904,6 @@ snapshots:
       exit: 0.1.2
       import-local: 3.1.0
       jest-config: 29.7.0(@types/node@20.14.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    optionalDependencies:
-      node-notifier: 8.0.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -32069,20 +31962,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
-    optionalDependencies:
-      node-notifier: 8.0.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
@@ -32114,8 +31993,6 @@ snapshots:
   js-cookie@3.0.1: {}
 
   js-levenshtein@1.1.6: {}
-
-  js-md5@0.8.3: {}
 
   js-sha3@0.8.0: {}
 
@@ -33231,6 +33108,12 @@ snapshots:
       react: 18.3.1
     optional: true
 
+  next-auth@5.0.0-beta.30(next@15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@auth/core': 0.41.0
+      next: 15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+
   next-auth@5.0.0-beta.30(next@15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
     dependencies:
       '@auth/core': 0.41.0
@@ -33240,7 +33123,7 @@ snapshots:
   next-auth@5.0.0-beta.30(next@15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@auth/core': 0.41.0
-      next: 15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   next@14.2.25(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -33302,6 +33185,30 @@ snapshots:
       react: 19.0.0-rc-66855b96-20241106
       react-dom: 18.3.1(react@19.0.0-rc-66855b96-20241106)
       styled-jsx: 5.1.6(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.7
+      '@next/swc-darwin-x64': 15.5.7
+      '@next/swc-linux-arm64-gnu': 15.5.7
+      '@next/swc-linux-arm64-musl': 15.5.7
+      '@next/swc-linux-x64-gnu': 15.5.7
+      '@next/swc-linux-x64-musl': 15.5.7
+      '@next/swc-win32-arm64-msvc': 15.5.7
+      '@next/swc-win32-x64-msvc': 15.5.7
+      '@playwright/test': 1.60.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@15.5.10(@babel/core@7.26.10)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 15.5.10
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001760
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.7
       '@next/swc-darwin-x64': 15.5.7
@@ -35090,7 +34997,7 @@ snapshots:
       '@remix-run/router': 1.7.2
       react: 18.3.1
 
-  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.23.1)(eslint@8.57.0)(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(type-fest@2.19.0)(typescript@5.6.2)(utf-8-validate@5.0.10):
+  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.23.1)(eslint@9.16.0(jiti@1.21.0))(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(type-fest@2.19.0)(typescript@5.6.2)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/core': 7.26.9
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.11.0)(type-fest@2.19.0)(webpack-dev-server@4.15.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1)))(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
@@ -35107,9 +35014,9 @@ snapshots:
       css-minimizer-webpack-plugin: 3.4.1(esbuild@0.23.1)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 8.57.0
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@8.57.0)(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2)
-      eslint-webpack-plugin: 3.2.0(eslint@8.57.0)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
+      eslint: 9.16.0(jiti@1.21.0)
+      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@9.16.0(jiti@1.21.0))(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2)
+      eslint-webpack-plugin: 3.2.0(eslint@9.16.0(jiti@1.21.0))(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
       file-loader: 6.2.0(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
       fs-extra: 10.1.0
       html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
@@ -35126,7 +35033,7 @@ snapshots:
       prompts: 2.4.2
       react: 18.3.1
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.6.2)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
+      react-dev-utils: 12.0.1(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
       react-refresh: 0.11.0
       resolve: 1.22.8
       resolve-url-loader: 4.0.0
@@ -35176,7 +35083,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.23.1)(eslint@9.16.0(jiti@1.21.0))(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(type-fest@2.19.0)(typescript@5.6.2)(utf-8-validate@5.0.10):
+  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.23.1)(eslint@8.57.0)(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(type-fest@2.19.0)(typescript@5.6.2)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/core': 7.26.9
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.11.0)(type-fest@2.19.0)(webpack-dev-server@4.15.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1)))(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
@@ -35193,9 +35100,9 @@ snapshots:
       css-minimizer-webpack-plugin: 3.4.1(esbuild@0.23.1)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 9.16.0(jiti@1.21.0)
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(eslint@9.16.0(jiti@1.21.0))(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2)
-      eslint-webpack-plugin: 3.2.0(eslint@9.16.0(jiti@1.21.0))(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
+      eslint: 8.57.0
+      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(eslint@8.57.0)(jest@27.5.1(bufferutil@4.0.8)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(utf-8-validate@5.0.10))(typescript@5.6.2)
+      eslint-webpack-plugin: 3.2.0(eslint@8.57.0)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
       file-loader: 6.2.0(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
       fs-extra: 10.1.0
       html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
@@ -35212,7 +35119,7 @@ snapshots:
       prompts: 2.4.2
       react: 18.3.1
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@9.16.0(jiti@1.21.0))(typescript@5.6.2)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
+      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.6.2)(webpack@5.88.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(esbuild@0.23.1))
       react-refresh: 0.11.0
       resolve: 1.22.8
       resolve-url-loader: 4.0.0
@@ -35742,17 +35649,9 @@ snapshots:
     dependencies:
       seaport-types: 0.0.1
 
-  seaport-core@1.6.5:
-    dependencies:
-      seaport-types: 1.6.3
-
   seaport-core@https://codeload.github.com/immutable/seaport-core/tar.gz/0633350ec34f21fcede657ff812f11cf7d19144e:
     dependencies:
       seaport-types: 0.0.1
-
-  seaport-core@https://codeload.github.com/immutable/seaport-core/tar.gz/f9b2e50267862570d0df3ed7e3e32d1ff2cd9813:
-    dependencies:
-      seaport-types: 1.6.3
 
   seaport-sol@1.6.0:
     dependencies:
@@ -35761,28 +35660,6 @@ snapshots:
 
   seaport-types@0.0.1: {}
 
-  seaport-types@1.6.3: {}
-
-  seaport@https://codeload.github.com/immutable/seaport/tar.gz/8345d291c69b7777a77bd81996ce46b28183586c(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10):
-    dependencies:
-      '@nomicfoundation/hardhat-network-helpers': 1.0.11(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
-      '@openzeppelin/contracts': 4.9.6
-      ethers: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      ethers-eip712: 0.2.0(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      hardhat: 2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
-      merkletreejs: 0.3.11
-      seaport-core: 1.6.5
-      seaport-sol: 1.6.0
-      seaport-types: 1.6.3
-      solady: 0.0.84
-    transitivePeerDependencies:
-      - bufferutil
-      - c-kzg
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
-
   seaport@https://codeload.github.com/immutable/seaport/tar.gz/ae061dc008105dd8d05937df9ad9a676f878cbf9(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10):
     dependencies:
       '@nomicfoundation/hardhat-network-helpers': 1.0.11(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
@@ -35790,26 +35667,6 @@ snapshots:
       ethers: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       ethers-eip712: 0.2.0(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       hardhat: 2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@20.14.13)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
-      merkletreejs: 0.3.11
-      seaport-core: https://codeload.github.com/immutable/seaport-core/tar.gz/0633350ec34f21fcede657ff812f11cf7d19144e
-      seaport-sol: 1.6.0
-      seaport-types: 0.0.1
-      solady: 0.0.84
-    transitivePeerDependencies:
-      - bufferutil
-      - c-kzg
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
-
-  seaport@https://codeload.github.com/immutable/seaport/tar.gz/ae061dc008105dd8d05937df9ad9a676f878cbf9(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10):
-    dependencies:
-      '@nomicfoundation/hardhat-network-helpers': 1.0.11(hardhat@2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10))
-      '@openzeppelin/contracts': 4.9.6
-      ethers: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      ethers-eip712: 0.2.0(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      hardhat: 2.22.6(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
       merkletreejs: 0.3.11
       seaport-core: https://codeload.github.com/immutable/seaport-core/tar.gz/0633350ec34f21fcede657ff812f11cf7d19144e
       seaport-sol: 1.6.0
@@ -37100,12 +36957,12 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.26.10)
       esbuild: 0.23.1
 
-  ts-jest@29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2))(typescript@5.6.2):
+  ts-jest@29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2)))(typescript@5.6.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)
+      jest: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.15))(@types/node@22.19.7)(typescript@5.6.2))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -37114,10 +36971,10 @@ snapshots:
       typescript: 5.6.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.26.9
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
+      babel-jest: 29.7.0(@babel/core@7.26.9)
       esbuild: 0.23.1
 
   ts-mockito@2.6.1:


### PR DESCRIPTION
The original `detectDoNotTrack()` had a broken ternary: both branches resolved to `'none'`, so GPC and DNT signals had no effect. This PR fixes the wiring and enforces privacy signals at every consent decision point.

**Core (`@imtbl/audience-core`)**
- `createConsentManager` forces consent to `'none'` at init if GPC or DNT is active, regardless of the configured `initialLevel`
- `setLevel` re-checks on every call and caps any attempted upgrade to `'none'` while either signal is active
- GPC is evaluated before DNT because it carries legal weight under CCPA/CPRA

**Web SDK (`@imtbl/audience`)**
- `setConsent` caps the incoming level before running side effects (cookie creation, queue start), not after — prevents tracking infrastructure spinning up for a level GPC would block
- Fires `gpc_consent_overridden` to New Relic via `@imtbl/metrics` with `{ signal, requestedLevel, context }`
  - `context: 'init'` when the configured level is overridden at SDK construction
  - `context: 'runtime'` on subsequent `setConsent` calls
- Logs a `console.warn` to the customer when `debug: true`

**Pixel (`@imtbl/pixel`)**
- No internal telemetry (pixel stubs out `@imtbl/metrics` to keep bundle size down)
- Adds `debug?: boolean` (default `false`) to `PixelInitOptions`: logs a `console.warn` if GPC/DNT is active and a non-`'none'` consent level was passed explicitly
- Warning is suppressed in auto-consent mode since auto mode already resolves to `'none'` independent of GPC
