### PR TITLE
feat(audience): stamp consentLevel on pixel and web SDK messages [SDK-565]

### DIFF
--- a/packages/audience/core/src/consent.test.ts
+++ b/packages/audience/core/src/consent.test.ts
@@ -85,7 +85,7 @@ describe('createConsentManager', () => {
     expect(purgeFn({ type: 'page' })).toBe(true);
   });
 
-  it('strips userId on downgrade from full to anonymous', () => {
+  it('strips userId and downgrades consentLevel on downgrade from full to anonymous', () => {
     const queue = createMockQueue();
     const send = createMockSend();
     const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
@@ -94,12 +94,15 @@ describe('createConsentManager', () => {
     expect(manager.level).toBe('anonymous');
     expect(queue.transform).toHaveBeenCalledWith(expect.any(Function));
 
-    // Verify the transform strips userId
+    // Verify the transform strips userId and rewrites the stamped consentLevel
     const transformFn = queue.transform.mock.calls[0][0];
-    const withUserId = { type: 'page', userId: 'u-1', anonymousId: 'a-1' };
+    const withUserId = {
+      type: 'page', userId: 'u-1', anonymousId: 'a-1', consentLevel: 'full',
+    };
     const result = transformFn(withUserId);
     expect(result.userId).toBeUndefined();
     expect(result.anonymousId).toBe('a-1');
+    expect(result.consentLevel).toBe('anonymous');
   });
 
   it('fires PUT to consent endpoint on level change via the injected send', () => {

--- a/packages/audience/core/src/consent.test.ts
+++ b/packages/audience/core/src/consent.test.ts
@@ -130,20 +130,20 @@ describe('createConsentManager', () => {
     expect(result.consentLevel).toBe('anonymous');
   });
 
-  it('leaves consentLevel absent on downgrade for messages that never carried one', () => {
+  it('stamps consentLevel anonymous on downgrade even for messages that lacked one', () => {
     const queue = createMockQueue();
     const send = createMockSend();
     const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'web', 'full');
 
     manager.setLevel('anonymous');
 
-    // A message with no consentLevel (e.g. current web SDK) must not gain one:
-    // the field is only rewritten, never introduced, so surfaces that haven't
-    // opted in stay untouched.
+    // The downgrade rewrites consentLevel unconditionally, so even a message
+    // that never carried one (e.g. persisted by a pre-consentLevel build and
+    // restored from storage) is normalised to 'anonymous'.
     const transformFn = queue.transform.mock.calls[0][0];
     const result = transformFn({ type: 'page', userId: 'u-1', anonymousId: 'a-1' });
     expect(result.userId).toBeUndefined();
-    expect('consentLevel' in result).toBe(false);
+    expect(result.consentLevel).toBe('anonymous');
   });
 
   it('fires PUT to consent endpoint on level change via the injected send', () => {

--- a/packages/audience/core/src/consent.test.ts
+++ b/packages/audience/core/src/consent.test.ts
@@ -105,6 +105,22 @@ describe('createConsentManager', () => {
     expect(result.consentLevel).toBe('anonymous');
   });
 
+  it('leaves consentLevel absent on downgrade for messages that never carried one', () => {
+    const queue = createMockQueue();
+    const send = createMockSend();
+    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'web', 'full');
+
+    manager.setLevel('anonymous');
+
+    // A message with no consentLevel (e.g. current web SDK) must not gain one:
+    // the field is only rewritten, never introduced, so surfaces that haven't
+    // opted in stay untouched.
+    const transformFn = queue.transform.mock.calls[0][0];
+    const result = transformFn({ type: 'page', userId: 'u-1', anonymousId: 'a-1' });
+    expect(result.userId).toBeUndefined();
+    expect('consentLevel' in result).toBe(false);
+  });
+
   it('fires PUT to consent endpoint on level change via the injected send', () => {
     const queue = createMockQueue();
     const send = createMockSend();

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -85,14 +85,16 @@ export function createConsentManager(
           // Purge all queued messages
           queue.purge(() => true);
         } else if (next === 'anonymous') {
-          // Remove identify/alias messages and strip userId from the rest
+          // Remove identify/alias messages, strip userId from the rest, and
+          // downgrade the stamped consentLevel.
           queue.purge((msg: Message) => msg.type === 'identify' || msg.type === 'alias');
           queue.transform((msg: Message) => {
-            if ('userId' in msg) {
-              const { userId, ...rest } = msg;
+            const downgraded = { ...msg, consentLevel: 'anonymous' as const } as Message;
+            if ('userId' in downgraded) {
+              const { userId, ...rest } = downgraded;
               return rest as Message;
             }
-            return msg;
+            return downgraded;
           });
         }
       }

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -86,10 +86,15 @@ export function createConsentManager(
           queue.purge(() => true);
         } else if (next === 'anonymous') {
           // Remove identify/alias messages, strip userId from the rest, and
-          // downgrade the stamped consentLevel.
+          // downgrade the stamped consentLevel. The rewrite only touches
+          // messages that already carry a consentLevel (the pixel stamps every
+          // message; the web SDK does not yet), so surfaces that haven't opted
+          // into the field are left exactly as before.
           queue.purge((msg: Message) => msg.type === 'identify' || msg.type === 'alias');
           queue.transform((msg: Message) => {
-            const downgraded = { ...msg, consentLevel: 'anonymous' as const } as Message;
+            const downgraded = 'consentLevel' in msg
+              ? ({ ...msg, consentLevel: 'anonymous' as const } as Message)
+              : msg;
             if ('userId' in downgraded) {
               const { userId, ...rest } = downgraded;
               return rest as Message;

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -122,14 +122,11 @@ export function createConsentManager(
           queue.purge(() => true);
         } else if (effective === 'anonymous') {
           // Remove identify/alias messages, strip userId from the rest, and
-          // downgrade the stamped consentLevel. The rewrite only touches
-          // messages that already carry a consentLevel, so any surface that
-          // hasn't opted into the field is left exactly as before.
+          // downgrade the stamped consentLevel to 'anonymous' — the user
+          // withdrew full consent, so queued events must not still report 'full'.
           queue.purge((msg: Message) => msg.type === 'identify' || msg.type === 'alias');
           queue.transform((msg: Message) => {
-            const downgraded = 'consentLevel' in msg
-              ? ({ ...msg, consentLevel: 'anonymous' as const } as Message)
-              : msg;
+            const downgraded = { ...msg, consentLevel: 'anonymous' as const } as Message;
             if ('userId' in downgraded) {
               const { userId, ...rest } = downgraded;
               return rest as Message;

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -126,10 +126,10 @@ export function createConsentManager(
           // withdrew full consent, so queued events must not still report 'full'.
           queue.purge((msg: Message) => msg.type === 'identify' || msg.type === 'alias');
           queue.transform((msg: Message) => {
-            const downgraded = { ...msg, consentLevel: 'anonymous' as const } as Message;
+            const downgraded = { ...msg, consentLevel: 'anonymous' as const };
             if ('userId' in downgraded) {
               const { userId, ...rest } = downgraded;
-              return rest as Message;
+              return rest;
             }
             return downgraded;
           });

--- a/packages/audience/core/src/types.ts
+++ b/packages/audience/core/src/types.ts
@@ -28,6 +28,7 @@ interface BaseMessage {
   anonymousId: string;
   surface: Surface;
   context: EventContext;
+  consentLevel?: ConsentLevel;
   /** Present when the SDK/pixel is initialised with testMode: true. */
   test?: true;
 }

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -229,6 +229,45 @@ describe('Pixel', () => {
     });
   });
 
+  describe('consent level', () => {
+    it('stamps the anonymous consent level on every emitted message', () => {
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
+
+      const calls = mockEnqueue.mock.calls.map((c: unknown[]) => (c[0] as Record<string, unknown>));
+      expect(calls.length).toBeGreaterThan(0);
+      calls.forEach((c) => expect(c.consentLevel).toBe('anonymous'));
+    });
+
+    it('stamps full consent with no userId (full-but-unidentified)', () => {
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consent: 'full' });
+
+      const pageCall = mockEnqueue.mock.calls
+        .map((c: unknown[]) => (c[0] as Record<string, unknown>))
+        .find((c) => c.type === 'page');
+      expect(pageCall!.consentLevel).toBe('full');
+      expect(pageCall!.userId).toBeUndefined();
+    });
+
+    it('reflects an upgraded consent level on later events', () => {
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
+      pixel.setConsent('full');
+      mockEnqueue.mockClear();
+
+      pixel.page();
+
+      const pageCall = mockEnqueue.mock.calls
+        .map((c: unknown[]) => (c[0] as Record<string, unknown>))
+        .find((c) => c.type === 'page');
+      expect(pageCall!.consentLevel).toBe('full');
+    });
+  });
+
   describe('session_end', () => {
     it('fires session_end on pagehide when session is active', () => {
       const pixel = new Pixel();

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -332,6 +332,7 @@ export class Pixel {
       anonymousId: this.anonymousId,
       surface: 'pixel' as const,
       context: collectContext('@imtbl/pixel', PIXEL_VERSION),
+      consentLevel: this.consent!.level,
       ...(this.testMode && { test: true as const }),
     };
   }

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -788,6 +788,56 @@ describe('Audience', () => {
     });
   });
 
+  describe('consent level', () => {
+    it('stamps the anonymous consent level on every emitted message', async () => {
+      const sdk = createSDK({ consent: 'anonymous' });
+      sdk.page();
+      sdk.track('purchase', { currency: 'USD', value: 1 });
+      await sdk.flush();
+
+      const msgs = sentMessages();
+      expect(msgs.length).toBeGreaterThan(0);
+      msgs.forEach((m: any) => expect(m.consentLevel).toBe('anonymous'));
+
+      sdk.shutdown();
+    });
+
+    it('stamps full consent, carrying userId once identified', async () => {
+      const sdk = createSDK({ consent: 'full' });
+      sdk.identify(TEST_USER.id, TEST_USER.identityType);
+      sdk.page();
+      await sdk.flush();
+
+      const idMsg = sentMessages().find((m: any) => m.type === 'identify');
+      expect(idMsg.consentLevel).toBe('full');
+      expect(idMsg.userId).toBe(TEST_USER.id);
+
+      const pageMsg = sentMessages().find((m: any) => m.type === 'page');
+      expect(pageMsg.consentLevel).toBe('full');
+      expect(pageMsg.userId).toBe(TEST_USER.id);
+
+      sdk.shutdown();
+    });
+
+    it('rewrites stamped consentLevel to anonymous and strips userId on downgrade from full', async () => {
+      const sdk = createSDK({ consent: 'full' });
+      sdk.identify(TEST_USER.id, TEST_USER.identityType);
+      sdk.track('purchase', { currency: 'USD', value: 9.99 });
+
+      sdk.setConsent('anonymous');
+      await sdk.flush();
+
+      const trackMsg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'purchase',
+      );
+      expect(trackMsg).toBeDefined();
+      expect(trackMsg.consentLevel).toBe('anonymous');
+      expect(trackMsg.userId).toBeUndefined();
+
+      sdk.shutdown();
+    });
+  });
+
   describe('identify', () => {
     it('sends an identify message at full consent', async () => {
       const sdk = createSDK({ consent: 'full' });

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -217,6 +217,11 @@ export class Audience {
       anonymousId: this.anonymousId,
       surface: 'web' as const,
       context: collectContext(LIBRARY_NAME, LIBRARY_VERSION),
+      // Every enqueue path is consent-guarded (page/track via isTrackingDisabled,
+      // identify/alias via canIdentify, session events only when tracking is
+      // allowed), so the level here is always a decided, sendable value
+      // (anonymous/full) — never none/not_set.
+      consentLevel: this.consent.level,
       ...(this.testMode && { test: true as const }),
     };
   }

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -223,10 +223,6 @@ export class Audience {
       anonymousId: this.anonymousId,
       surface: 'web' as const,
       context: collectContext(LIBRARY_NAME, LIBRARY_VERSION),
-      // Every enqueue path is consent-guarded (page/track via isTrackingDisabled,
-      // identify/alias via canIdentify, session events only when tracking is
-      // allowed), so the level here is always a decided, sendable value
-      // (anonymous/full) — never none/not_set.
       consentLevel: this.consent.level,
       ...(this.testMode && { test: true as const }),
     };


### PR DESCRIPTION
## What

- Adds an optional `consentLevel` field to the shared `BaseMessage` type in `@imtbl/audience-core`.
- **Pixel**: stamps the current consent level onto every message in `Pixel.buildBase()`.
- **Web SDK**: stamps the current consent level onto every message in `Audience.baseMessage()`.
- On a `full → anonymous` consent downgrade, queued messages have their stamped `consentLevel` rewritten to `anonymous` (alongside the existing `userId` strip), so no queued event still reports `full` after the user withdraws consent.

## Why

Consent level is being plumbed end-to-end through the pipeline (SDK → audience ingest → attribution → postbacks) as part of [SDK-449](https://linear.app/imtbl/issue/SDK-449). Attribution currently *infers* consent from the presence of a `userId`, which cannot distinguish **full-but-unidentified** traffic (full consent granted before/without `identify()`, e.g. all pixel traffic) from genuinely anonymous traffic. Sending the decided level explicitly lets the backend record provenance rather than guess.

The audience-service ingest/derivation side ([SDK-554](https://linear.app/imtbl/issue/SDK-554)) has already landed and accepts the field as optional, so this is a non-breaking, forward-compatible change.

Both client surfaces are included together because the change touches the shared `@imtbl/audience-core` (the `BaseMessage` type and the shared consent-downgrade transform), so shipping them in one PR keeps core and its consumers consistent.

Notes:
- Every enqueue path is consent-guarded (pixel `buildBase`, web `baseMessage` via `isTrackingDisabled`/`canIdentify`), so the stamped level is always a decided, sendable value (`anonymous`/`full`) — never `none`/`not_set`.
- The pixel never calls `identify()`, so it emits `full` consent with **no** `userId` — exactly the case the explicit field exists to capture. The web SDK carries `userId` once `identify()` is called under `full` consent.

## Tests

- `pixel.test.ts`: stamps `anonymous` on all emitted messages; stamps `full` with `userId` undefined; reflects an upgraded level on later events.
- `sdk.test.ts`: stamps `anonymous` on all emitted messages; stamps `full` carrying `userId` once identified; downgrade from `full → anonymous` rewrites `consentLevel` to `anonymous` and strips `userId`.
- `consent.test.ts`: downgrade rewrites `consentLevel` to `anonymous` (including messages that lacked one, e.g. restored from a pre-`consentLevel` build).