### PR TITLE
feat(audience): avoid mutating or purging queued messages on consent change [SDK-647]

### DIFF
--- a/packages/audience/core/src/consent.test.ts
+++ b/packages/audience/core/src/consent.test.ts
@@ -13,21 +13,6 @@ function createMockSend() {
   return jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue({ ok: true });
 }
 
-function createMockQueue() {
-  return {
-    purge: jest.fn(),
-    transform: jest.fn(),
-    enqueue: jest.fn(),
-    flush: jest.fn(),
-    flushUnload: jest.fn(),
-    start: jest.fn(),
-    stop: jest.fn(),
-    destroy: jest.fn(),
-    clear: jest.fn(),
-    get length() { return 0; },
-  } as any;
-}
-
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -72,84 +57,52 @@ describe('detectDoNotTrack', () => {
 
 describe('createConsentManager', () => {
   it('defaults to none when no initial level provided', () => {
-    const queue = createMockQueue();
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel');
     expect(manager.level).toBe('none');
   });
 
   it('uses the initial level when provided', () => {
-    const queue = createMockQueue();
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
     expect(manager.level).toBe('anonymous');
   });
 
-  it('upgrades consent without modifying queue', () => {
-    const queue = createMockQueue();
+  it('upgrades consent and notifies the backend', () => {
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
 
     manager.setLevel('anonymous');
     expect(manager.level).toBe('anonymous');
-    expect(queue.purge).not.toHaveBeenCalled();
-    expect(queue.transform).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledTimes(1);
   });
 
-  it('purges queue on downgrade to none', () => {
-    const queue = createMockQueue();
+  it('changes level to none on downgrade and notifies the backend', () => {
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
 
     manager.setLevel('none');
     expect(manager.level).toBe('none');
-    expect(queue.purge).toHaveBeenCalledWith(expect.any(Function));
-
-    // Verify the purge predicate matches all messages
-    const purgeFn = queue.purge.mock.calls[0][0];
-    expect(purgeFn({ type: 'page' })).toBe(true);
+    expect(send).toHaveBeenCalledWith(
+      'https://api.immutable.com/v1/audience/tracking-consent',
+      'pk_imapik-test-local',
+      { anonymousId: 'anon-1', status: 'none', source: 'pixel' },
+      { method: 'PUT', keepalive: true },
+    );
   });
 
-  it('strips userId and downgrades consentLevel on downgrade from full to anonymous', () => {
-    const queue = createMockQueue();
+  it('changes level to anonymous on downgrade from full and notifies the backend', () => {
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
 
     manager.setLevel('anonymous');
     expect(manager.level).toBe('anonymous');
-    expect(queue.transform).toHaveBeenCalledWith(expect.any(Function));
-
-    // Verify the transform strips userId and rewrites the stamped consentLevel
-    const transformFn = queue.transform.mock.calls[0][0];
-    const withUserId = {
-      type: 'page', userId: 'u-1', anonymousId: 'a-1', consentLevel: 'full',
-    };
-    const result = transformFn(withUserId);
-    expect(result.userId).toBeUndefined();
-    expect(result.anonymousId).toBe('a-1');
-    expect(result.consentLevel).toBe('anonymous');
-  });
-
-  it('stamps consentLevel anonymous on downgrade even for messages that lacked one', () => {
-    const queue = createMockQueue();
-    const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'web', 'full');
-
-    manager.setLevel('anonymous');
-
-    // The downgrade rewrites consentLevel unconditionally, so even a message
-    // that never carried one (e.g. persisted by a pre-consentLevel build and
-    // restored from storage) is normalised to 'anonymous'.
-    const transformFn = queue.transform.mock.calls[0][0];
-    const result = transformFn({ type: 'page', userId: 'u-1', anonymousId: 'a-1' });
-    expect(result.userId).toBeUndefined();
-    expect(result.consentLevel).toBe('anonymous');
+    expect(send).toHaveBeenCalledTimes(1);
   });
 
   it('fires PUT to consent endpoint on level change via the injected send', () => {
-    const queue = createMockQueue();
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
 
     manager.setLevel('anonymous');
 
@@ -162,39 +115,33 @@ describe('createConsentManager', () => {
   });
 
   it('does nothing when setting the same level', () => {
-    const queue = createMockQueue();
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
 
     manager.setLevel('anonymous');
-    expect(queue.purge).not.toHaveBeenCalled();
-    expect(queue.transform).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
   });
 
   it('forces none when DNT is set even if initialLevel is not none', () => {
     Object.defineProperty(navigator, 'doNotTrack', { value: '1', configurable: true });
-    const queue = createMockQueue();
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
     expect(manager.level).toBe('none');
     Object.defineProperty(navigator, 'doNotTrack', { value: '0', configurable: true });
   });
 
   it('forces none when GPC is set even if initialLevel is not none', () => {
     Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
-    const queue = createMockQueue();
     const send = createMockSend();
-    const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
+    const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
     expect(manager.level).toBe('none');
     Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
   });
 
   it('tracks gpc_consent_override metric with signal and configured level when GPC fires', () => {
     Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
-    const queue = createMockQueue();
     const send = createMockSend();
-    createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
+    createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'full');
     const expected = {
       signal: 'gpc', requestedLevel: 'full', context: 'init', publishableKey: 'pk_imapik-test-local',
     };
@@ -204,9 +151,8 @@ describe('createConsentManager', () => {
 
   it('tracks gpc_consent_override metric with dnt signal when DNT fires', () => {
     Object.defineProperty(navigator, 'doNotTrack', { value: '1', configurable: true });
-    const queue = createMockQueue();
     const send = createMockSend();
-    createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
+    createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'anonymous');
     const expected = {
       signal: 'dnt', requestedLevel: 'anonymous', context: 'init', publishableKey: 'pk_imapik-test-local',
     };
@@ -217,9 +163,8 @@ describe('createConsentManager', () => {
   describe('setLevel GPC enforcement', () => {
     it('caps setLevel to none when GPC is active', () => {
       Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
-      const queue = createMockQueue();
       const send = createMockSend();
-      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+      const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
       manager.setLevel('anonymous');
       expect(manager.level).toBe('none');
       Object.defineProperty(navigator, 'globalPrivacyControl', { value: undefined, configurable: true });
@@ -227,9 +172,8 @@ describe('createConsentManager', () => {
 
     it('tracks gpc_consent_overridden when setLevel is blocked by GPC', () => {
       Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
-      const queue = createMockQueue();
       const send = createMockSend();
-      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+      const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
       (track as jest.Mock).mockClear();
       manager.setLevel('full');
       const expected = {
@@ -241,9 +185,8 @@ describe('createConsentManager', () => {
 
     it('tracks gpc_consent_overridden with dnt signal when blocked by DNT at runtime', () => {
       Object.defineProperty(navigator, 'doNotTrack', { value: '1', configurable: true });
-      const queue = createMockQueue();
       const send = createMockSend();
-      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+      const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
       (track as jest.Mock).mockClear();
       manager.setLevel('full');
       const expected = {
@@ -255,9 +198,8 @@ describe('createConsentManager', () => {
 
     it('does not track gpc_consent_overridden when setting none while GPC is active', () => {
       Object.defineProperty(navigator, 'globalPrivacyControl', { value: true, configurable: true });
-      const queue = createMockQueue();
       const send = createMockSend();
-      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
+      const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none');
       (track as jest.Mock).mockClear();
       manager.setLevel('none');
       expect(track).not.toHaveBeenCalled();
@@ -267,7 +209,6 @@ describe('createConsentManager', () => {
 
   describe('onError callback', () => {
     it('fires onError with mapped CONSENT_SYNC_FAILED on consent PUT failure', async () => {
-      const queue = createMockQueue();
       const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue({
         ok: false,
         error: new TransportError({
@@ -277,7 +218,7 @@ describe('createConsentManager', () => {
         }),
       });
       const onError = jest.fn();
-      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none', onError);
+      const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none', onError);
 
       manager.setLevel('anonymous');
 
@@ -293,7 +234,6 @@ describe('createConsentManager', () => {
     });
 
     it('fires onError with NETWORK_ERROR on network failure', async () => {
-      const queue = createMockQueue();
       const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue({
         ok: false,
         error: new TransportError({
@@ -303,7 +243,7 @@ describe('createConsentManager', () => {
         }),
       });
       const onError = jest.fn();
-      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none', onError);
+      const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none', onError);
 
       manager.setLevel('anonymous');
       await Promise.resolve();
@@ -316,10 +256,9 @@ describe('createConsentManager', () => {
     });
 
     it('does not fire onError on successful consent sync', async () => {
-      const queue = createMockQueue();
       const send = createMockSend();
       const onError = jest.fn();
-      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none', onError);
+      const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none', onError);
 
       manager.setLevel('anonymous');
       await Promise.resolve();
@@ -329,13 +268,12 @@ describe('createConsentManager', () => {
     });
 
     it('swallows exceptions thrown from the onError callback', async () => {
-      const queue = createMockQueue();
       const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue({
         ok: false,
         error: new TransportError({ status: 500, endpoint: 'x', body: null }),
       });
       const onError = jest.fn().mockImplementation(() => { throw new Error('callback boom'); });
-      const manager = createConsentManager(queue, send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none', onError);
+      const manager = createConsentManager(send, 'pk_imapik-test-local', 'anon-1', 'pixel', 'none', onError);
 
       // Synchronous call must not throw even though the .then() handler will.
       expect(() => manager.setLevel('anonymous')).not.toThrow();

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -51,8 +51,7 @@ export function resolvePrivacySignal(): 'gpc' | 'dnt' {
  *   remains active.
  * - Already-queued events are never mutated on a consent change. Each event
  *   keeps the `consentLevel` (and any `userId`) it carried when it was
- *   recorded, since under GDPR the applicable consent is the one in force at
- *   capture time. Consent only gates what is collected going forward.
+ *   recorded. Consent only gates what is collected going forward.
  * - Fires PUT to `/v1/audience/tracking-consent` on every state change via
  *   the injected `send`, keeping the transport layer uniform across surfaces.
  * - On consent sync failure, fires `onError` with a public {@link AudienceError}
@@ -112,9 +111,6 @@ export function createConsentManager(
 
       if (effective === current) return;
 
-      // Consent changes only gate future collection; events already queued
-      // keep the consentLevel/userId they were recorded with (GDPR: consent
-      // is determined at capture time), so the queue is intentionally untouched.
       current = effective;
       notifyBackend(effective);
     },

--- a/packages/audience/core/src/consent.ts
+++ b/packages/audience/core/src/consent.ts
@@ -1,8 +1,7 @@
 import { track } from '@imtbl/metrics';
 import type {
-  ConsentLevel, ConsentUpdatePayload, Message,
+  ConsentLevel, ConsentUpdatePayload,
 } from './types';
-import type { MessageQueue } from './queue';
 import type { HttpSend } from './transport';
 import { type AudienceError, invokeOnError, toAudienceError } from './errors';
 import { BASE_URL, CONSENT_PATH } from './config';
@@ -50,18 +49,18 @@ export function resolvePrivacySignal(): 'gpc' | 'dnt' {
  * - If GPC or DNT is detected, consent is forced to `'none'` regardless of
  *   `initialLevel`. Upgrades via `setLevel` are also blocked while the signal
  *   remains active.
- * - On downgrade (e.g. full -> anonymous), strips `userId` from queued messages.
- * - On downgrade to `'none'`, purges the queue entirely.
+ * - Already-queued events are never mutated on a consent change. Each event
+ *   keeps the `consentLevel` (and any `userId`) it carried when it was
+ *   recorded, since under GDPR the applicable consent is the one in force at
+ *   capture time. Consent only gates what is collected going forward.
  * - Fires PUT to `/v1/audience/tracking-consent` on every state change via
- *   the injected `send`. Sharing the same `HttpSend` instance with the queue
- *   keeps the transport layer uniform — no module-level mocking required.
+ *   the injected `send`, keeping the transport layer uniform across surfaces.
  * - On consent sync failure, fires `onError` with a public {@link AudienceError}
  *   mapped via {@link toAudienceError}, so callers don't have to repeat the
- *   `status === 0 → NETWORK_ERROR` mapping themselves. Exceptions thrown
+ *   `status === 0` to `NETWORK_ERROR` mapping themselves. Exceptions thrown
  *   from the callback are swallowed.
  */
 export function createConsentManager(
-  queue: MessageQueue,
   send: HttpSend,
   publishableKey: string,
   anonymousId: string,
@@ -80,8 +79,6 @@ export function createConsentManager(
     });
   }
   let current: ConsentLevel = privacySignalActive ? 'none' : (initialLevel ?? 'none');
-
-  const LEVELS: Record<ConsentLevel, number> = { none: 0, anonymous: 1, full: 2 };
 
   function notifyBackend(level: ConsentLevel): void {
     const url = `${baseUrl ?? BASE_URL}${CONSENT_PATH}`;
@@ -115,27 +112,9 @@ export function createConsentManager(
 
       if (effective === current) return;
 
-      const isDowngrade = LEVELS[effective] < LEVELS[current];
-
-      if (isDowngrade) {
-        if (effective === 'none') {
-          queue.purge(() => true);
-        } else if (effective === 'anonymous') {
-          // Remove identify/alias messages, strip userId from the rest, and
-          // downgrade the stamped consentLevel to 'anonymous' — the user
-          // withdrew full consent, so queued events must not still report 'full'.
-          queue.purge((msg: Message) => msg.type === 'identify' || msg.type === 'alias');
-          queue.transform((msg: Message) => {
-            const downgraded = { ...msg, consentLevel: 'anonymous' as const };
-            if ('userId' in downgraded) {
-              const { userId, ...rest } = downgraded;
-              return rest;
-            }
-            return downgraded;
-          });
-        }
-      }
-
+      // Consent changes only gate future collection; events already queued
+      // keep the consentLevel/userId they were recorded with (GDPR: consent
+      // is determined at capture time), so the queue is intentionally untouched.
       current = effective;
       notifyBackend(effective);
     },

--- a/packages/audience/core/src/queue.test.ts
+++ b/packages/audience/core/src/queue.test.ts
@@ -295,35 +295,6 @@ describe('MessageQueue', () => {
     expect(err.status).toBe(200);
     expect(err.responseBody).toEqual({ accepted: 1, rejected: 1 });
   });
-
-  it('purges messages matching a predicate', () => {
-    const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue(okResult);
-    const queue = createQueue(send);
-
-    queue.enqueue(makeMessage('1'));
-    queue.enqueue({ ...makeMessage('2'), type: 'identify' } as any);
-    queue.enqueue(makeMessage('3'));
-
-    queue.purge((m) => m.type === 'identify');
-    expect(queue.length).toBe(2);
-  });
-
-  it('transforms messages in place', async () => {
-    const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue(okResult);
-    const queue = createQueue(send);
-
-    queue.enqueue({ ...makeMessage('1'), userId: 'should-strip' } as any);
-
-    queue.transform((m) => {
-      const cleaned = { ...m };
-      delete (cleaned as any).userId;
-      return cleaned;
-    });
-
-    await queue.flush();
-    const msg = (send.mock.calls[0][2] as { messages: Message[] }).messages[0];
-    expect((msg as any).userId).toBeUndefined();
-  });
 });
 
 describe('exponential backoff', () => {

--- a/packages/audience/core/src/queue.ts
+++ b/packages/audience/core/src/queue.ts
@@ -207,18 +207,6 @@ export class MessageQueue {
     this.persist();
   }
 
-  /** Remove all messages matching a predicate. */
-  purge(predicate: (msg: Message) => boolean): void {
-    this.messages = this.messages.filter((m) => !predicate(m));
-    this.persist();
-  }
-
-  /** Transform messages in place (e.g., strip userId on consent downgrade). */
-  transform(fn: (msg: Message) => Message): void {
-    this.messages = this.messages.map(fn);
-    this.persist();
-  }
-
   get length(): number {
     return this.messages.length;
   }

--- a/packages/audience/pixel/README.md
+++ b/packages/audience/pixel/README.md
@@ -70,7 +70,8 @@ If you are not using `consentMode: 'auto'`, you can set consent manually at any 
 // After cookie banner interaction, upgrade to full
 window.__imtbl.push(['consent', 'full']);
 
-// Or downgrade (purges PII from queue)
+// Or downgrade. Consent changes only gate what is collected from now on;
+// events already recorded keep the consent level they were captured under.
 window.__imtbl.push(['consent', 'none']);
 ```
 

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -19,8 +19,6 @@ const mockStartCmpDetection = jest.fn().mockReturnValue(mockTeardownCmp);
 const mockEnqueue = jest.fn();
 const mockStart = jest.fn();
 const mockDestroy = jest.fn();
-const mockPurge = jest.fn();
-const mockTransform = jest.fn();
 const mockGetOrCreateSession = jest.fn().mockReturnValue({ sessionId: 'session-abc', isNew: true });
 
 jest.mock('@imtbl/audience-core', () => ({
@@ -28,8 +26,6 @@ jest.mock('@imtbl/audience-core', () => ({
     enqueue: mockEnqueue,
     start: mockStart,
     destroy: mockDestroy,
-    purge: mockPurge,
-    transform: mockTransform,
     stop: jest.fn(),
     flush: jest.fn(),
     flushUnload: jest.fn(),
@@ -56,7 +52,6 @@ jest.mock('@imtbl/audience-core', () => ({
   startCmpDetection: (...args: unknown[]) => mockStartCmpDetection(...args),
   createConsentManager: jest.fn().mockImplementation(
     (
-      _queue: unknown,
       _send: unknown,
       _key: unknown,
       _anonId: unknown,
@@ -501,7 +496,6 @@ describe('Pixel', () => {
 
       // consentMode: 'auto' should start at 'none' regardless of consent param
       expect(createConsentManager).toHaveBeenCalledWith(
-        expect.anything(),
         expect.anything(),
         'pk_imapik-test-local',
         'anon-123',

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -99,7 +99,6 @@ export class Pixel {
     const isAutoConsent = consentMode === 'auto';
 
     this.consent = createConsentManager(
-      this.queue,
       httpSend,
       key,
       this.anonymousId,

--- a/packages/audience/sdk-sample-app/README.md
+++ b/packages/audience/sdk-sample-app/README.md
@@ -54,7 +54,7 @@ first-class environment and must be reached via explicit override.
 5. Set Consent to **full**.
 6. In **Identity → Named identify**, enter `user@example.com`, type `email`, traits `{"name":"Jane"}`, click.
 7. In **Identity → Alias**, connect a Steam ID to the email above.
-8. Set Consent back to **none**. Notice the queue purge in the event log.
+8. Set Consent back to **none**. Tracking stops going forward; events already queued keep the consent level they were captured under and are not rewritten or dropped.
 9. In **Lifecycle → Simulate error**, pick `NETWORK_ERROR` from the dropdown and click **Fire onError**. The `onError` entry lands in the event log with the documented shape.
 
 ## `AudienceEvents` catalogue

--- a/packages/audience/sdk-sample-app/sample-app.js
+++ b/packages/audience/sdk-sample-app/sample-app.js
@@ -682,7 +682,7 @@
       // Log observable side effects of the transition.
       var effects = [];
       if (previous === 'none' && level !== 'none') effects.push('queue started, session created');
-      if (level === 'none') effects.push('queue purged, cookies deleted');
+      if (level === 'none') effects.push('tracking stopped, cookies deleted (queued events kept)');
       if (!canIdentify(level)) {
         currentUserId = null;
         identityMirror = emptyIdentity();

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -855,7 +855,7 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('rewrites stamped consentLevel to anonymous and strips userId on downgrade from full', async () => {
+    it('leaves queued events with their capture-time consentLevel and userId on downgrade from full', async () => {
       const sdk = createSDK({ consent: 'full' });
       sdk.identify(TEST_USER.id, TEST_USER.identityType);
       sdk.track('purchase', { currency: 'USD', value: 9.99 });
@@ -863,12 +863,14 @@ describe('Audience', () => {
       sdk.setConsent('anonymous');
       await sdk.flush();
 
+      // The purchase was recorded under full consent; the downgrade must not
+      // retro-actively rewrite it, so it still reports full + userId.
       const trackMsg = sentMessages().find(
         (m: any) => m.type === 'track' && m.eventName === 'purchase',
       );
       expect(trackMsg).toBeDefined();
-      expect(trackMsg.consentLevel).toBe('anonymous');
-      expect(trackMsg.userId).toBeUndefined();
+      expect(trackMsg.consentLevel).toBe('full');
+      expect(trackMsg.userId).toBe(TEST_USER.id);
 
       sdk.shutdown();
     });
@@ -1102,7 +1104,7 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('purges identify/alias, strips userId on downgrade', async () => {
+    it('keeps queued identify/alias and userId intact on downgrade to anonymous', async () => {
       const sdk = createSDK({ consent: 'full' });
 
       sdk.identify(TEST_USER.id, TEST_USER.identityType);
@@ -1112,18 +1114,17 @@ describe('Audience', () => {
       sdk.setConsent('anonymous');
       await sdk.flush();
 
+      // Events captured under full consent are not mutated by the downgrade:
+      // identify/alias stay queued and the purchase keeps its userId + level.
       const msgs = sentMessages();
-      expect(
-        msgs.every((m: any) => m.type !== 'identify'),
-      ).toBe(true);
-      expect(
-        msgs.every((m: any) => m.type !== 'alias'),
-      ).toBe(true);
+      expect(msgs.some((m: any) => m.type === 'identify')).toBe(true);
+      expect(msgs.some((m: any) => m.type === 'alias')).toBe(true);
       const trackMsg = msgs.find(
         (m: any) => m.type === 'track' && m.eventName === 'purchase',
       );
       expect(trackMsg).toBeDefined();
-      expect(trackMsg.userId).toBeUndefined();
+      expect(trackMsg.userId).toBe(TEST_USER.id);
+      expect(trackMsg.consentLevel).toBe('full');
 
       sdk.shutdown();
     });

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -151,7 +151,6 @@ export class Audience {
     );
 
     this.consent = createConsentManager(
-      this.queue,
       httpSend,
       publishableKey,
       this.anonymousId,


### PR DESCRIPTION
## Summary

Stops the web SDK and pixel from retro-actively mutating already-queued events when the client consent level changes. Under GDPR the applicable consent is the one in force at capture time, so events keep the `consentLevel`/`userId` they were recorded with; consent now only gates what is collected going forward.

Both surfaces share the consent state machine in `@imtbl/audience-core`, so the fix lands in one place.

- `core/src/consent.ts`: removed the downgrade block in `setLevel`. A consent change no longer:
  - purges the entire queue (downgrade to `none`),
  - purges `identify`/`alias` messages, or
  - rewrites `consentLevel` to `anonymous` / strips `userId` (downgrade to `anonymous`).
  Consent changes now only update the current level and notify the backend. Also dropped the now-dead `queue` parameter (and unused imports) from `createConsentManager`.
- `core/src/queue.ts`: removed `purge()` and `transform()` from `MessageQueue` - they existed solely for consent-driven mutation and have no remaining callers.
- Updated the two `createConsentManager` call sites (`sdk.ts`, `pixel.ts`).
- Updated unit/integration tests and the pixel/sample-app docs describing the old behavior.

## Context

[SDK-647](https://linear.app/imtbl/issue/SDK-647/avoid-mutating-consent-level-in-client-side-message-queues). Complements the consent-level provenance pipeline (SDK-449/SDK-565): each message already carries the consent level it was captured under, which the client-side rewrite was destroying.

## Behavioral note for reviewers

`setConsent('none')` still stops the queue and deletes cookies, but no longer clears the queue. Events captured before the downgrade now persist (and flush if consent is later re-enabled) instead of being dropped. This is the intended data-retention change - flagging for privacy visibility.

Unity is intentionally out of scope for this PR (web + pixel first).

## Test plan

- [x] `core` unit tests (178 passing), incl. rewritten consent tests
- [x] `sdk` tests (86 passing) - integration tests now assert queued events retain capture-time `consentLevel` + `userId` across a downgrade
- [x] `pixel` tests (120 passing)
- [x] `eslint --max-warnings=0` + `tsc` typecheck clean on all three packages