### PR TITLE
feat(audience): remove session_start and session_end events [SDK-689]

### DIFF
--- a/packages/audience/core/src/config.ts
+++ b/packages/audience/core/src/config.ts
@@ -11,6 +11,3 @@ export const COOKIE_NAME = 'imtbl_anon_id';
 export const SESSION_COOKIE = '_imtbl_sid';
 export const COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60 * 2; // 2 years
 export const SESSION_MAX_AGE = 30 * 60; // 30 minutes in seconds
-
-export const SESSION_START = 'session_start';
-export const SESSION_END = 'session_end';

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -25,8 +25,6 @@ export {
   BASE_URL,
   COOKIE_NAME,
   SESSION_COOKIE,
-  SESSION_START,
-  SESSION_END,
   DATA_PATH,
 } from './config';
 
@@ -40,8 +38,7 @@ export { MessageQueue } from './queue';
 export { collectContext } from './context';
 export { isTimestampValid, isAliasValid, truncate } from './validation';
 
-export { getOrCreateSession } from './session';
-export type { SessionResult } from './session';
+export { getOrCreateSessionId } from './session';
 
 export { collectSessionAttribution, collectPageAttribution } from './attribution';
 export type { Attribution } from './attribution';

--- a/packages/audience/core/src/session.test.ts
+++ b/packages/audience/core/src/session.test.ts
@@ -1,4 +1,4 @@
-import { getOrCreateSession, getOrCreateSessionId, getSessionId } from './session';
+import { getOrCreateSessionId, getSessionId } from './session';
 
 const SESSION_COOKIE = '_imtbl_sid';
 
@@ -21,45 +21,29 @@ beforeEach(() => {
   mockGenerateId.mockReturnValue('new-session-id');
 });
 
-describe('getOrCreateSession', () => {
-  it('creates a new session when no cookie exists', () => {
-    mockGetCookie.mockReturnValue(undefined);
-
-    const result = getOrCreateSession();
-    expect(result.sessionId).toBe('new-session-id');
-    expect(result.isNew).toBe(true);
-    expect(mockSetCookie).toHaveBeenCalledWith(SESSION_COOKIE, 'new-session-id', 1800, undefined);
-  });
-
-  it('returns existing session and refreshes expiry', () => {
-    mockGetCookie.mockReturnValue('existing-sid');
-
-    const result = getOrCreateSession();
-    expect(result.sessionId).toBe('existing-sid');
-    expect(result.isNew).toBe(false);
-    expect(mockSetCookie).toHaveBeenCalledWith(SESSION_COOKIE, 'existing-sid', 1800, undefined);
-    expect(mockGenerateId).not.toHaveBeenCalled();
-  });
-
-  it('passes domain to setCookie', () => {
-    mockGetCookie.mockReturnValue(undefined);
-
-    getOrCreateSession('.example.com');
-    expect(mockSetCookie).toHaveBeenCalledWith(SESSION_COOKIE, 'new-session-id', 1800, '.example.com');
-  });
-});
-
 describe('getOrCreateSessionId', () => {
-  it('returns the session ID string', () => {
+  it('creates a new session id when no cookie exists', () => {
     mockGetCookie.mockReturnValue(undefined);
 
     const id = getOrCreateSessionId();
     expect(id).toBe('new-session-id');
+    expect(mockSetCookie).toHaveBeenCalledWith(SESSION_COOKIE, 'new-session-id', 1800, undefined);
   });
 
-  it('returns existing session ID', () => {
+  it('returns existing session id and refreshes expiry without generating a new id', () => {
     mockGetCookie.mockReturnValue('existing-sid');
-    expect(getOrCreateSessionId()).toBe('existing-sid');
+
+    const id = getOrCreateSessionId();
+    expect(id).toBe('existing-sid');
+    expect(mockSetCookie).toHaveBeenCalledWith(SESSION_COOKIE, 'existing-sid', 1800, undefined);
+    expect(mockGenerateId).not.toHaveBeenCalled();
+  });
+
+  it('passes the domain through to setCookie', () => {
+    mockGetCookie.mockReturnValue(undefined);
+
+    getOrCreateSessionId('.example.com');
+    expect(mockSetCookie).toHaveBeenCalledWith(SESSION_COOKIE, 'new-session-id', 1800, '.example.com');
   });
 });
 

--- a/packages/audience/core/src/session.ts
+++ b/packages/audience/core/src/session.ts
@@ -2,33 +2,21 @@ import { getCookie, setCookie } from './cookie';
 import { generateId } from './utils';
 import { SESSION_COOKIE, SESSION_MAX_AGE } from './config';
 
-export interface SessionResult {
-  sessionId: string;
-  isNew: boolean;
-}
-
 /**
  * Get or create a session ID.
  *
- * The session cookie has a 30-minute rolling expiry — each call refreshes it.
- * Returns whether the session is new so the caller can fire a `session_start` event.
+ * The session cookie has a 30-minute rolling expiry — each call refreshes it,
+ * so a session ends after 30 minutes of inactivity.
  */
-export function getOrCreateSession(domain?: string): SessionResult {
+export function getOrCreateSessionId(domain?: string): string {
   const existing = getCookie(SESSION_COOKIE);
   if (existing) {
-    // Refresh the rolling expiry
     setCookie(SESSION_COOKIE, existing, SESSION_MAX_AGE, domain);
-    return { sessionId: existing, isNew: false };
+    return existing;
   }
-
   const id = generateId();
   setCookie(SESSION_COOKIE, id, SESSION_MAX_AGE, domain);
-  return { sessionId: id, isNew: true };
-}
-
-/** Convenience wrapper that returns just the session ID string. */
-export function getOrCreateSessionId(domain?: string): string {
-  return getOrCreateSession(domain).sessionId;
+  return id;
 }
 
 export function getSessionId(): string | undefined {

--- a/packages/audience/pixel/src/bootstrap.test.ts
+++ b/packages/audience/pixel/src/bootstrap.test.ts
@@ -28,7 +28,7 @@ jest.mock('@imtbl/audience-core', () => ({
   getCookie: jest.fn(),
   setCookie: jest.fn(),
   collectSessionAttribution: jest.fn().mockReturnValue({}),
-  getOrCreateSession: jest.fn().mockReturnValue({ sessionId: 's', isNew: false }),
+  getOrCreateSessionId: jest.fn().mockReturnValue('s'),
   createConsentManager: jest.fn().mockReturnValue({ level: 'none', setLevel: jest.fn() }),
 }));
 

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -19,7 +19,7 @@ const mockStartCmpDetection = jest.fn().mockReturnValue(mockTeardownCmp);
 const mockEnqueue = jest.fn();
 const mockStart = jest.fn();
 const mockDestroy = jest.fn();
-const mockGetOrCreateSession = jest.fn().mockReturnValue({ sessionId: 'session-abc', isNew: true });
+const mockGetOrCreateSessionId = jest.fn().mockReturnValue('session-abc');
 
 jest.mock('@imtbl/audience-core', () => ({
   MessageQueue: jest.fn().mockImplementation(() => ({
@@ -48,7 +48,7 @@ jest.mock('@imtbl/audience-core', () => ({
   }),
   collectThirdPartyIds: (...args: unknown[]) => mockCollectThirdPartyIds(...args),
   setupAutocapture: (...args: unknown[]) => mockSetupAutocapture(...args),
-  getOrCreateSession: (...args: unknown[]) => mockGetOrCreateSession(...args),
+  getOrCreateSessionId: (...args: unknown[]) => mockGetOrCreateSessionId(...args),
   startCmpDetection: (...args: unknown[]) => mockStartCmpDetection(...args),
   createConsentManager: jest.fn().mockImplementation(
     (
@@ -75,7 +75,7 @@ let activePixel: Pixel | null = null;
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-abc', isNew: true });
+  mockGetOrCreateSessionId.mockReturnValue('session-abc');
 });
 
 afterEach(() => {
@@ -88,53 +88,29 @@ afterEach(() => {
 
 describe('Pixel', () => {
   describe('init', () => {
-    it('creates queue, starts it, and fires page view + session_start when consent is anonymous', () => {
+    it('creates queue, starts it, and fires page view when consent is anonymous', () => {
       const pixel = new Pixel();
       activePixel = pixel;
       pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
 
       expect(mockStart).toHaveBeenCalled();
 
-      // Should fire session_start (new session) then page view
       const calls = mockEnqueue.mock.calls.map((c: unknown[]) => (c[0] as Record<string, unknown>));
       const pageCall = calls.find((c) => c.type === 'page');
-      const sessionStartCall = calls.find(
-        (c) => c.type === 'track' && c.eventName === 'session_start',
-      );
 
       expect(pageCall).toBeDefined();
       expect(pageCall!.surface).toBe('pixel');
       expect(pageCall!.anonymousId).toBe('anon-123');
       expect((pageCall!.properties as Record<string, unknown>).utm_source).toBe('google');
-
-      expect(sessionStartCall).toBeDefined();
-      expect(sessionStartCall!.sessionId).toBe('session-abc');
     });
 
-    it('does not fire page view or session_start when consent is none', () => {
+    it('does not fire page view when consent is none', () => {
       const pixel = new Pixel();
       activePixel = pixel;
       pixel.init({ key: 'pk_imapik-test-local', consent: 'none' });
 
       expect(mockStart).toHaveBeenCalled();
       expect(mockEnqueue).not.toHaveBeenCalled();
-    });
-
-    it('does not fire session_start for existing sessions', () => {
-      mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-abc', isNew: false });
-
-      const pixel = new Pixel();
-      activePixel = pixel;
-      pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
-
-      const calls = mockEnqueue.mock.calls.map((c: unknown[]) => (c[0] as Record<string, unknown>));
-      const sessionStartCall = calls.find(
-        (c) => c.type === 'track' && c.eventName === 'session_start',
-      );
-
-      expect(sessionStartCall).toBeUndefined();
-      // Page view should still fire
-      expect(calls.find((c) => c.type === 'page')).toBeDefined();
     });
 
     it('only initializes once', () => {
@@ -149,7 +125,7 @@ describe('Pixel', () => {
 
   describe('page', () => {
     it('enqueues a page message with attribution and session', () => {
-      mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-abc', isNew: false });
+      mockGetOrCreateSessionId.mockReturnValue('session-abc');
 
       const pixel = new Pixel();
       activePixel = pixel;
@@ -181,7 +157,7 @@ describe('Pixel', () => {
     });
 
     it('includes GA and Meta cookies in page properties when present', () => {
-      mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-abc', isNew: false });
+      mockGetOrCreateSessionId.mockReturnValue('session-abc');
       mockCollectThirdPartyIds.mockReturnValue({
         ga_client_id: 'GA1.2.123456.789012',
         fb_click_id: 'fb.1.1234567890.AbCdEf',
@@ -202,7 +178,7 @@ describe('Pixel', () => {
     });
 
     it('omits third-party IDs when cookies are not set', () => {
-      mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-abc', isNew: false });
+      mockGetOrCreateSessionId.mockReturnValue('session-abc');
       mockCollectThirdPartyIds.mockReturnValue({});
 
       const pixel = new Pixel();
@@ -259,72 +235,16 @@ describe('Pixel', () => {
   });
 
   describe('session id', () => {
-    it('stamps sessionId at the top level on both page and track (session_start) messages', () => {
-      // Default mock (isNew: true) means init() fires both a page view and a session_start track event.
+    it('stamps sessionId at the top level on the page view', () => {
       const pixel = new Pixel();
       activePixel = pixel;
       pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
 
       const calls = mockEnqueue.mock.calls.map((c: unknown[]) => (c[0] as Record<string, unknown>));
       const pageCall = calls.find((c) => c.type === 'page');
-      const trackCall = calls.find((c) => c.type === 'track');
 
       expect(pageCall).toBeDefined();
-      expect(trackCall).toBeDefined();
       expect(pageCall!.sessionId).toBe('session-abc');
-      expect(trackCall!.sessionId).toBe('session-abc');
-    });
-  });
-
-  describe('session_end', () => {
-    it('fires session_end on pagehide when session is active', () => {
-      const pixel = new Pixel();
-      activePixel = pixel;
-      pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
-      mockEnqueue.mockClear();
-
-      // Simulate pagehide
-      window.dispatchEvent(new Event('pagehide'));
-
-      expect(mockEnqueue).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'track',
-          eventName: 'session_end',
-          sessionId: 'session-abc',
-        }),
-      );
-    });
-
-    it('includes duration in session_end', () => {
-      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000000);
-
-      const pixel = new Pixel();
-      activePixel = pixel;
-      pixel.init({ key: 'pk_imapik-test-local', consent: 'anonymous' });
-      mockEnqueue.mockClear();
-
-      // Advance time by 15 seconds before triggering pagehide
-      dateNowSpy.mockReturnValue(1015000);
-      window.dispatchEvent(new Event('pagehide'));
-
-      const sessionEndCall = mockEnqueue.mock.calls.find(
-        (c: unknown[]) => (c[0] as Record<string, unknown>).eventName === 'session_end',
-      );
-      expect(sessionEndCall).toBeDefined();
-      expect((sessionEndCall![0] as Record<string, unknown>).properties).toEqual(
-        expect.objectContaining({ duration: 15 }),
-      );
-
-      dateNowSpy.mockRestore();
-    });
-
-    it('does not fire session_end when consent is none', () => {
-      const pixel = new Pixel();
-      activePixel = pixel;
-      pixel.init({ key: 'pk_imapik-test-local', consent: 'none' });
-
-      window.dispatchEvent(new Event('pagehide'));
-      expect(mockEnqueue).not.toHaveBeenCalled();
     });
   });
 
@@ -591,7 +511,7 @@ describe('Pixel', () => {
     });
 
     it('enqueue callback fires TrackMessage with session', () => {
-      mockGetOrCreateSession.mockReturnValue({ sessionId: 'session-xyz', isNew: false });
+      mockGetOrCreateSessionId.mockReturnValue('session-xyz');
 
       const pixel = new Pixel();
       activePixel = pixel;

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -13,10 +13,9 @@ import {
   collectContext,
   generateId,
   getTimestamp,
-  isBrowser,
   collectSessionAttribution,
   collectThirdPartyIds,
-  getOrCreateSession,
+  getOrCreateSessionId,
   createConsentManager,
   canTrack,
   startCmpDetection,
@@ -51,8 +50,6 @@ export class Pixel {
 
   private sessionId: string | undefined;
 
-  private sessionStartTime: number | undefined;
-
   private publishableKey = '';
 
   private domain: string | undefined;
@@ -60,8 +57,6 @@ export class Pixel {
   private testMode = false;
 
   private initialized = false;
-
-  private unloadHandler?: () => void;
 
   private teardownAutocapture?: () => void;
 
@@ -110,10 +105,6 @@ export class Pixel {
 
     this.initialized = true;
 
-    // Register session_end listener BEFORE starting the queue so that
-    // on page unload, session_end is enqueued before the queue flushes.
-    // DOM event listeners fire in registration order.
-    this.registerSessionEnd();
     this.queue.start();
 
     if (isAutoConsent) {
@@ -140,8 +131,7 @@ export class Pixel {
     // Reset scroll milestones so each page view starts from 0.
     this.resetScrollDepth?.();
 
-    const { sessionId, isNew } = getOrCreateSession(this.domain);
-    this.refreshSession(sessionId, isNew);
+    this.sessionId = getOrCreateSessionId(this.domain);
     const attribution = collectSessionAttribution();
     const thirdPartyIds = collectThirdPartyIds();
 
@@ -173,7 +163,6 @@ export class Pixel {
   }
 
   destroy(): void {
-    this.removeSessionEnd();
     if (this.teardownCmp) {
       this.teardownCmp();
       this.teardownCmp = undefined;
@@ -221,8 +210,7 @@ export class Pixel {
   private track(eventName: string, properties: Record<string, unknown>): void {
     if (!this.isTrackingAllowed()) return;
 
-    const { sessionId, isNew } = getOrCreateSession(this.domain);
-    this.refreshSession(sessionId, isNew);
+    this.sessionId = getOrCreateSessionId(this.domain);
 
     const message: TrackMessage = {
       ...this.buildBase(),
@@ -233,69 +221,6 @@ export class Pixel {
     };
 
     this.queue!.enqueue(message);
-  }
-
-  // -- Session lifecycle --------------------------------------------------
-
-  private refreshSession(sessionId: string, isNew: boolean): void {
-    this.sessionId = sessionId;
-    if (isNew) {
-      this.sessionStartTime = Date.now();
-      this.fireSessionStart();
-    }
-  }
-
-  private fireSessionStart(): void {
-    if (!this.isTrackingAllowed()) return;
-
-    const message: TrackMessage = {
-      ...this.buildBase(),
-      type: 'track',
-      eventName: 'session_start',
-      userId: undefined,
-    };
-
-    this.queue!.enqueue(message);
-  }
-
-  private fireSessionEnd(): void {
-    if (!this.isTrackingAllowed() || !this.sessionId) return;
-
-    const duration = this.sessionStartTime
-      ? Math.round((Date.now() - this.sessionStartTime) / 1000)
-      : undefined;
-
-    const message: TrackMessage = {
-      ...this.buildBase(),
-      type: 'track',
-      eventName: 'session_end',
-      properties: { duration },
-      userId: undefined,
-    };
-
-    this.queue!.enqueue(message);
-  }
-
-  private registerSessionEnd(): void {
-    if (!isBrowser()) return;
-
-    this.unloadHandler = () => {
-      this.fireSessionEnd();
-    };
-
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'hidden') {
-        this.unloadHandler?.();
-      }
-    });
-    window.addEventListener('pagehide', this.unloadHandler);
-  }
-
-  private removeSessionEnd(): void {
-    if (this.unloadHandler) {
-      window.removeEventListener('pagehide', this.unloadHandler);
-      this.unloadHandler = undefined;
-    }
   }
 
   // -- Helpers ------------------------------------------------------------

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -1,5 +1,5 @@
 import {
-  COOKIE_NAME, SESSION_COOKIE, SESSION_START, SESSION_END,
+  COOKIE_NAME, SESSION_COOKIE,
 } from '@imtbl/audience-core';
 import { track } from '@imtbl/metrics';
 import { Audience } from './sdk';
@@ -263,47 +263,6 @@ describe('Audience', () => {
 
       const sdk = createSDK({ consent: 'none' });
       expect(sdk.getAnonymousId()).not.toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
-      sdk.shutdown();
-    });
-
-    it('emits session_start on new session', async () => {
-      const sdk = createSDK({ consent: 'full' });
-      await sdk.flush();
-
-      const msg = sentMessages().find(
-        (m: any) => m.type === 'track' && m.eventName === SESSION_START,
-      );
-      expect(msg).toBeDefined();
-      expect(msg).toHaveProperty('sessionId');
-
-      sdk.shutdown();
-    });
-
-    it('includes attribution on session_start', async () => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          ...window.location,
-          search: '?utm_source=youtube&utm_campaign=launch',
-          href: 'https://studio.com/?utm_source=youtube&utm_campaign=launch',
-          protocol: 'https:',
-          pathname: '/',
-        },
-        writable: true,
-        configurable: true,
-      });
-      sessionStorage.clear();
-
-      const sdk = createSDK({ consent: 'full' });
-      await sdk.flush();
-
-      const msg = sentMessages().find(
-        (m: any) => m.type === 'track' && m.eventName === SESSION_START,
-      );
-      expect(msg).toBeDefined();
-      expect(msg).toHaveProperty('sessionId');
-      expect(msg.properties).toHaveProperty('utm_source', 'youtube');
-      expect(msg.properties).toHaveProperty('utm_campaign', 'launch');
-
       sdk.shutdown();
     });
   });
@@ -754,17 +713,12 @@ describe('Audience', () => {
       sdk.track('purchase', { currency: 'USD', value: 2 });
       await sdk.flush();
 
-      const msgs = sentMessages();
-      const sessionStarts = msgs.filter(
-        (m: any) => m.type === 'track' && m.eventName === SESSION_START,
-      );
-      const purchases = msgs.filter(
+      const purchases = sentMessages().filter(
         (m: any) => m.type === 'track' && m.eventName === 'purchase',
       );
 
-      expect(sessionStarts).toHaveLength(2);
+      expect(purchases[1].sessionId).toEqual(expect.any(String));
       expect(purchases[1].sessionId).not.toBe(firstSessionId);
-      expect(purchases[1].sessionId).toBe(sessionStarts[1].sessionId);
 
       sdk.shutdown();
     });
@@ -1164,7 +1118,7 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('starts queue and emits session_start when upgrading from none', async () => {
+    it('starts queue when upgrading from none', async () => {
       const sdk = createSDK({ consent: 'none' });
 
       sdk.track('sign_up', { method: 'google' });
@@ -1175,14 +1129,7 @@ describe('Audience', () => {
       sdk.track('sign_up', { method: 'google' });
       await sdk.flush();
 
-      const msgs = sentMessages();
-      const sessionStart = msgs.find(
-        (m: any) => m.type === 'track' && m.eventName === SESSION_START,
-      );
-      expect(sessionStart).toBeDefined();
-      expect(sessionStart).toHaveProperty('sessionId');
-
-      const signUp = msgs.find(
+      const signUp = sentMessages().find(
         (m: any) => m.type === 'track' && m.eventName === 'sign_up',
       );
       expect(signUp).toBeDefined();
@@ -1283,27 +1230,6 @@ describe('Audience', () => {
   });
 
   describe('shutdown', () => {
-    it('emits session_end with duration', async () => {
-      const sdk = createSDK({ consent: 'full' });
-      await sdk.flush();
-      fetchCalls.length = 0;
-
-      jest.advanceTimersByTime(5000);
-      sdk.shutdown();
-
-      // destroy() calls flushUnload() which fires a keepalive fetch synchronously.
-      // Yield to ensure all microtasks settle before reading fetchCalls.
-      await Promise.resolve();
-      await Promise.resolve();
-
-      const msg = sentMessages().find(
-        (m: any) => m.type === 'track' && m.eventName === SESSION_END,
-      );
-      expect(msg).toBeDefined();
-      expect(msg).toHaveProperty('sessionId');
-      expect(msg.properties.duration).toBe(5);
-    });
-
     it('is safe to call twice (React strict mode)', async () => {
       const sdk = createSDK({ consent: 'full' });
       sdk.shutdown();
@@ -1312,23 +1238,11 @@ describe('Audience', () => {
       await Promise.resolve();
       fetchCalls.length = 0;
 
-      sdk.shutdown();
+      expect(() => sdk.shutdown()).not.toThrow();
       await Promise.resolve();
       await Promise.resolve();
 
-      const sessionEnds = sentMessages().filter(
-        (m: any) => m.eventName === SESSION_END,
-      );
-      expect(sessionEnds).toHaveLength(0);
-    });
-
-    it('does not emit session_end at none consent', async () => {
-      const sdk = createSDK({ consent: 'none' });
-      sdk.shutdown();
-
-      expect(sentMessages().filter(
-        (m: any) => m.eventName === SESSION_END,
-      )).toHaveLength(0);
+      expect(sentMessages()).toHaveLength(0);
     });
   });
 
@@ -1373,22 +1287,6 @@ describe('Audience', () => {
       expect(msg.userId).toBeUndefined();
       expect(msg.anonymousId).toBeDefined();
       expect(msg.anonymousId).not.toBe(originalAnonId);
-
-      sdk.shutdown();
-    });
-
-    it('emits session_start after reset', async () => {
-      const sdk = createSDK({ consent: 'full' });
-      await sdk.flush();
-      fetchCalls.length = 0;
-
-      sdk.reset();
-      await sdk.flush();
-
-      const sessionStarts = sentMessages().filter(
-        (m: any) => m.type === 'track' && m.eventName === SESSION_START,
-      );
-      expect(sessionStarts).toHaveLength(1);
 
       sdk.shutdown();
     });

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -25,15 +25,13 @@ import {
   collectContext,
   collectSessionAttribution,
   collectThirdPartyIds,
-  getOrCreateSession,
+  getOrCreateSessionId,
   createConsentManager,
   canTrack,
   canIdentify,
   detectDoNotTrack,
   isBrowser,
   setupAutocapture,
-  SESSION_START,
-  SESSION_END,
 } from '@imtbl/audience-core';
 import { adoptAnonymousId, resolvePrivacySignal } from '@imtbl/audience-core/internal';
 import { track } from '@imtbl/metrics';
@@ -79,8 +77,6 @@ export class Audience {
   private anonymousId: string;
 
   private sessionId: string | undefined;
-
-  private sessionStartTime: number | undefined;
 
   private userId: string | undefined;
 
@@ -128,7 +124,6 @@ export class Audience {
 
     const incomingAid = Audience.readAndStripAidParam();
 
-    let isNewSession = false;
     if (canTrack(consentLevel)) {
       if (incomingAid) {
         adoptAnonymousId(incomingAid, cookieDomain);
@@ -136,7 +131,7 @@ export class Audience {
       } else {
         this.anonymousId = getOrCreateAnonymousId(cookieDomain);
       }
-      isNewSession = this.startSession();
+      this.refreshSession();
     } else {
       this.anonymousId = getCookie(COOKIE_NAME) ?? generateId();
     }
@@ -167,10 +162,7 @@ export class Audience {
 
     this.attribution = collectSessionAttribution();
 
-    if (!this.isTrackingDisabled()) {
-      this.queue.start();
-      if (isNewSession) this.trackSessionStart();
-    }
+    if (!this.isTrackingDisabled()) this.queue.start();
 
     // Consent is checked at fire time by each handler, not here.
     const autocaptureResult = setupAutocapture(
@@ -218,22 +210,9 @@ export class Audience {
     return canIdentify(this.consent.level) ? this.userId : undefined;
   }
 
-  /** Create or resume a session, returning whether it's new. */
-  private startSession(): boolean {
-    const session = getOrCreateSession(this.cookieDomain);
-    this.sessionId = session.sessionId;
-    this.sessionStartTime = Date.now();
-    return session.isNew;
-  }
-
-  // Unlike startSession(), fires session_start directly: callers here always already have a queue.
+  /** Create or resume the rolling session and cache its ID. */
   private refreshSession(): void {
-    const session = getOrCreateSession(this.cookieDomain);
-    this.sessionId = session.sessionId;
-    if (session.isNew) {
-      this.sessionStartTime = Date.now();
-      this.trackSessionStart();
-    }
+    this.sessionId = getOrCreateSessionId(this.cookieDomain);
   }
 
   // --- Message factory ---
@@ -255,32 +234,6 @@ export class Audience {
   private enqueue(label: string, message: Message): void {
     this.queue.enqueue(message);
     this.debug.logEvent(label, message);
-  }
-
-  // --- Session lifecycle ---
-
-  private trackSessionStart(): void {
-    if (!this.sessionId) return;
-    this.enqueue('track(session_start)', {
-      ...this.baseMessage(),
-      type: 'track',
-      eventName: SESSION_START,
-      properties: { ...this.attribution },
-    });
-  }
-
-  private trackSessionEnd(): void {
-    if (!this.sessionId) return;
-    this.enqueue('track(session_end)', {
-      ...this.baseMessage(),
-      type: 'track',
-      eventName: SESSION_END,
-      properties: {
-        ...(this.sessionStartTime && {
-          duration: Math.round((Date.now() - this.sessionStartTime) / 1000),
-        }),
-      },
-    });
   }
 
   // --- Page tracking ---
@@ -462,9 +415,8 @@ export class Audience {
 
     if (isUpgradeFromNone) {
       this.isFirstPage = true;
-      const isNewSession = this.startSession();
+      this.refreshSession();
       this.queue.start();
-      if (isNewSession) this.trackSessionStart();
     }
   }
 
@@ -524,12 +476,10 @@ export class Audience {
     deleteCookie(SESSION_COOKIE, this.cookieDomain);
     if (!this.isTrackingDisabled()) {
       this.anonymousId = getOrCreateAnonymousId(this.cookieDomain);
-      const isNewSession = this.startSession();
-      if (isNewSession) this.trackSessionStart();
+      this.refreshSession();
     } else {
       this.anonymousId = generateId();
       this.sessionId = undefined;
-      this.sessionStartTime = undefined;
     }
     this.isFirstPage = true;
   }
@@ -549,7 +499,6 @@ export class Audience {
   shutdown(): void {
     if (this.destroyed) return;
     this.destroyed = true;
-    if (!this.isTrackingDisabled()) this.trackSessionEnd();
     this.teardownAutocapture?.();
     this.queue.destroy();
     Audience.liveInstances = Math.max(0, Audience.liveInstances - 1);


### PR DESCRIPTION
## Summary

Stops the pixel and web SDK from emitting the client-side `session_start` and `session_end` events. Session tracking is otherwise unchanged: every message still carries a `sessionId` from the 30-minute rolling session cookie, so session boundaries are derived from that rather than from dedicated events. Internally the now-unused `getOrCreateSession`/`SessionResult` are replaced by `getOrCreateSessionId`.

Note for consumers: `session_start`/`session_end` are no longer emitted by either surface, and `@imtbl/audience-core` no longer exports `getOrCreateSession`/`SessionResult`.

Ticket: [SDK-689](https://linear.app/imtbl/issue/SDK-689)

## Test plan

- [x] `pnpm test` passes in core (248), pixel (50), and sdk (89 + 5 CDN-artifact build test)
- [x] `pnpm lint` passes in core, pixel, and sdk
- [x] Confirmed no `session_start`/`session_end` remain in source and `sessionId` is still stamped on every message
- [ ] Verified in a running integration (not done here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)