### PR TITLE
PLT-1330: align CODEOWNERS with new GitHub teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,34 +1,34 @@
-* @immutable/blockchain-services
+* @immutable/ped-engineering-blockchain-list
 
 # Shared Files
-/package.json @immutable/blockchain-services @immutable/ped-stream-sdk-integrations-list
-/.github/ @immutable/security @immutable/blockchain-services @immutable/ped-stream-sdk-integrations-list
-/.husky/ @immutable/blockchain-services
-/.nvmrc/ @immutable/blockchain-services
-/pnpm-lock.yaml @immutable/blockchain-services @immutable/ped-stream-sdk-integrations-list
-/pnpm-workspace.yaml @immutable/blockchain-services @immutable/ped-stream-sdk-integrations-list
-/tsconfig.base.json @immutable/blockchain-services @immutable/ped-stream-sdk-integrations-list
-/tsup.config.js @immutable/blockchain-services @immutable/ped-stream-sdk-integrations-list
+/package.json @immutable/ped-engineering-blockchain-list @immutable/ped-stream-sdk-integrations-list
+/.github/ @immutable/security @immutable/ped-engineering-blockchain-list @immutable/ped-stream-sdk-integrations-list
+/.husky/ @immutable/ped-engineering-blockchain-list
+/.nvmrc/ @immutable/ped-engineering-blockchain-list
+/pnpm-lock.yaml @immutable/ped-engineering-blockchain-list @immutable/ped-stream-sdk-integrations-list
+/pnpm-workspace.yaml @immutable/ped-engineering-blockchain-list @immutable/ped-stream-sdk-integrations-list
+/tsconfig.base.json @immutable/ped-engineering-blockchain-list @immutable/ped-stream-sdk-integrations-list
+/tsup.config.js @immutable/ped-engineering-blockchain-list @immutable/ped-stream-sdk-integrations-list
 /examples/ @immutable/devgrowth
-/packages/config/ @immutable/blockchain-services @immutable/ped-stream-sdk-integrations-list
+/packages/config/ @immutable/ped-engineering-blockchain-list @immutable/ped-stream-sdk-integrations-list
 
 # Blockchain Services
-/packages/internal/metrics/ @immutable/blockchain-services
-/packages/internal/generated-clients/ @immutable/blockchain-services
+/packages/internal/metrics/ @immutable/ped-engineering-blockchain-list
+/packages/internal/generated-clients/ @immutable/ped-engineering-blockchain-list
 /packages/internal/generated-clients/src/blockchain-data/ @immutable/activation
-/packages/internal/toolkit/ @immutable/blockchain-services
-/packages/internal/cryptofiat/ @immutable/blockchain-services
+/packages/internal/toolkit/ @immutable/ped-engineering-blockchain-list
+/packages/internal/cryptofiat/ @immutable/ped-engineering-blockchain-list
 /packages/internal/dex/ @immutable/gamefi
-/packages/internal/bridge/ @immutable/rollups
-/packages/orderbook/ @immutable/blockchain-services
-/packages/passport/ @immutable/blockchain-services
-/packages/x-provider/ @immutable/blockchain-services
-/packages/checkout/ @immutable/blockchain-services
-/packages/checkout/widgets-lib/ @immutable/blockchain-services
-/packages/blockchain-data/ @immutable/blockchain-services
-/packages/minting-backend/ @shineli1984 @immutable/blockchain-services
-/packages/webhook/ @shineli1984 @immutable/blockchain-services
-/packages/game-bridge/ @immutable/gamesdk @immutable/blockchain-services
+/packages/internal/bridge/ @immutable/ped-engineering-blockchain-list
+/packages/orderbook/ @immutable/ped-engineering-blockchain-list
+/packages/passport/ @immutable/ped-engineering-blockchain-list
+/packages/x-provider/ @immutable/ped-engineering-blockchain-list
+/packages/checkout/ @immutable/ped-engineering-blockchain-list
+/packages/checkout/widgets-lib/ @immutable/ped-engineering-blockchain-list
+/packages/blockchain-data/ @immutable/ped-engineering-blockchain-list
+/packages/minting-backend/ @shineli1984 @immutable/ped-engineering-blockchain-list
+/packages/webhook/ @shineli1984 @immutable/ped-engineering-blockchain-list
+/packages/game-bridge/ @immutable/gamesdk @immutable/ped-engineering-blockchain-list
 
 # Ped Stream SDK Integrations List
 /packages/audience/ @immutable/ped-stream-sdk-integrations-list


### PR DESCRIPTION
Aligns CODEOWNERS with the new GitHub team structure (PLT-1330).

Mapping applied (only the entries present in this repo are changed):
- `core-engineering`, `sre` → `platform-engineering`
- `rollups`, `blockchain-services` → `ped-engineering-blockchain-list`
- `immutable/agents` → `ped-stream-agents-list`
- `distribution` (team removed) → `platform-engineering`

🤖 Generated with [Claude Code](https://claude.com/claude-code)