### PR TITLE
feat(audience): mirror server-side event validation client-side [SDK-679]

### DIFF
--- a/packages/audience/core/src/context.test.ts
+++ b/packages/audience/core/src/context.test.ts
@@ -29,4 +29,40 @@ describe('collectContext', () => {
     expect(typeof ctx.pageReferrer).toBe('string');
     expect(typeof ctx.pageTitle).toBe('string');
   });
+
+  describe('field length limits', () => {
+    // Backend maxLength: userAgent 512, pageReferrer/pageTitle 2048/256 -
+    // none of these were truncated before, so a real long value (a big query
+    // string on the referrer, an unusual UA string) could get the whole
+    // message rejected server-side.
+    it('truncates a userAgent longer than 512 chars', () => {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: 'x'.repeat(600),
+        configurable: true,
+      });
+
+      const ctx = collectContext();
+
+      expect(ctx.userAgent).toHaveLength(512);
+    });
+
+    it('truncates a pageReferrer longer than 2048 chars', () => {
+      Object.defineProperty(document, 'referrer', {
+        value: `https://example.com/?q=${'x'.repeat(2100)}`,
+        configurable: true,
+      });
+
+      const ctx = collectContext();
+
+      expect(ctx.pageReferrer).toHaveLength(2048);
+    });
+
+    it('truncates a pageTitle longer than 256 chars', () => {
+      document.title = 'x'.repeat(300);
+
+      const ctx = collectContext();
+
+      expect(ctx.pageTitle).toHaveLength(256);
+    });
+  });
 });

--- a/packages/audience/core/src/context.ts
+++ b/packages/audience/core/src/context.ts
@@ -1,8 +1,13 @@
 import type { EventContext } from './types';
 import { isBrowser } from './utils';
+import { truncate } from './validation';
 
 // WARNING: DO NOT CHANGE THE STRING BELOW. IT GETS REPLACED AT BUILD TIME.
 const SDK_VERSION = '__SDK_VERSION__';
+
+// Backend maxLength constraints from OAS for EventContext fields.
+const MAX_USER_AGENT_LENGTH = 512;
+const MAX_PAGE_FIELD_LENGTH = 2048; // pageUrl, pagePath, pageReferrer
 
 /**
  * Collect browser context for event payloads.
@@ -22,15 +27,15 @@ export function collectContext(
 
   if (!isBrowser()) return context;
 
-  context.userAgent = navigator.userAgent;
-  context.locale = navigator.language;
-  context.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  context.userAgent = truncate(navigator.userAgent, MAX_USER_AGENT_LENGTH);
+  context.locale = truncate(navigator.language);
+  context.timezone = truncate(Intl.DateTimeFormat().resolvedOptions().timeZone);
   context.screen = `${window.screen.width}x${window.screen.height}`;
   context.screenDensity = window.devicePixelRatio;
-  context.pageUrl = window.location.href;
-  context.pagePath = window.location.pathname;
-  context.pageReferrer = document.referrer;
-  context.pageTitle = document.title;
+  context.pageUrl = truncate(window.location.href, MAX_PAGE_FIELD_LENGTH);
+  context.pagePath = truncate(window.location.pathname, MAX_PAGE_FIELD_LENGTH);
+  context.pageReferrer = truncate(document.referrer, MAX_PAGE_FIELD_LENGTH);
+  context.pageTitle = truncate(document.title);
 
   return context;
 }

--- a/packages/audience/core/src/errors.ts
+++ b/packages/audience/core/src/errors.ts
@@ -69,10 +69,12 @@ export interface TransportResult {
  * - `'NETWORK_ERROR'`:fetch rejected before a response was received
  *                       (network failure, CORS, DNS, etc.).
  * - `'VALIDATION_REJECTED'`:backend returned 2xx but the body reported
- *                       `rejected > 0`, or the server returned a 4xx (non-429)
- *                       indicating the payload was malformed or unauthorised.
+ *                       `rejected > 0`, the server returned a 4xx (non-429)
+ *                       indicating the payload was malformed or unauthorised,
+ *                       or messages were dropped locally for exceeding the
+ *                       backend's timestamp window before ever being sent.
  *                       Terminal: retrying won't help, the messages were dropped
- *                       from the queue.
+ *                       from the queue. `status` is `0` for the locally-dropped case.
  * - `'RATE_LIMITED'`:server returned 429. The batch is retained and will
  *                       be retried after the backoff window (honoring
  *                       `Retry-After` when present).

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -37,7 +37,13 @@ export { TransportError, AudienceError } from './errors';
 export { MessageQueue } from './queue';
 export { collectContext } from './context';
 export {
-  isTimestampValid, isAliasValid, isPassportIdValid, truncate,
+  isTimestampValid,
+  isAliasValid,
+  isPassportIdValid,
+  isValidConsentLevel,
+  isValidIdentityType,
+  hasValue,
+  truncate,
 } from './validation';
 
 export { getOrCreateSessionId } from './session';

--- a/packages/audience/core/src/queue.test.ts
+++ b/packages/audience/core/src/queue.test.ts
@@ -144,6 +144,51 @@ describe('MessageQueue', () => {
     expect(queue.length).toBe(1);
   });
 
+  it('filters stale messages before a flush attempt, not just on restore', async () => {
+    // A message enqueued fresh can still go stale while waiting for a flush
+    // (offline, backoff, backgrounded tab) without the page ever reloading,
+    // so staleFilter has to run again here too, not only at construction.
+    const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue(okResult);
+    const onError = jest.fn();
+    const queue = createQueue(send, {
+      staleFilter: (m) => m.messageId === 'fresh',
+      onError,
+    });
+
+    queue.enqueue(makeMessage('fresh'));
+    queue.enqueue(makeMessage('stale'));
+    expect(queue.length).toBe(2);
+
+    await queue.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [, , payload] = send.mock.calls[0];
+    expect((payload as { messages: Message[] }).messages).toHaveLength(1);
+    expect((payload as { messages: Message[] }).messages[0].messageId).toBe('fresh');
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'VALIDATION_REJECTED',
+      status: 0,
+    }));
+  });
+
+  it('drops a batch that is entirely stale without attempting to send', async () => {
+    const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue(okResult);
+    const onError = jest.fn();
+    const queue = createQueue(send, {
+      staleFilter: () => false,
+      onError,
+    });
+
+    queue.enqueue(makeMessage('stale-1'));
+    queue.enqueue(makeMessage('stale-2'));
+
+    await queue.flush();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(queue.length).toBe(0);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'VALIDATION_REJECTED' }));
+  });
+
   it('does not flush concurrently', async () => {
     let resolveFirst: () => void;
     const firstCall = new Promise<TransportResult>((r) => { resolveFirst = () => r(okResult); });

--- a/packages/audience/core/src/queue.ts
+++ b/packages/audience/core/src/queue.ts
@@ -1,6 +1,6 @@
 import type { Message, BatchPayload } from './types';
 import type { HttpSend } from './transport';
-import { type AudienceError, invokeOnError, toAudienceError } from './errors';
+import { AudienceError, invokeOnError, toAudienceError } from './errors';
 import {
   BASE_URL, INGEST_PATH, FLUSH_INTERVAL_MS, FLUSH_SIZE,
 } from './config';
@@ -74,6 +74,8 @@ export class MessageQueue {
 
   private readonly onError?: (err: AudienceError) => void;
 
+  private readonly staleFilter?: (msg: Message) => boolean;
+
   private readonly storagePrefix?: string;
 
   private readonly endpointUrl: string;
@@ -97,11 +99,12 @@ export class MessageQueue {
     this.flushSize = options?.flushSize ?? FLUSH_SIZE;
     this.onFlush = options?.onFlush;
     this.onError = options?.onError;
+    this.staleFilter = options?.staleFilter;
     this.storagePrefix = options?.storagePrefix;
 
     const restored = (storage.getItem(STORAGE_KEY, this.storagePrefix) as Message[] | undefined) ?? [];
-    this.messages = options?.staleFilter
-      ? restored.filter(options.staleFilter)
+    this.messages = this.staleFilter
+      ? restored.filter(this.staleFilter)
       : restored;
   }
 
@@ -147,6 +150,27 @@ export class MessageQueue {
 
     this.flushing = true;
     try {
+      // Messages can go stale while queued (offline, backoff, backgrounded
+      // tab) without ever going through a restore, which is the only other
+      // place staleFilter runs. Re-check here so a batch isn't sent only to
+      // be rejected for a timestamp that was fine when it was enqueued.
+      if (this.staleFilter) {
+        const before = this.messages.length;
+        this.messages = this.messages.filter(this.staleFilter);
+        const dropped = before - this.messages.length;
+        if (dropped > 0) {
+          this.persist();
+          invokeOnError(this.onError, new AudienceError({
+            code: 'VALIDATION_REJECTED',
+            message: `${dropped} queued message(s) exceeded the backend's accepted timestamp `
+              + 'window and were dropped without sending',
+            status: 0,
+            endpoint: this.endpointUrl,
+          }));
+        }
+        if (this.messages.length === 0) return;
+      }
+
       const batch = this.messages.slice(0, MAX_BATCH_SIZE);
       const payload: BatchPayload = { messages: batch };
 

--- a/packages/audience/core/src/validation.test.ts
+++ b/packages/audience/core/src/validation.test.ts
@@ -2,6 +2,9 @@ import {
   isTimestampValid,
   isAliasValid,
   isPassportIdValid,
+  isValidConsentLevel,
+  isValidIdentityType,
+  hasValue,
   truncate,
   truncateSource,
 } from './validation';
@@ -38,15 +41,55 @@ describe('isTimestampValid', () => {
 
 describe('isAliasValid', () => {
   it('returns true when from and to differ', () => {
-    expect(isAliasValid('steam_123', 'steam', 'user@example.com', 'email')).toBe(true);
+    expect(isAliasValid('steam_123', 'user@example.com')).toBe(true);
   });
 
-  it('returns true when same ID but different type', () => {
-    expect(isAliasValid('123', 'steam', '123', 'email')).toBe(true);
+  it('returns false when the same ID is used even with different identity types', () => {
+    // Matches the backend: identityType is not a factor, only the ids are compared.
+    expect(isAliasValid('123', '123')).toBe(false);
   });
 
   it('returns false when from and to are identical', () => {
-    expect(isAliasValid('user@example.com', 'email', 'user@example.com', 'email')).toBe(false);
+    expect(isAliasValid('user@example.com', 'user@example.com')).toBe(false);
+  });
+});
+
+describe('isValidConsentLevel', () => {
+  it.each(['none', 'anonymous', 'full'])('accepts %s', (level) => {
+    expect(isValidConsentLevel(level)).toBe(true);
+  });
+
+  it('rejects an unrecognised level', () => {
+    expect(isValidConsentLevel('not_set')).toBe(false);
+  });
+});
+
+describe('isValidIdentityType', () => {
+  it.each(['passport', 'steam', 'epic', 'google', 'apple', 'discord', 'email', 'custom'])('accepts %s', (type) => {
+    expect(isValidIdentityType(type)).toBe(true);
+  });
+
+  it('rejects an unrecognised type', () => {
+    expect(isValidIdentityType('myspace')).toBe(false);
+  });
+});
+
+describe('hasValue', () => {
+  it('accepts a non-empty string', () => {
+    expect(hasValue('abc')).toBe(true);
+  });
+
+  it('rejects an empty string', () => {
+    expect(hasValue('')).toBe(false);
+  });
+
+  it('rejects a whitespace-only string', () => {
+    expect(hasValue('   ')).toBe(false);
+  });
+
+  it('rejects undefined and null', () => {
+    expect(hasValue(undefined)).toBe(false);
+    expect(hasValue(null)).toBe(false);
   });
 });
 

--- a/packages/audience/core/src/validation.ts
+++ b/packages/audience/core/src/validation.ts
@@ -1,3 +1,5 @@
+import { IdentityType } from './types';
+
 const MAX_FUTURE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const MAX_PAST_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
@@ -29,15 +31,32 @@ export function isPassportIdValid(id: string): boolean {
 }
 
 /**
- * Validate that alias from and to are not the same identity.
+ * Validate that alias from and to are not the same identity. Matches the
+ * backend: only the ids are compared, identityType is not a factor.
  */
-export function isAliasValid(
-  fromId: string,
-  fromType: string,
-  toId: string,
-  toType: string,
-): boolean {
-  return fromId !== toId || fromType !== toType;
+export function isAliasValid(fromId: string, toId: string): boolean {
+  return fromId !== toId;
+}
+
+const CONSENT_LEVELS: ReadonlySet<string> = new Set(['none', 'anonymous', 'full']);
+const IDENTITY_TYPES: ReadonlySet<string> = new Set(Object.values(IdentityType));
+
+/** Validate that a consent level is one the backend recognises. */
+export function isValidConsentLevel(value: string): boolean {
+  return CONSENT_LEVELS.has(value);
+}
+
+/** Validate that an identity type is one the backend recognises. */
+export function isValidIdentityType(value: string): boolean {
+  return IDENTITY_TYPES.has(value);
+}
+
+/**
+ * Matches the backend's MISSING_REQUIRED_FIELD check: empty or
+ * whitespace-only counts as missing.
+ */
+export function hasValue(value: string | undefined | null): boolean {
+  return typeof value === 'string' && value.trim() !== '';
 }
 
 /**

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -20,6 +20,7 @@ const mockEnqueue = jest.fn();
 const mockStart = jest.fn();
 const mockDestroy = jest.fn();
 const mockGetOrCreateSessionId = jest.fn().mockReturnValue('session-abc');
+const mockIsValidConsentLevel = jest.fn().mockReturnValue(true);
 
 jest.mock('@imtbl/audience-core', () => ({
   MessageQueue: jest.fn().mockImplementation(() => ({
@@ -50,6 +51,7 @@ jest.mock('@imtbl/audience-core', () => ({
   setupAutocapture: (...args: unknown[]) => mockSetupAutocapture(...args),
   getOrCreateSessionId: (...args: unknown[]) => mockGetOrCreateSessionId(...args),
   startCmpDetection: (...args: unknown[]) => mockStartCmpDetection(...args),
+  isValidConsentLevel: (...args: [string]) => mockIsValidConsentLevel(...args),
   createConsentManager: jest.fn().mockImplementation(
     (
       _send: unknown,
@@ -259,6 +261,18 @@ describe('Pixel', () => {
       // setConsent should have auto-fired the deferred initial page view
       const calls = mockEnqueue.mock.calls.map((c: unknown[]) => (c[0] as Record<string, unknown>));
       expect(calls.find((c) => c.type === 'page')).toBeDefined();
+    });
+
+    it('throws for an unrecognised consent level', () => {
+      const pixel = new Pixel();
+      activePixel = pixel;
+      pixel.init({ key: 'pk_imapik-test-local', consent: 'none' });
+
+      mockIsValidConsentLevel.mockReturnValueOnce(false);
+      expect(() => pixel.setConsent('bogus' as never)).toThrow(/unrecognised level/);
+
+      const calls = mockEnqueue.mock.calls.map((c: unknown[]) => (c[0] as Record<string, unknown>));
+      expect(calls.find((c) => c.type === 'page')).toBeUndefined();
     });
 
     it('fires deferred page view only once on repeated setConsent calls', () => {

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -20,7 +20,10 @@ import {
   canTrack,
   startCmpDetection,
   setupAutocapture,
+  isValidConsentLevel,
 } from '@imtbl/audience-core';
+
+const LOG_PREFIX = '[pixel]';
 
 // Replaced at build time by tsup `define` (see tsup.config.ts).
 // In tests the global isn't defined, so we fall back to 'unknown'.
@@ -149,8 +152,12 @@ export class Pixel {
     this.queue!.enqueue(message);
   }
 
+  /** Throws if `level` isn't a recognised consent level. */
   setConsent(level: ConsentLevel): void {
     if (!this.isReady()) return;
+    if (!isValidConsentLevel(level)) {
+      throw new Error(`${LOG_PREFIX} setConsent() called with unrecognised level "${level}".`);
+    }
     this.consent!.setLevel(level);
 
     // Fire the deferred page view if consent was upgraded from 'none'

--- a/packages/audience/sdk-sample-app/sample-app.js
+++ b/packages/audience/sdk-sample-app/sample-app.js
@@ -258,10 +258,6 @@
   var currentSessionId = null;
   var pendingQueueCount = 0;
 
-  // Set by the console mirror when the SDK rejects a passport id, so
-  // onIdentify() can tell a dropped call from one that went through.
-  var lastIdentifyRejected = false;
-
   function installConsoleMirror() {
     var originalLog = console.log.bind(console);
     var originalWarn = console.warn.bind(console);
@@ -287,7 +283,6 @@
       var msg = args[0].slice(11);
       var payload = args.length > 1 ? args[1] : undefined;
       harvestIds(payload);
-      if (msg.indexOf("doesn't look like a Passport ID") !== -1) lastIdentifyRejected = true;
       // Promote flush outcomes to ok/err so they stand out in the log.
       var flushMatch = msg.match(/^flush (ok|failed)/);
       if (flushMatch && flushMatch[1] === 'ok') { pendingQueueCount = 0; updateStatus(); }
@@ -823,12 +818,7 @@
     try { traits = parseTraits($('id-traits').value); }
     catch (err) { log('identify()', 'invalid traits JSON: ' + err.message, 'err'); return; }
     try {
-      lastIdentifyRejected = false;
       audience.identify(id, type, traits);
-      if (lastIdentifyRejected) {
-        log('identify()', 'dropped — invalid Passport ID (see warning above)', 'err');
-        return;
-      }
       enqueued();
       currentUserId = id;
       identityMirror.userId = id;
@@ -849,7 +839,8 @@
     var fromType = $('alias-from-type').value;
     var toId = $('alias-to-id').value.trim();
     var toType = $('alias-to-type').value;
-    if (!fromId || !toId || (fromId === toId && fromType === toType)) {
+    // Matches the SDK: ids alone decide equality, identityType isn't a factor.
+    if (!fromId || !toId || fromId === toId) {
       log('alias()', 'from and to must both be set and differ', 'err');
       return;
     }

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -722,6 +722,16 @@ describe('Audience', () => {
 
       sdk.shutdown();
     });
+
+    it('throws when the event name is empty', async () => {
+      const sdk = createSDK();
+
+      expect(() => sdk.track('')).toThrow(/empty event name/);
+      await sdk.flush();
+      expect(sentMessages().filter((m: any) => m.type === 'track')).toHaveLength(0);
+
+      sdk.shutdown();
+    });
   });
 
   describe('page', () => {
@@ -985,75 +995,49 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('warns and drops the call when identityType is passport but the id is not passport shaped', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('throws when identityType is passport but the id is not passport shaped', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.identify('12345', 'passport');
+      expect(() => sdk.identify('12345', 'passport')).toThrow(/doesn't look like a/);
       await sdk.flush();
-
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('doesn\'t look like a'));
       const ids = sentMessages().filter((m: any) => m.type === 'identify');
       expect(ids).toHaveLength(0);
 
-      warnSpy.mockRestore();
       sdk.shutdown();
     });
 
-    it('warns without needing debug mode enabled', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      const sdk = createSDK({ consent: 'full', debug: false });
-
-      sdk.identify('12345', 'passport');
-
-      expect(warnSpy).toHaveBeenCalled();
-
-      warnSpy.mockRestore();
-      sdk.shutdown();
-    });
-
-    it('does not persist userId after a dropped passport identify, so later track calls stay anonymous', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('does not persist userId after a rejected passport identify, so later track calls stay anonymous', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.identify('12345', 'passport');
+      expect(() => sdk.identify('12345', 'passport')).toThrow();
       sdk.track('sign_up', { method: 'email' });
       await sdk.flush();
 
       const trackMsg = sentMessages().find((m: any) => m.eventName === 'sign_up');
       expect(trackMsg.userId).toBeUndefined();
 
-      warnSpy.mockRestore();
       sdk.shutdown();
     });
 
-    it('does not warn for a passport shaped id', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('does not throw for a passport shaped id', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.identify('email|abc123', 'passport');
+      expect(() => sdk.identify('email|abc123', 'passport')).not.toThrow();
       await sdk.flush();
-
-      expect(warnSpy).not.toHaveBeenCalled();
       const msg = sentMessages().find((m: any) => m.type === 'identify');
       expect(msg).toBeDefined();
 
-      warnSpy.mockRestore();
       sdk.shutdown();
     });
 
-    it('does not warn for a bare UUID passport id', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('does not throw for a bare UUID passport id', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.identify('550e8400-e29b-41d4-a716-446655440000', 'passport');
+      expect(() => sdk.identify('550e8400-e29b-41d4-a716-446655440000', 'passport')).not.toThrow();
       await sdk.flush();
-
-      expect(warnSpy).not.toHaveBeenCalled();
       const msg = sentMessages().find((m: any) => m.type === 'identify');
       expect(msg).toBeDefined();
 
-      warnSpy.mockRestore();
       sdk.shutdown();
     });
 
@@ -1069,18 +1053,34 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('does not warn for non-passport identity types regardless of id shape', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('does not throw for non-passport identity types regardless of id shape', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.identify('12345', 'steam');
+      expect(() => sdk.identify('12345', 'steam')).not.toThrow();
       await sdk.flush();
-
-      expect(warnSpy).not.toHaveBeenCalled();
       const msg = sentMessages().find((m: any) => m.type === 'identify');
       expect(msg).toBeDefined();
 
-      warnSpy.mockRestore();
+      sdk.shutdown();
+    });
+
+    it('throws when id is empty', async () => {
+      const sdk = createSDK({ consent: 'full' });
+
+      expect(() => sdk.identify('', 'steam')).toThrow(/empty id/);
+      await sdk.flush();
+      expect(sentMessages().filter((m: any) => m.type === 'identify')).toHaveLength(0);
+
+      sdk.shutdown();
+    });
+
+    it('throws when identityType is not recognised', async () => {
+      const sdk = createSDK({ consent: 'full' });
+
+      expect(() => sdk.identify('player-1', 'facebook' as never)).toThrow(/unrecognised identityType/);
+      await sdk.flush();
+      expect(sentMessages().filter((m: any) => m.type === 'identify')).toHaveLength(0);
+
       sdk.shutdown();
     });
   });
@@ -1104,13 +1104,13 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('rejects alias when from and to are identical', async () => {
+    it('throws when from and to are identical', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.alias(
+      expect(() => sdk.alias(
         { id: 'same_id', identityType: 'steam' },
         { id: 'same_id', identityType: 'steam' },
-      );
+      )).toThrow(/from and to are identical/);
       await sdk.flush();
 
       const aliases = sentMessages().filter((m: any) => m.type === 'alias');
@@ -1119,48 +1119,74 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('warns and drops the call when to.identityType is passport but to.id is not passport shaped', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('throws when the ids match even if identityType differs, matching the backend', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.alias(TEST_STEAM, { id: '12345', identityType: 'passport' });
+      expect(() => sdk.alias(
+        { id: 'same_id', identityType: 'steam' },
+        { id: 'same_id', identityType: 'email' },
+      )).toThrow(/from and to are identical/);
       await sdk.flush();
 
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('doesn\'t look like a'));
       const aliases = sentMessages().filter((m: any) => m.type === 'alias');
       expect(aliases).toHaveLength(0);
 
-      warnSpy.mockRestore();
       sdk.shutdown();
     });
 
-    it('warns and drops the call when from.identityType is passport but from.id is not passport shaped', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('throws when from.id or to.id is empty', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.alias({ id: '12345', identityType: 'passport' }, TEST_STEAM);
+      expect(() => sdk.alias({ id: '', identityType: 'steam' }, TEST_USER)).toThrow(/empty from.id or to.id/);
       await sdk.flush();
+      expect(sentMessages().filter((m: any) => m.type === 'alias')).toHaveLength(0);
 
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('doesn\'t look like a'));
+      sdk.shutdown();
+    });
+
+    it('throws when either identityType is not recognised', async () => {
+      const sdk = createSDK({ consent: 'full' });
+
+      expect(() => sdk.alias({ id: 'fb-id', identityType: 'facebook' as never }, TEST_USER))
+        .toThrow(/unrecognised identityType/);
+      await sdk.flush();
+      expect(sentMessages().filter((m: any) => m.type === 'alias')).toHaveLength(0);
+
+      sdk.shutdown();
+    });
+
+    it('throws when to.identityType is passport but to.id is not passport shaped', async () => {
+      const sdk = createSDK({ consent: 'full' });
+
+      expect(() => sdk.alias(TEST_STEAM, { id: '12345', identityType: 'passport' }))
+        .toThrow(/doesn't look like a/);
+      await sdk.flush();
       const aliases = sentMessages().filter((m: any) => m.type === 'alias');
       expect(aliases).toHaveLength(0);
 
-      warnSpy.mockRestore();
       sdk.shutdown();
     });
 
-    it('does not warn when the passport side has a passport-shaped id', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('throws when from.identityType is passport but from.id is not passport shaped', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.alias(TEST_STEAM, { id: 'email|abc123', identityType: 'passport' });
+      expect(() => sdk.alias({ id: '12345', identityType: 'passport' }, TEST_STEAM))
+        .toThrow(/doesn't look like a/);
       await sdk.flush();
+      const aliases = sentMessages().filter((m: any) => m.type === 'alias');
+      expect(aliases).toHaveLength(0);
 
-      expect(warnSpy).not.toHaveBeenCalled();
+      sdk.shutdown();
+    });
+
+    it('does not throw when the passport side has a passport-shaped id', async () => {
+      const sdk = createSDK({ consent: 'full' });
+
+      expect(() => sdk.alias(TEST_STEAM, { id: 'email|abc123', identityType: 'passport' })).not.toThrow();
+      await sdk.flush();
       const msg = sentMessages().find((m: any) => m.type === 'alias');
       expect(msg).toBeDefined();
 
-      warnSpy.mockRestore();
       sdk.shutdown();
     });
 
@@ -1176,18 +1202,15 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
-    it('does not warn when neither side is passport, regardless of id shape', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it('does not throw when neither side is passport, regardless of id shape', async () => {
       const sdk = createSDK({ consent: 'full' });
 
-      sdk.alias({ id: '12345', identityType: 'steam' }, { id: '67890', identityType: 'epic' });
+      expect(() => sdk.alias({ id: '12345', identityType: 'steam' }, { id: '67890', identityType: 'epic' }))
+        .not.toThrow();
       await sdk.flush();
-
-      expect(warnSpy).not.toHaveBeenCalled();
       const msg = sentMessages().find((m: any) => m.type === 'alias');
       expect(msg).toBeDefined();
 
-      warnSpy.mockRestore();
       sdk.shutdown();
     });
 
@@ -1221,13 +1244,13 @@ describe('Audience', () => {
       const sdk = createSDK({ consent: 'full' });
 
       // Valid — should type-check.
-      sdk.identify('player-1', 'passport', { plan: 'premium' });
+      sdk.identify('email|player-1', 'passport', { plan: 'premium' });
 
       // @ts-expect-error — 'facebook' is not a valid IdentityType literal.
-      sdk.identify('player-2', 'facebook');
+      expect(() => sdk.identify('player-2', 'facebook')).toThrow();
 
       // @ts-expect-error — arbitrary strings are rejected.
-      sdk.identify('player-3', 'not-a-real-type' as string);
+      expect(() => sdk.identify('player-3', 'not-a-real-type' as string)).toThrow();
 
       sdk.shutdown();
     });
@@ -1238,20 +1261,29 @@ describe('Audience', () => {
       // Valid.
       sdk.alias(
         { id: 'steam-id', identityType: 'steam' },
-        { id: 'passport-id', identityType: 'passport' },
+        { id: 'email|passport-id', identityType: 'passport' },
       );
 
       // @ts-expect-error — 'facebook' is not a valid IdentityType.
-      sdk.alias(
+      expect(() => sdk.alias(
         { id: 'fb-id', identityType: 'facebook' },
-        { id: 'passport-id', identityType: 'passport' },
-      );
+        { id: 'email|passport-id', identityType: 'passport' },
+      )).toThrow();
 
       sdk.shutdown();
     });
   });
 
   describe('setConsent', () => {
+    it('throws for an unrecognised consent level', async () => {
+      const sdk = createSDK({ consent: 'none' });
+
+      expect(() => sdk.setConsent('bogus' as never)).toThrow(/unrecognised level/);
+      expect(document.cookie).not.toContain(`${COOKIE_NAME}=`);
+
+      sdk.shutdown();
+    });
+
     it('is a no-op when setting the same level', async () => {
       const sdk = createSDK({ consent: 'full' });
       await sdk.flush();

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -22,6 +22,9 @@ import {
   isAliasValid,
   isTimestampValid,
   isPassportIdValid,
+  isValidConsentLevel,
+  isValidIdentityType,
+  hasValue,
   truncate,
   collectContext,
   collectSessionAttribution,
@@ -48,15 +51,18 @@ const UTM_EVENTS: ReadonlySet<string> = new Set([
   'sign_up', 'link_clicked',
 ]);
 
-// Bypasses the debug gate: a caller bug, not routine noise. The sample app
-// string-matches "doesn't look like a Passport ID" to detect a drop — keep
-// that phrase if this wording changes.
-function warnMalformedPassportId(method: string, typeLabel: string, idLabel: string, id: string): void {
-  // eslint-disable-next-line no-console
-  console.warn(
-    `${LOG_PREFIX} ${method} called with ${typeLabel} 'passport' but ${idLabel} "${id}" doesn't look `
+// Thrown so a caller bug can't be missed the way a console warning can be.
+function invalidCall(message: string): never {
+  throw new Error(`${LOG_PREFIX} ${message}`);
+}
+
+// The sample app string-matches "doesn't look like a Passport ID" to detect
+// this failure — keep that phrase if this wording changes.
+function invalidPassportId(method: string, typeLabel: string, idLabel: string, id: string): never {
+  invalidCall(
+    `${method} called with ${typeLabel} 'passport' but ${idLabel} "${id}" doesn't look `
     + 'like a Passport ID (expected a format like "email|123" or a UUID). Check you\'re passing '
-    + 'the Passport user ID, not your own internal user ID. Call ignored.',
+    + 'the Passport user ID, not your own internal user ID.',
   );
 }
 
@@ -291,7 +297,7 @@ export class Audience {
    * `sign_up` and `link_clicked` events automatically include the UTM
    * attribution captured at session start. All events include `sessionId`.
    *
-   * No-op when consent is 'none'.
+   * No-op when consent is 'none'. Throws if the event name is empty.
    */
   track<E extends AudienceEventName | string & {}>(
     event: E,
@@ -300,6 +306,7 @@ export class Audience {
       : [properties: PropsFor<E>]
   ): void {
     if (this.isTrackingDisabled()) return;
+    if (!hasValue(event)) invalidCall('track() called with an empty event name.');
     this.refreshSession();
 
     const [properties] = args;
@@ -327,17 +334,20 @@ export class Audience {
    * `sdk.identify('user@example.com', 'email', { name: 'Jane' })`
    *
    * Requires 'full' consent. When `identityType` is `'passport'`, the id must
-   * look like a real Passport id (`connection|id` or a UUID) — otherwise the
-   * call is dropped and a warning is logged.
+   * look like a real Passport id (`connection|id` or a UUID) — otherwise this
+   * throws.
    */
   identify(id: string, identityType: IdentityType, traits?: UserTraits): void {
     if (!canIdentify(this.consent.level)) {
       this.debug.logWarning('identify() requires full consent — call ignored.');
       return;
     }
+    if (!hasValue(id)) invalidCall('identify() called with an empty id.');
+    if (!isValidIdentityType(identityType)) {
+      invalidCall(`identify() called with unrecognised identityType "${identityType}".`);
+    }
     if (identityType === IdentityType.Passport && !isPassportIdValid(id)) {
-      warnMalformedPassportId('identify()', 'identityType', 'id', id);
-      return;
+      invalidPassportId('identify()', 'identityType', 'id', id);
     }
     this.refreshSession();
 
@@ -360,7 +370,7 @@ export class Audience {
    *
    * Requires 'full' consent. `from` and `to` must differ. When either side's
    * `identityType` is `'passport'`, that side's id must look like a real
-   * Passport id (`connection|id` or a UUID) — otherwise the call is dropped.
+   * Passport id (`connection|id` or a UUID) — otherwise this throws.
    */
   alias(
     from: { id: string; identityType: IdentityType },
@@ -370,17 +380,22 @@ export class Audience {
       this.debug.logWarning('alias() requires full consent — call ignored.');
       return;
     }
-    if (!isAliasValid(from.id, from.identityType, to.id, to.identityType)) {
-      this.debug.logWarning('alias() from and to are identical — call ignored.');
-      return;
+    if (!hasValue(from.id) || !hasValue(to.id)) {
+      invalidCall('alias() called with an empty from.id or to.id.');
+    }
+    if (!isValidIdentityType(from.identityType) || !isValidIdentityType(to.identityType)) {
+      invalidCall(
+        `alias() called with an unrecognised identityType ("${from.identityType}"/"${to.identityType}").`,
+      );
+    }
+    if (!isAliasValid(from.id, to.id)) {
+      invalidCall('alias() from and to are identical.');
     }
     if (from.identityType === IdentityType.Passport && !isPassportIdValid(from.id)) {
-      warnMalformedPassportId('alias()', 'from.identityType', 'from.id', from.id);
-      return;
+      invalidPassportId('alias()', 'from.identityType', 'from.id', from.id);
     }
     if (to.identityType === IdentityType.Passport && !isPassportIdValid(to.id)) {
-      warnMalformedPassportId('alias()', 'to.identityType', 'to.id', to.id);
-      return;
+      invalidPassportId('alias()', 'to.identityType', 'to.id', to.id);
     }
     this.refreshSession();
 
@@ -403,8 +418,13 @@ export class Audience {
    * - 'none': all tracking stops, cookies are cleared.
    * - 'anonymous': track activity without knowing who the player is.
    * - 'full': track everything including player identity.
+   *
+   * Throws if `level` isn't one of the above.
    */
   setConsent(level: ConsentLevel): void {
+    if (!isValidConsentLevel(level)) {
+      invalidCall(`setConsent() called with unrecognised level "${level}".`);
+    }
     const privacySignalActive = detectDoNotTrack();
     const effective: ConsentLevel = privacySignalActive ? 'none' : level;
 


### PR DESCRIPTION
## Summary

Ticket: [SDK-679](https://linear.app/imtbl/issue/SDK-679/mirror-server-side-event-validation-in-the-sdks)

Brings client-side validation in `@imtbl/audience` and `@imtbl/pixel` to parity with the ingest API. Invalid calls (bad id, wrong identity type, unrecognised consent level, etc.) now throw immediately instead of dropping silently with a console warning that's easy to miss in normal development; valid calls are unaffected and still enqueue as before. The passport-ID format check already covered part of this scope (predates this PR); this closes the rest.

| Gap | Before | After |
|---|---|---|
| `alias()` equality check | Only rejected when the id *and* `identityType` both matched | Throws when the ids match alone — matches the backend exactly |
| Empty required fields (`track()`'s event name, `identify()`'s id, `alias()`'s ids) | Only enforced by TypeScript's compile-time types — doesn't stop an empty string from a loosely-typed or non-TS caller | Throws at runtime |
| `identityType`/`fromType`/`toType`, consent level | Only enforced by TypeScript's compile-time types | Throws at runtime against the backend's accepted values |
| Queued message timestamps | Re-checked only once, when the queue restores from localStorage on page load | Re-checked before every flush attempt, so a message that goes stale while queued (offline, backoff, backgrounded tab) is dropped locally instead of sent and rejected |
| `collectContext()` fields (`userAgent`, `pageUrl`, `pagePath`, `pageReferrer`, `pageTitle`) | Never truncated — a long query string in `pageUrl` was a realistic way to get a message rejected server-side | Truncated to the backend's limits |

The two rows above the divider are the ones that changed from warn-and-drop to throw. The bottom two (stale queued messages, context field truncation) have no synchronous caller to throw to — those still report via `onError`/truncate silently, unchanged.

Also fixed the sample app (`sdk-sample-app`): its own `onAlias()` had a duplicate pre-check hardcoding the *old* equality rule (id + type both had to match), and a `console.warn`-sniffing hack to detect a dropped `identify()` call. Both are gone now: the pre-check matches the current rule, and `identify()`/`alias()` failures are caught directly from the thrown error like any other SDK call.

## Test plan

- [x] `nx test` passes: core (278), sdk (108 + 5 CDN-artifact), pixel (51) — includes new coverage for every row above, converted from `console.warn` spies to `expect(...).toThrow()`
- [x] `nx lint` passes across core, sdk, pixel
- [x] `tsc --noEmit` (typecheck) passes across all three packages, including the pinned type-level invariants in `sdk.test-d.ts`
- [x] `nx build` passes across all three packages
- [ ] Verified in a running integration (not done here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)