### PR TITLE
feat(audience): validate required properties for reserved events at runtime

### DIFF
--- a/packages/audience/core/src/autocapture.test.ts
+++ b/packages/audience/core/src/autocapture.test.ts
@@ -317,8 +317,8 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'link_clicked',
         expect.objectContaining({
-          link_url: 'https://store.steampowered.com/app/12345',
-          link_text: 'Wishlist on Steam',
+          url: 'https://store.steampowered.com/app/12345',
+          label: 'Wishlist on Steam',
           element_id: 'steam-link',
           outbound: true,
         }),
@@ -395,7 +395,7 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'link_clicked',
         expect.objectContaining({
-          link_url: 'https://discord.gg/invite',
+          url: 'https://discord.gg/invite',
           outbound: true,
         }),
       );
@@ -425,7 +425,7 @@ describe('autocapture', () => {
       link.dispatchEvent(new Event('click', { bubbles: true }));
 
       const props = enqueue.mock.calls[0][1];
-      expect(props.link_text).toHaveLength(256);
+      expect(props.label).toHaveLength(256);
     });
 
     it('resolves clicks on child elements to nearest anchor', () => {
@@ -445,8 +445,8 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'link_clicked',
         expect.objectContaining({
-          link_url: 'https://store.steampowered.com/app/12345',
-          link_text: 'Click me',
+          url: 'https://store.steampowered.com/app/12345',
+          label: 'Click me',
           outbound: true,
         }),
       );
@@ -517,8 +517,8 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'link_clicked',
         expect.objectContaining({
-          link_url: `${window.location.origin}/about`,
-          link_text: 'About Us',
+          url: `${window.location.origin}/about`,
+          label: 'About Us',
           element_id: 'about-link',
           outbound: false,
         }),
@@ -550,7 +550,7 @@ describe('autocapture', () => {
       expect(enqueue).toHaveBeenCalledWith(
         'link_clicked',
         expect.objectContaining({
-          link_text: 'Watch Trailer',
+          label: 'Watch Trailer',
           outbound: false,
         }),
       );
@@ -607,7 +607,7 @@ describe('autocapture', () => {
 
       link.dispatchEvent(new Event('click', { bubbles: true }));
 
-      expect(enqueue.mock.calls[0][1].link_text).toHaveLength(256);
+      expect(enqueue.mock.calls[0][1].label).toHaveLength(256);
     });
   });
 

--- a/packages/audience/core/src/autocapture.ts
+++ b/packages/audience/core/src/autocapture.ts
@@ -256,16 +256,16 @@ export function setupAutocapture(
         if (isOutbound && options.clicks !== false) {
           enqueue('link_clicked', {
             ...collectSessionAttribution(),
-            link_url: anchor.href,
-            link_text: (anchor.textContent || '').trim().slice(0, 256),
+            url: anchor.href,
+            label: (anchor.textContent || '').trim().slice(0, 256),
             element_id: anchor.id || undefined,
             outbound: true,
           });
         } else if (!isOutbound && options.internalClicks === true) {
           enqueue('link_clicked', {
             ...collectSessionAttribution(),
-            link_url: anchor.href,
-            link_text: (anchor.textContent || '').trim().slice(0, 256),
+            url: anchor.href,
+            label: (anchor.textContent || '').trim().slice(0, 256),
             element_id: anchor.id || undefined,
             outbound: false,
           });

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -85,7 +85,6 @@ export interface LinkClickedProperties {
   url: string;
   label?: string;
   source?: string;
-  game_id?: string;
   /** Only set by auto-capture. */
   element_id?: string;
   /** Only set by auto-capture. */

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -36,7 +36,8 @@ export interface WishlistRemoveProperties {
 
 export interface PurchaseProperties {
   currency: string;
-  value: number;
+  // String, not number: crypto amounts need precision a JS number can't hold.
+  value: string;
   item_id?: string;
   item_name?: string;
   quantity?: number;

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -85,6 +85,10 @@ export interface LinkClickedProperties {
   label?: string;
   source?: string;
   game_id?: string;
+  /** DOM id of the clicked element. Only set by auto-capture. */
+  element_id?: string;
+  /** Whether the link led off-site. Only set by auto-capture. */
+  outbound?: boolean;
 }
 
 export interface ButtonClickedProperties {
@@ -136,10 +140,7 @@ export const REQUIRED_EVENT_PROPS: Record<AudienceEventName, readonly string[]> 
   resource: ['flow', 'currency', 'amount'],
   email_acquired: [],
   game_page_viewed: ['game_id'],
-  // Deliberately empty: auto-capture's own link_clicked calls (autocapture.ts)
-  // send link_url/link_text, not url/label — a pre-existing type mismatch
-  // tracked separately, not fixed here.
-  link_clicked: [],
+  link_clicked: ['url'],
   button_clicked: [],
   achievement_unlocked: ['achievement_id', 'achievement_name'],
 };

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -85,9 +85,9 @@ export interface LinkClickedProperties {
   label?: string;
   source?: string;
   game_id?: string;
-  /** DOM id of the clicked element. Only set by auto-capture. */
+  /** Only set by auto-capture. */
   element_id?: string;
-  /** Whether the link led off-site. Only set by auto-capture. */
+  /** Only set by auto-capture. */
   outbound?: boolean;
 }
 

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -124,12 +124,27 @@ export type AudienceEventName = keyof EventPropsMap;
  * `Audience.track()`. `PropsFor`'s required/optional distinction only exists
  * at compile time; a caller can still bypass it (raw JS, an `any` cast, a
  * dynamically-built properties object), so this is checked again at the
- * call site. Events not listed here have no required properties.
+ * call site. `Record`, not `Partial`: every event must have an entry (`[]`
+ * if it has no required properties), so adding a new event to
+ * `EventPropsMap` without deciding what to list here fails to compile.
  */
-export const REQUIRED_EVENT_PROPS: Partial<Record<AudienceEventName, readonly string[]>> = {
+export const REQUIRED_EVENT_PROPS: Record<AudienceEventName, readonly string[]> = {
+  sign_up: [],
+  sign_in: [],
+  wishlist_add: ['game_id'],
+  wishlist_remove: ['game_id'],
   purchase: ['currency', 'value'],
+  game_launch: [],
   progression: ['status'],
   resource: ['flow', 'currency', 'amount'],
+  email_acquired: [],
+  game_page_viewed: ['game_id'],
+  // Not enforced: auto-capture's own link_clicked calls (autocapture.ts)
+  // send link_url/link_text, not url/label, so `url` isn't actually
+  // guaranteed present. Pre-existing mismatch between LinkClickedProperties
+  // and auto-capture's payload shape, tracked separately.
+  link_clicked: [],
+  button_clicked: [],
   achievement_unlocked: ['achievement_id', 'achievement_name'],
 };
 

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -120,6 +120,20 @@ interface EventPropsMap {
 export type AudienceEventName = keyof EventPropsMap;
 
 /**
+ * Required property names per reserved event, enforced at runtime by
+ * `Audience.track()`. `PropsFor`'s required/optional distinction only exists
+ * at compile time; a caller can still bypass it (raw JS, an `any` cast, a
+ * dynamically-built properties object), so this is checked again at the
+ * call site. Events not listed here have no required properties.
+ */
+export const REQUIRED_EVENT_PROPS: Partial<Record<AudienceEventName, readonly string[]>> = {
+  purchase: ['currency', 'value'],
+  progression: ['status'],
+  resource: ['flow', 'currency', 'amount'],
+  achievement_unlocked: ['achievement_id', 'achievement_name'],
+};
+
+/**
  * Event name → property type. Falls back to `Record<string, unknown>` for
  * unknown names. Used by `sdk.track()` to type-check property shapes at the
  * call site. Invariants pinned by `sdk.test-d.ts` — run it before simplifying.

--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -121,12 +121,9 @@ export type AudienceEventName = keyof EventPropsMap;
 
 /**
  * Required property names per reserved event, enforced at runtime by
- * `Audience.track()`. `PropsFor`'s required/optional distinction only exists
- * at compile time; a caller can still bypass it (raw JS, an `any` cast, a
- * dynamically-built properties object), so this is checked again at the
- * call site. `Record`, not `Partial`: every event must have an entry (`[]`
- * if it has no required properties), so adding a new event to
- * `EventPropsMap` without deciding what to list here fails to compile.
+ * `Audience.track()` (see `validateRequiredProps` in sdk.ts). `Record`, not
+ * `Partial`: every event needs an entry (`[]` if none are required), so a
+ * new event added to `EventPropsMap` without one fails to compile.
  */
 export const REQUIRED_EVENT_PROPS: Record<AudienceEventName, readonly string[]> = {
   sign_up: [],
@@ -139,10 +136,9 @@ export const REQUIRED_EVENT_PROPS: Record<AudienceEventName, readonly string[]> 
   resource: ['flow', 'currency', 'amount'],
   email_acquired: [],
   game_page_viewed: ['game_id'],
-  // Not enforced: auto-capture's own link_clicked calls (autocapture.ts)
-  // send link_url/link_text, not url/label, so `url` isn't actually
-  // guaranteed present. Pre-existing mismatch between LinkClickedProperties
-  // and auto-capture's payload shape, tracked separately.
+  // Deliberately empty: auto-capture's own link_clicked calls (autocapture.ts)
+  // send link_url/link_text, not url/label — a pre-existing type mismatch
+  // tracked separately, not fixed here.
   link_clicked: [],
   button_clicked: [],
   achievement_unlocked: ['achievement_id', 'achievement_name'],

--- a/packages/audience/sdk/src/sdk.test-d.ts
+++ b/packages/audience/sdk/src/sdk.test-d.ts
@@ -9,10 +9,10 @@ sdk.track('sign_in', { method: 'passport' });
 sdk.track('wishlist_add', { game_id: 'abc' });
 sdk.track('wishlist_add', { game_id: 'abc', source: 'game_page', platform: 'steam' });
 sdk.track('wishlist_remove', { game_id: 'abc' });
-sdk.track('purchase', { currency: 'USD', value: 9.99 });
+sdk.track('purchase', { currency: 'USD', value: '9.99' });
 sdk.track('purchase', {
   currency: 'USD',
-  value: 9.99,
+  value: '9.99',
   item_id: 'sku_1',
   item_name: 'Gold Pack',
   quantity: 2,
@@ -51,7 +51,7 @@ sdk.track('link_clicked', {
 });
 
 sdk.track(AudienceEvents.SIGN_UP, { method: 'email' });
-sdk.track(AudienceEvents.PURCHASE, { currency: 'USD', value: 9.99 });
+sdk.track(AudienceEvents.PURCHASE, { currency: 'USD', value: '9.99' });
 sdk.track(AudienceEvents.PROGRESSION, { status: 'complete' });
 sdk.track(AudienceEvents.ACHIEVEMENT_UNLOCKED, { achievement_id: 'first_win', achievement_name: 'First Win' });
 sdk.track('achievement_unlocked', { achievement_id: 'first_win', achievement_name: 'First Win' });
@@ -101,16 +101,16 @@ sdk.track('game_page_viewed');
 sdk.track('link_clicked');
 
 // @ts-expect-error — unknown property 'currenyc'
-sdk.track('purchase', { currenyc: 'USD', value: 9.99 });
+sdk.track('purchase', { currenyc: 'USD', value: '9.99' });
 
 // @ts-expect-error — unknown property 'extra'
-sdk.track('purchase', { currency: 'USD', value: 9.99, extra: 1 });
+sdk.track('purchase', { currency: 'USD', value: '9.99', extra: 1 });
 
 // @ts-expect-error — unknown property 'isLoggedIn'
 sdk.track('link_clicked', { url: 'x', isLoggedIn: true });
 
-// @ts-expect-error — 'value' must be number
-sdk.track('purchase', { currency: 'USD', value: '9.99' });
+// @ts-expect-error — 'value' must be a string
+sdk.track('purchase', { currency: 'USD', value: 9.99 });
 
 // @ts-expect-error — 'status' must be a ProgressionStatus
 sdk.track('progression', { status: 'done' });

--- a/packages/audience/sdk/src/sdk.test-d.ts
+++ b/packages/audience/sdk/src/sdk.test-d.ts
@@ -47,8 +47,10 @@ sdk.track('link_clicked', {
   url: 'https://example.com',
   label: 'Play Now',
   source: 'game_page',
-  game_id: 'abc',
 });
+
+// @ts-expect-error — unknown property 'game_id'
+sdk.track('link_clicked', { url: 'https://example.com', game_id: 'abc' });
 
 sdk.track(AudienceEvents.SIGN_UP, { method: 'email' });
 sdk.track(AudienceEvents.PURCHASE, { currency: 'USD', value: '9.99' });

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -294,7 +294,7 @@ describe('Audience', () => {
 
       sdk.track('purchase', {
         currency: 'USD',
-        value: 9.99,
+        value: '9.99',
         item_id: 'sword_01',
       });
 
@@ -309,7 +309,7 @@ describe('Audience', () => {
       expect(msg.sessionId).toEqual(expect.any(String));
       expect(msg.properties).toEqual({
         currency: 'USD',
-        value: 9.99,
+        value: '9.99',
         item_id: 'sword_01',
       });
       expect(msg.surface).toBe('web');
@@ -664,7 +664,7 @@ describe('Audience', () => {
       sessionStorage.clear();
 
       const sdk = createSDK();
-      sdk.track('purchase', { currency: 'USD', value: 9.99 });
+      sdk.track('purchase', { currency: 'USD', value: '9.99' });
       await sdk.flush();
 
       const msg = sentMessages().find(
@@ -674,7 +674,7 @@ describe('Audience', () => {
       expect(msg.sessionId).toEqual(expect.any(String));
       expect(msg.properties).toEqual({
         currency: 'USD',
-        value: 9.99,
+        value: '9.99',
       });
 
       sdk.shutdown();
@@ -701,7 +701,7 @@ describe('Audience', () => {
     it('picks up a session rollover on the next call instead of keeping a stale id', async () => {
       const sdk = createSDK();
 
-      sdk.track('purchase', { currency: 'USD', value: 1 });
+      sdk.track('purchase', { currency: 'USD', value: '1' });
       await sdk.flush();
       const firstSessionId = sentMessages().find(
         (m: any) => m.type === 'track' && m.eventName === 'purchase',
@@ -710,7 +710,7 @@ describe('Audience', () => {
       // Simulate the session cookie expiring (30 min idle) before the next call.
       document.cookie = `${SESSION_COOKIE}=;max-age=0;path=/`;
 
-      sdk.track('purchase', { currency: 'USD', value: 2 });
+      sdk.track('purchase', { currency: 'USD', value: '2' });
       await sdk.flush();
 
       const purchases = sentMessages().filter(
@@ -804,7 +804,7 @@ describe('Audience', () => {
       it('does not throw when all required properties are present', async () => {
         const sdk = createSDK();
 
-        expect(() => sdk.track('purchase', { currency: 'USD', value: 9.99 })).not.toThrow();
+        expect(() => sdk.track('purchase', { currency: 'USD', value: '9.99' })).not.toThrow();
         expect(() => sdk.track('progression', { status: 'start' })).not.toThrow();
         expect(() => sdk.track('resource', { flow: 'source', currency: 'gold', amount: 10 })).not.toThrow();
         expect(() => sdk.track('achievement_unlocked', {
@@ -994,7 +994,7 @@ describe('Audience', () => {
     it('stamps the anonymous consent level on every emitted message', async () => {
       const sdk = createSDK({ consent: 'anonymous' });
       sdk.page();
-      sdk.track('purchase', { currency: 'USD', value: 1 });
+      sdk.track('purchase', { currency: 'USD', value: '1' });
       await sdk.flush();
 
       const msgs = sentMessages();
@@ -1024,7 +1024,7 @@ describe('Audience', () => {
     it('leaves queued events with their capture-time consentLevel and userId on downgrade from full', async () => {
       const sdk = createSDK({ consent: 'full' });
       sdk.identify(TEST_USER.id, TEST_USER.identityType);
-      sdk.track('purchase', { currency: 'USD', value: 9.99 });
+      sdk.track('purchase', { currency: 'USD', value: '9.99' });
 
       sdk.setConsent('anonymous');
       await sdk.flush();
@@ -1046,7 +1046,7 @@ describe('Audience', () => {
     it('stamps sessionId at the top level on every message type, including identify and alias', async () => {
       const sdk = createSDK({ consent: 'full' });
       sdk.page();
-      sdk.track('purchase', { currency: 'USD', value: 1 });
+      sdk.track('purchase', { currency: 'USD', value: '1' });
       sdk.identify(TEST_USER.id, TEST_USER.identityType);
       sdk.alias(TEST_STEAM, TEST_USER);
       await sdk.flush();
@@ -1425,7 +1425,7 @@ describe('Audience', () => {
       expect(document.cookie).toContain(`${COOKIE_NAME}=`);
 
       sdk.identify(TEST_USER.id, TEST_USER.identityType);
-      sdk.track('purchase', { currency: 'USD', value: 9.99 });
+      sdk.track('purchase', { currency: 'USD', value: '9.99' });
       await sdk.flush();
 
       const trackMsg = sentMessages().find(
@@ -1461,7 +1461,7 @@ describe('Audience', () => {
 
       sdk.identify(TEST_USER.id, TEST_USER.identityType);
       sdk.alias(TEST_STEAM, TEST_USER);
-      sdk.track('purchase', { currency: 'USD', value: 9.99 });
+      sdk.track('purchase', { currency: 'USD', value: '9.99' });
 
       sdk.setConsent('anonymous');
       await sdk.flush();

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -819,6 +819,15 @@ describe('Audience', () => {
         sdk.shutdown();
       });
 
+      it('throws when link_clicked is missing url', async () => {
+        const sdk = createSDK();
+
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('link_clicked', {})).toThrow(/missing required property: url/);
+
+        sdk.shutdown();
+      });
+
       it('does not throw for events with no required properties', async () => {
         const sdk = createSDK();
 
@@ -827,9 +836,6 @@ describe('Audience', () => {
         expect(() => sdk.track('game_launch')).not.toThrow();
         expect(() => sdk.track('email_acquired')).not.toThrow();
         expect(() => sdk.track('button_clicked')).not.toThrow();
-        // link_clicked isn't enforced at runtime; see REQUIRED_EVENT_PROPS in events.ts.
-        // @ts-expect-error deliberately bypassing the compile-time check
-        expect(() => sdk.track('link_clicked', {})).not.toThrow();
 
         sdk.shutdown();
       });
@@ -1836,7 +1842,7 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.properties).toMatchObject({
-        link_url: 'https://store.steampowered.com/app/12345',
+        url: 'https://store.steampowered.com/app/12345',
         outbound: true,
       });
 

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -774,6 +774,33 @@ describe('Audience', () => {
         sdk.shutdown();
       });
 
+      it('throws when wishlist_add is missing game_id', async () => {
+        const sdk = createSDK();
+
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('wishlist_add', {})).toThrow(/missing required property: game_id/);
+
+        sdk.shutdown();
+      });
+
+      it('throws when wishlist_remove is missing game_id', async () => {
+        const sdk = createSDK();
+
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('wishlist_remove', {})).toThrow(/missing required property: game_id/);
+
+        sdk.shutdown();
+      });
+
+      it('throws when game_page_viewed is missing game_id', async () => {
+        const sdk = createSDK();
+
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('game_page_viewed', {})).toThrow(/missing required property: game_id/);
+
+        sdk.shutdown();
+      });
+
       it('does not throw when all required properties are present', async () => {
         const sdk = createSDK();
 
@@ -784,6 +811,27 @@ describe('Audience', () => {
           achievement_id: 'a1',
           achievement_name: 'First Steps',
         })).not.toThrow();
+        expect(() => sdk.track('wishlist_add', { game_id: 'abc' })).not.toThrow();
+        expect(() => sdk.track('wishlist_remove', { game_id: 'abc' })).not.toThrow();
+        expect(() => sdk.track('game_page_viewed', { game_id: 'abc' })).not.toThrow();
+        expect(() => sdk.track('link_clicked', { url: 'https://example.com' })).not.toThrow();
+
+        sdk.shutdown();
+      });
+
+      it('does not throw for events with no required properties', async () => {
+        const sdk = createSDK();
+
+        expect(() => sdk.track('sign_up')).not.toThrow();
+        expect(() => sdk.track('sign_in')).not.toThrow();
+        expect(() => sdk.track('game_launch')).not.toThrow();
+        expect(() => sdk.track('email_acquired')).not.toThrow();
+        expect(() => sdk.track('button_clicked')).not.toThrow();
+        // link_clicked's `url` isn't enforced at runtime (unlike its compile-time
+        // type): auto-capture's own calls (autocapture.ts) don't send it, see the
+        // comment on REQUIRED_EVENT_PROPS.link_clicked in events.ts.
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('link_clicked', {})).not.toThrow();
 
         sdk.shutdown();
       });

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -827,9 +827,7 @@ describe('Audience', () => {
         expect(() => sdk.track('game_launch')).not.toThrow();
         expect(() => sdk.track('email_acquired')).not.toThrow();
         expect(() => sdk.track('button_clicked')).not.toThrow();
-        // link_clicked's `url` isn't enforced at runtime (unlike its compile-time
-        // type): auto-capture's own calls (autocapture.ts) don't send it, see the
-        // comment on REQUIRED_EVENT_PROPS.link_clicked in events.ts.
+        // link_clicked isn't enforced at runtime; see REQUIRED_EVENT_PROPS in events.ts.
         // @ts-expect-error deliberately bypassing the compile-time check
         expect(() => sdk.track('link_clicked', {})).not.toThrow();
 

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -732,6 +732,70 @@ describe('Audience', () => {
 
       sdk.shutdown();
     });
+
+    describe('reserved event required properties', () => {
+      it('throws when purchase is missing currency and value', async () => {
+        const sdk = createSDK();
+
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('purchase', {})).toThrow(/missing required properties: currency, value/);
+        await sdk.flush();
+        expect(sentMessages().filter((m: any) => m.type === 'track')).toHaveLength(0);
+
+        sdk.shutdown();
+      });
+
+      it('throws when progression is missing status', async () => {
+        const sdk = createSDK();
+
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('progression', {})).toThrow(/missing required property: status/);
+
+        sdk.shutdown();
+      });
+
+      it('throws when resource is missing flow, currency, and amount', async () => {
+        const sdk = createSDK();
+
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('resource', {})).toThrow(/missing required properties: flow, currency, amount/);
+
+        sdk.shutdown();
+      });
+
+      it('throws when achievement_unlocked is missing achievement_id and achievement_name', async () => {
+        const sdk = createSDK();
+
+        // @ts-expect-error deliberately bypassing the compile-time check
+        expect(() => sdk.track('achievement_unlocked', {})).toThrow(
+          /missing required properties: achievement_id, achievement_name/,
+        );
+
+        sdk.shutdown();
+      });
+
+      it('does not throw when all required properties are present', async () => {
+        const sdk = createSDK();
+
+        expect(() => sdk.track('purchase', { currency: 'USD', value: 9.99 })).not.toThrow();
+        expect(() => sdk.track('progression', { status: 'start' })).not.toThrow();
+        expect(() => sdk.track('resource', { flow: 'source', currency: 'gold', amount: 10 })).not.toThrow();
+        expect(() => sdk.track('achievement_unlocked', {
+          achievement_id: 'a1',
+          achievement_name: 'First Steps',
+        })).not.toThrow();
+
+        sdk.shutdown();
+      });
+
+      it('does not validate unrecognised event names', async () => {
+        const sdk = createSDK();
+
+        expect(() => sdk.track('some_custom_event', {})).not.toThrow();
+
+        sdk.shutdown();
+      });
+    });
   });
 
   describe('page', () => {

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -312,8 +312,9 @@ export class Audience {
    * attribution captured at session start. All events include `sessionId`.
    *
    * No-op when consent is 'none'. Throws if the event name is empty, or if a
-   * reserved event (`purchase`, `progression`, `resource`,
-   * `achievement_unlocked`) is missing one of its required properties.
+   * reserved event with required properties (`wishlist_add`,
+   * `wishlist_remove`, `purchase`, `progression`, `resource`,
+   * `game_page_viewed`, `achievement_unlocked`) is missing one of them.
    */
   track<E extends AudienceEventName | string & {}>(
     event: E,

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -314,7 +314,8 @@ export class Audience {
    * No-op when consent is 'none'. Throws if the event name is empty, or if a
    * reserved event with required properties (`wishlist_add`,
    * `wishlist_remove`, `purchase`, `progression`, `resource`,
-   * `game_page_viewed`, `achievement_unlocked`) is missing one of them.
+   * `game_page_viewed`, `link_clicked`, `achievement_unlocked`) is missing
+   * one of them.
    */
   track<E extends AudienceEventName | string & {}>(
     event: E,

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -40,7 +40,7 @@ import {
 import { adoptAnonymousId, resolvePrivacySignal } from '@imtbl/audience-core/internal';
 import { track } from '@imtbl/metrics';
 import { DebugLogger } from './debug';
-import type { AudienceEventName, PropsFor } from './events';
+import { REQUIRED_EVENT_PROPS, type AudienceEventName, type PropsFor } from './events';
 import type { AudienceConfig } from './types';
 import {
   LIBRARY_NAME, LIBRARY_VERSION, LOG_PREFIX, DEFAULT_CONSENT_SOURCE,
@@ -64,6 +64,19 @@ function invalidPassportId(method: string, typeLabel: string, idLabel: string, i
     + 'like a Passport ID (expected a format like "email|123" or a UUID). Check you\'re passing '
     + 'the Passport user ID, not your own internal user ID.',
   );
+}
+
+// TypeScript enforces this shape at the call site, but only for callers who
+// go through the compiler; this closes the gap for anyone else (raw JS, an
+// `any` cast, a dynamically-built properties object).
+function validateRequiredProps(event: string, properties: Record<string, unknown> | undefined): void {
+  const required = REQUIRED_EVENT_PROPS[event as AudienceEventName];
+  if (!required) return;
+  const missing = required.filter((key) => properties?.[key] === undefined);
+  if (missing.length > 0) {
+    const plural = missing.length > 1 ? 'ies' : 'y';
+    invalidCall(`track('${event}', ...) is missing required propert${plural}: ${missing.join(', ')}.`);
+  }
 }
 
 /**
@@ -298,7 +311,9 @@ export class Audience {
    * `sign_up` and `link_clicked` events automatically include the UTM
    * attribution captured at session start. All events include `sessionId`.
    *
-   * No-op when consent is 'none'. Throws if the event name is empty.
+   * No-op when consent is 'none'. Throws if the event name is empty, or if a
+   * reserved event (`purchase`, `progression`, `resource`,
+   * `achievement_unlocked`) is missing one of its required properties.
    */
   track<E extends AudienceEventName | string & {}>(
     event: E,
@@ -308,9 +323,12 @@ export class Audience {
   ): void {
     if (this.isTrackingDisabled()) return;
     if (!hasValue(event)) invalidCall('track() called with an empty event name.');
-    this.refreshSession();
 
     const [properties] = args;
+    validateRequiredProps(event, properties as Record<string, unknown> | undefined);
+
+    this.refreshSession();
+
     const mergedProps: Record<string, unknown> = {
       ...(UTM_EVENTS.has(event) ? this.attribution : {}),
       ...properties as Record<string, unknown> | undefined,


### PR DESCRIPTION
## Summary

Ticket: [SDK-687](https://linear.app/imtbl/issue/SDK-687/define-required-properties-for-pre-definedreserved-events)

TypeScript already requires properties like `purchase`'s `currency`/`value` at compile time, but only for callers who go through the compiler. `track()` now enforces the same required properties at runtime (throwing, like an empty event name already does), and `REQUIRED_EVENT_PROPS` is exhaustive over all 13 reserved events so a future one can't be added without a decision recorded here.

Also fixes a bug this surfaced: auto-capture's `link_clicked` calls sent `link_url`/`link_text`, while the public type and every real manual caller (confirmed against Play's production code) used `url`/`label`. Auto-capture now matches the public type; confirmed with the data team since this changes a live wire format. Companion docs PR: [documentation#138](https://github.com/immutable/documentation/pull/138).

Two more changes while touching these types: `purchase.value` is now a `string` (a JS `number` can't precisely hold crypto-scale amounts; confirmed zero production `purchase` events exist yet and no consumer depends on the numeric shape, so this is zero-risk right now). And `link_clicked.game_id` is dropped — redundant with the `project_uuid` the ingest API already resolves server-side from the publishable key; confirmed 3 real Play call sites pass it today, companion Play PR removes them.

The ingest API side of this ticket, and pre-existing TS/Unity drift (`milestone_reached`, `purchase.currency` ISO-4217), are tracked separately.

| | Before | After |
|---|---|---|
| `track('purchase', {})` at runtime | Ships silently with missing fields if TypeScript is bypassed | Throws, listing exactly which required properties are missing |
| A new reserved event added later | No reminder to add runtime validation | `REQUIRED_EVENT_PROPS` must have an entry or the build fails |
| Auto-captured `link_clicked` | Sent `link_url`/`link_text`, unenforced | Sends `url`/`label` matching the public type, now enforced |
| `purchase.value` | `number` | `string`, for crypto-precision amounts |
| `link_clicked.game_id` | Client-supplied, duplicate of server-resolved project identity | Removed |

## Test plan

- [x] `nx test`, `nx lint`, `nx build` all pass for `@imtbl/audience`, `@imtbl/audience-core`, and `@imtbl/pixel`
- [x] New/updated tests cover: missing required properties throws per validated event (including `link_clicked`), all-required-properties-present does not throw, events with no required properties never throw, unrecognised event names are never validated, auto-capture's link/form tests updated to assert `url`/`label`, `purchase.value` type-checked as a string everywhere, `link_clicked.game_id` now a compile error

🤖 Generated with [Claude Code](https://claude.com/claude-code)