### PR TITLE
feat(audience): capture Reddit click IDs [SDK-697]

### DIFF
--- a/packages/audience/core/src/attribution.test.ts
+++ b/packages/audience/core/src/attribution.test.ts
@@ -31,7 +31,7 @@ describe('collectSessionAttribution', () => {
 
   it('parses ad network click IDs', () => {
     setLocation(
-      'https://example.com/?gclid=abc&dclid=dc1&fbclid=fb2&ttclid=tt3&msclkid=ms4&li_fat_id=li5',
+      'https://example.com/?gclid=abc&dclid=dc1&fbclid=fb2&ttclid=tt3&rdt_cid=rdt4&msclkid=ms5&li_fat_id=li6',
     );
 
     const result = collectSessionAttribution();
@@ -39,8 +39,9 @@ describe('collectSessionAttribution', () => {
     expect(result.dclid).toBe('dc1');
     expect(result.fbclid).toBe('fb2');
     expect(result.ttclid).toBe('tt3');
-    expect(result.msclkid).toBe('ms4');
-    expect(result.li_fat_id).toBe('li5');
+    expect(result.rdt_cid).toBe('rdt4');
+    expect(result.msclkid).toBe('ms5');
+    expect(result.li_fat_id).toBe('li6');
   });
 
   it('captures referrer and landing page', () => {

--- a/packages/audience/core/src/attribution.ts
+++ b/packages/audience/core/src/attribution.ts
@@ -11,6 +11,7 @@ const CLICK_ID_PARAMS = [
   'dclid',
   'fbclid',
   'ttclid',
+  'rdt_cid',
   'msclkid',
   'li_fat_id',
 ] as const;
@@ -27,6 +28,7 @@ export interface Attribution {
   dclid?: string;
   fbclid?: string;
   ttclid?: string;
+  rdt_cid?: string;
   msclkid?: string;
   li_fat_id?: string;
   referral_code?: string;


### PR DESCRIPTION
## Summary
- Capture the `rdt_cid` query parameter in shared Audience SDK attribution data.
- Treat `rdt_cid` as a click identifier so landing-page events are marked `touchpoint_type: click`.
- Add coverage for parsing and preserving Reddit click IDs.

## Before / after

**Before:** A game-page visit from a Reddit ad discarded `rdt_cid`; the Audience event had no Reddit click identifier and was not marked as an ad-click solely because of that parameter.

**After:** The Audience SDK retains `rdt_cid` in event properties and treats it as click attribution. The Attribution service can use it to identify a Reddit touchpoint once SDK-697's service-side change is deployed.

## Test plan
- [x] `cd packages/audience/core && pnpm test -- attribution.test.ts`
- [x] `cd packages/audience/core && pnpm lint`
- [x] `cd packages/audience/core && pnpm typecheck`
