### PR TITLE
chore(ci): skip functional tests for audience-only changes

### DIFF
--- a/.github/workflows/flows.md
+++ b/.github/workflows/flows.md
@@ -1,13 +1,13 @@
 ## PR / Merge Group
 
-Runs on every PR and merge queue entry. All jobs are automated — no manual gate.
+Runs on every PR and merge queue entry. Functional tests are skipped when all changed files are under `packages/audience/`. All jobs are automated - no manual gate.
 
 ```mermaid
 flowchart LR
     PR([Pull Request\nor Merge Group]) --> sync[Syncpack\ndependency alignment]
     PR --> blt[Build · Lint · Test\nSDK packages]
     PR --> ex[Build · Lint · Test\nExamples]
-    PR --> func[Functional Tests\nSepolia · zkEVM testnet]
+    PR --> func[Functional Tests\nexcept audience-only changes]
     PR --> ab[Audience Bundle\nSize Check]
     PR --> pb[Pixel Bundle\nSize Check]
     PR --> tv[Title Validation\nconventional commits]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -123,8 +123,37 @@ jobs:
         shell: bash
         run: pnpm test:examples
 
+  should-run-functional-tests:
+    name: Determine whether functional tests are needed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should-run: ${{ steps.changed-files.outputs.should-run }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check changed files
+        id: changed-files
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qv '^packages/audience/'; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   func-tests:
     name: Functional tests
+    if: needs.should-run-functional-tests.outputs.should-run == 'true'
+    needs: should-run-functional-tests
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- skip the zkEVM functional-test job when all changed files are under `packages/audience/`
- apply the same decision to pull requests, merge-queue entries, and pushes to `main`
- document the audience-only exception in the workflow overview

## Test plan
- [x] Parsed `.github/workflows/pr.yaml` with Ruby YAML
- [x] Checked the diff for whitespace errors
- [ ] Confirm GitHub Actions skips the functional-test job on an audience-only PR