### PR TITLE
fix(audience): trim crypto mention from purchase.value comment

### DIFF
--- a/packages/audience/sdk/src/events.ts
+++ b/packages/audience/sdk/src/events.ts
@@ -36,7 +36,7 @@ export interface WishlistRemoveProperties {
 
 export interface PurchaseProperties {
   currency: string;
-  // String, not number: crypto amounts need precision a JS number can't hold.
+  // String, not number: avoids floating-point precision loss.
   value: string;
   item_id?: string;
   item_name?: string;


### PR DESCRIPTION
## Summary

Follow-up to [#2907](https://github.com/immutable/ts-immutable-sdk/pull/2907) (already merged): that PR's `purchase.value` comment mentioned "crypto amounts" as the reason for using a string. This SDK is mainly used by web2 games, so trimmed to the underlying reason (floating-point precision loss) without calling out crypto specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)