### PR TITLE
docs(audience): fix stale audience docs and sample app event catalogue [SDK-701] 

### DIFF
--- a/packages/audience/pixel/README.md
+++ b/packages/audience/pixel/README.md
@@ -81,11 +81,11 @@ All events fire automatically with no instrumentation required.
 
 | Event | When it fires | Key properties |
 |-------|--------------|----------------|
-| `page` | Every page load | UTMs, click IDs (`gclid`, `fbclid`, `ttclid`, `msclkid`, `dclid`, `li_fat_id`), `referral_code`, `landing_page` |
+| `page` | Every page load | UTMs, click IDs (`gclid`, `fbclid`, `ttclid`, `rdt_cid`, `msclkid`, `dclid`, `li_fat_id`), `referral_code`, `landing_page` |
 | `session_start` | New session (no active `_imtbl_sid` cookie) | `session_id` |
 | `session_end` | Page unload (`visibilitychange` / `pagehide`) | `session_id`, `duration` (seconds) |
 | `form_submitted` | HTML form submission | `form_action`, `form_id`, `form_name`, `field_names`. `email_hash` at `full` consent only. |
-| `link_clicked` | Outbound link click (external domains only) | `link_url`, `link_text`, `element_id`, `outbound: true`, plus session attribution (UTMs, click IDs) |
+| `link_clicked` | Outbound link click (external domains only) | `url`, `label`, `element_id`, `outbound: true`, plus session attribution (UTMs, click IDs) |
 | `button_clicked` | Button or `input[type=button\|submit\|reset]` click. Off by default (set `"autocapture":{"buttons":true}` to enable). | `button_text`, `element_id`, `element_type`. Submit buttons inside a `<form>` are skipped (the form's own `form_submitted` already covers that interaction). |
 | `scroll_depth` | Scroll milestone reached (25%, 50%, 75%, 90%, 100%) | `depth` (integer). Fires on standard document scroll or on any internal scroll container larger than half the viewport. Milestones reset on each `page` call. |
 

--- a/packages/audience/sdk-sample-app/README.md
+++ b/packages/audience/sdk-sample-app/README.md
@@ -59,7 +59,7 @@ first-class environment and must be reached via explicit override.
 
 ## `AudienceEvents` catalogue
 
-These are the 11 predefined event names and their typed property shapes.
+These are the 13 predefined event names and their typed property shapes.
 Both the CDN bundle and the ESM package expose them:
 
 ```ts
@@ -71,7 +71,7 @@ const { AudienceEvents } = window.ImmutableAudience;
 
 audience.track(AudienceEvents.PURCHASE, {
   currency: 'USD',
-  value: 9.99,
+  value: '9.99',
   item_id: 'sword',
   transaction_id: 'tx_123',
 });
@@ -94,7 +94,9 @@ picked up yet, the event log shows a `drift warn` entry.
 | `resource` | `flow: 'sink' \| 'source'`, `currency`, `amount` | `item_type`, `item_id` |
 | `email_acquired` | - | `source` |
 | `game_page_viewed` | `game_id` | `game_name`, `slug` |
-| `link_clicked` | `url` | `label`, `source`, `game_id` |
+| `link_clicked` | `url` | `label`, `source` |
+| `button_clicked` | - | `button_text`, `element_id`, `element_type` |
+| `achievement_unlocked` | `achievement_id`, `achievement_name` | `achievement_type` |
 
 Pass anything else as a custom event with the `string & {}` escape hatch:
 

--- a/packages/audience/sdk-sample-app/sample-app.js
+++ b/packages/audience/sdk-sample-app/sample-app.js
@@ -28,7 +28,7 @@
     { name: 'wishlist_remove',  fields: [{ key: 'game_id', type: 'string' }] },
     { name: 'purchase',         fields: [
       { key: 'currency', type: 'string' },
-      { key: 'value', type: 'number' },
+      { key: 'value', type: 'string' },
       { key: 'item_id', type: 'string', optional: true },
       { key: 'item_name', type: 'string', optional: true },
       { key: 'quantity', type: 'number', optional: true },
@@ -63,7 +63,16 @@
       { key: 'url', type: 'string' },
       { key: 'label', type: 'string', optional: true },
       { key: 'source', type: 'string', optional: true },
-      { key: 'game_id', type: 'string', optional: true },
+    ] },
+    { name: 'button_clicked',   fields: [
+      { key: 'button_text', type: 'string', optional: true },
+      { key: 'element_id', type: 'string', optional: true },
+      { key: 'element_type', type: 'string', optional: true },
+    ] },
+    { name: 'achievement_unlocked', fields: [
+      { key: 'achievement_id', type: 'string' },
+      { key: 'achievement_name', type: 'string' },
+      { key: 'achievement_type', type: 'enum', optional: true, values: ['onboarding', 'progression', 'mastery', 'social', 'collection'] },
     ] },
   ];
 

--- a/packages/audience/sdk/README.md
+++ b/packages/audience/sdk/README.md
@@ -34,7 +34,7 @@ const audience = Audience.init({
 });
 
 audience.page();
-audience.track('purchase', { currency: 'USD', value: 9.99 });
+audience.track('purchase', { currency: 'USD', value: '9.99' });
 audience.identify('user@example.com', 'email', { name: 'Jane' });
 audience.setConsent('full');
 
@@ -51,7 +51,7 @@ configure it.
 
 | Event | When it fires | Key properties |
 |-------|--------------|----------------|
-| `link_clicked` | Outbound link click (external domains only) | `link_url`, `link_text`, `element_id`, `outbound: true`, plus session attribution (UTMs, click IDs) |
+| `link_clicked` | Outbound link click (external domains only) | `url`, `label`, `element_id`, `outbound: true`, plus session attribution (UTMs, click IDs) |
 | `form_submitted` | HTML form submission | `form_action`, `form_id`, `form_name`, `field_names`. `email_hash` at `full` consent only. |
 | `button_clicked` | Button or `input[type=button\|submit\|reset]` click. Off by default (pass `autocapture: { buttons: true }` to enable). | `button_text`, `element_id`, `element_type`. Submit buttons inside a `<form>` are skipped (the form's own `form_submitted` already covers that interaction). |
 | `scroll_depth` | Scroll milestone reached (25%, 50%, 75%, 90%, 100%) | `depth` (integer). Resets on each `page()` call. |
@@ -79,7 +79,7 @@ const audience = Audience.init({
     onError: (err) => console.error(err.code, err.message),
   });
   audience.page();
-  audience.track(AudienceEvents.PURCHASE, { currency: 'USD', value: 9.99 });
+  audience.track(AudienceEvents.PURCHASE, { currency: 'USD', value: '9.99' });
 </script>
 ```
 


### PR DESCRIPTION
Three package READMEs still referenced pre-rename property names, a stale number type for purchase.value, and a missing Reddit click ID, and the sample app's own event catalogue was missing two events entirely (silencing its own drift-detection warning) plus sending purchase.value as a number instead of a string.

Linear: https://linear.app/imtbl/issue/SDK-701/improve-webunity-sdk-docs-for-auto-trackedcaptured-data
Related: immutable/documentation#140 (fixes the same rdt_cid/property-name drift on the docs site)