### PR TITLE
feat(audience): add paid traffic network detection [SDK-710]

### DIFF
--- a/packages/audience/core/src/attribution.test.ts
+++ b/packages/audience/core/src/attribution.test.ts
@@ -1,4 +1,14 @@
-import { collectSessionAttribution, collectPageAttribution, clearAttribution } from './attribution';
+import {
+  collectSessionAttribution,
+  collectPageAttribution,
+  clearAttribution,
+  getAttributionNetwork,
+  isPaidMeta,
+  isPaidTikTok,
+  isPaidGoogle,
+  isPaidReddit,
+  isPaidX,
+} from './attribution';
 
 const STORAGE_KEY = '__imtbl_attribution';
 
@@ -31,7 +41,8 @@ describe('collectSessionAttribution', () => {
 
   it('parses ad network click IDs', () => {
     setLocation(
-      'https://example.com/?gclid=abc&dclid=dc1&fbclid=fb2&ttclid=tt3&rdt_cid=rdt4&msclkid=ms5&li_fat_id=li6',
+      'https://example.com/?gclid=abc&dclid=dc1&fbclid=fb2&ttclid=tt3'
+      + '&rdt_cid=rdt4&msclkid=ms5&li_fat_id=li6&twclid=tw7',
     );
 
     const result = collectSessionAttribution();
@@ -42,6 +53,7 @@ describe('collectSessionAttribution', () => {
     expect(result.rdt_cid).toBe('rdt4');
     expect(result.msclkid).toBe('ms5');
     expect(result.li_fat_id).toBe('li6');
+    expect(result.twclid).toBe('tw7');
   });
 
   it('captures referrer and landing page', () => {
@@ -175,5 +187,80 @@ describe('clearAttribution', () => {
 
     clearAttribution();
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('getAttributionNetwork', () => {
+  it.each([
+    ['facebook', 'meta'],
+    ['instagram', 'meta'],
+    ['meta', 'meta'],
+    ['fb', 'meta'],
+    ['ig', 'meta'],
+    ['FACEBOOK', 'meta'],
+    ['tiktok', 'tiktok'],
+    ['google', 'google'],
+    ['reddit', 'reddit'],
+    ['x', 'x'],
+    ['twitter', 'x'],
+  ])('classifies utm_source=%s as %s', (source, expected) => {
+    setLocation(`https://example.com/?utm_source=${source}`);
+    expect(getAttributionNetwork()).toBe(expected);
+  });
+
+  it.each([
+    ['fbclid', 'meta'],
+    ['ttclid', 'tiktok'],
+    ['gclid', 'google'],
+    ['dclid', 'google'],
+    ['rdt_cid', 'reddit'],
+    ['twclid', 'x'],
+  ])('classifies %s presence as %s regardless of utm_source', (param, expected) => {
+    setLocation(`https://example.com/?${param}=123`);
+    expect(getAttributionNetwork()).toBe(expected);
+  });
+
+  it.each(['msclkid', 'li_fat_id'])('classifies %s presence as other', (param) => {
+    setLocation(`https://example.com/?${param}=123`);
+    expect(getAttributionNetwork()).toBe('other');
+  });
+
+  it('classifies no params as organic', () => {
+    setLocation('https://example.com/');
+    expect(getAttributionNetwork()).toBe('organic');
+  });
+
+  it('classifies an unrecognised utm_source as organic', () => {
+    setLocation('https://example.com/?utm_source=newsletter');
+    expect(getAttributionNetwork()).toBe('organic');
+  });
+});
+
+describe('isPaid* helpers', () => {
+  it('isPaidMeta reflects getAttributionNetwork', () => {
+    setLocation('https://example.com/?utm_source=facebook');
+    expect(isPaidMeta()).toBe(true);
+    expect(isPaidTikTok()).toBe(false);
+  });
+
+  it('isPaidTikTok reflects getAttributionNetwork', () => {
+    setLocation('https://example.com/?ttclid=abc');
+    expect(isPaidTikTok()).toBe(true);
+    expect(isPaidMeta()).toBe(false);
+  });
+
+  it('isPaidGoogle reflects getAttributionNetwork', () => {
+    setLocation('https://example.com/?gclid=abc');
+    expect(isPaidGoogle()).toBe(true);
+  });
+
+  it('isPaidReddit reflects getAttributionNetwork', () => {
+    setLocation('https://example.com/?utm_source=reddit');
+    expect(isPaidReddit()).toBe(true);
+  });
+
+  it('isPaidX reflects getAttributionNetwork', () => {
+    setLocation('https://example.com/?twclid=abc');
+    expect(isPaidX()).toBe(true);
   });
 });

--- a/packages/audience/core/src/attribution.ts
+++ b/packages/audience/core/src/attribution.ts
@@ -14,6 +14,7 @@ const CLICK_ID_PARAMS = [
   'rdt_cid',
   'msclkid',
   'li_fat_id',
+  'twclid',
 ] as const;
 
 const STORAGE_KEY = '__imtbl_attribution';
@@ -31,6 +32,7 @@ export interface Attribution {
   rdt_cid?: string;
   msclkid?: string;
   li_fat_id?: string;
+  twclid?: string;
   referral_code?: string;
   referrer?: string;
   landing_page?: string;
@@ -129,4 +131,78 @@ export function clearAttribution(): void {
   } catch {
     // noop
   }
+}
+
+/**
+ * The ad network a visit is attributed to, derived from `utm_source` and
+ * ad-network click IDs on the current URL. Mirrors the network taxonomy
+ * used by Immutable's server-side attribution pipeline so client- and
+ * server-classified traffic agree on the same names.
+ */
+export type AttributionNetwork = 'meta' | 'tiktok' | 'google' | 'reddit' | 'x' | 'organic' | 'other';
+
+const META_SOURCES = ['facebook', 'instagram', 'meta', 'fb', 'ig'];
+const X_SOURCES = ['x', 'twitter'];
+
+/**
+ * Classifies the current page load's traffic source from `utm_source` and
+ * ad-network click IDs on the URL (e.g. `fbclid`, `ttclid`, `gclid`).
+ *
+ * @returns The matched network, `'organic'` when no UTM or click ID is
+ * present, or `'other'` when a recognised click ID (e.g. `msclkid`,
+ * `li_fat_id`) doesn't map to a named network.
+ * @example
+ * // https://example.com/?utm_source=facebook
+ * getAttributionNetwork(); // 'meta'
+ */
+export function getAttributionNetwork(): AttributionNetwork {
+  if (typeof window === 'undefined' || !window.location) return 'organic';
+
+  const params = new URLSearchParams(window.location.search);
+  const source = params.get('utm_source')?.toLowerCase();
+
+  if (META_SOURCES.includes(source ?? '') || params.has('fbclid')) {
+    return 'meta';
+  }
+  if (source === 'tiktok' || params.has('ttclid')) {
+    return 'tiktok';
+  }
+  if (source === 'google' || params.has('gclid') || params.has('dclid')) {
+    return 'google';
+  }
+  if (source === 'reddit' || params.has('rdt_cid')) {
+    return 'reddit';
+  }
+  if (X_SOURCES.includes(source ?? '') || params.has('twclid')) {
+    return 'x';
+  }
+  if (params.has('msclkid') || params.has('li_fat_id')) {
+    return 'other';
+  }
+  return 'organic';
+}
+
+/** @returns Whether the current visit is attributed to paid Meta (Facebook/Instagram) traffic. */
+export function isPaidMeta(): boolean {
+  return getAttributionNetwork() === 'meta';
+}
+
+/** @returns Whether the current visit is attributed to paid TikTok traffic. */
+export function isPaidTikTok(): boolean {
+  return getAttributionNetwork() === 'tiktok';
+}
+
+/** @returns Whether the current visit is attributed to paid Google traffic. */
+export function isPaidGoogle(): boolean {
+  return getAttributionNetwork() === 'google';
+}
+
+/** @returns Whether the current visit is attributed to paid Reddit traffic. */
+export function isPaidReddit(): boolean {
+  return getAttributionNetwork() === 'reddit';
+}
+
+/** @returns Whether the current visit is attributed to paid X (Twitter) traffic. */
+export function isPaidX(): boolean {
+  return getAttributionNetwork() === 'x';
 }

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -50,8 +50,17 @@ export {
 
 export { getOrCreateSessionId } from './session';
 
-export { collectSessionAttribution, collectPageAttribution } from './attribution';
-export type { Attribution } from './attribution';
+export {
+  collectSessionAttribution,
+  collectPageAttribution,
+  getAttributionNetwork,
+  isPaidMeta,
+  isPaidTikTok,
+  isPaidGoogle,
+  isPaidReddit,
+  isPaidX,
+} from './attribution';
+export type { Attribution, AttributionNetwork } from './attribution';
 
 export { collectThirdPartyIds } from './thirdPartyIds';
 

--- a/packages/audience/pixel/README.md
+++ b/packages/audience/pixel/README.md
@@ -81,7 +81,7 @@ All events fire automatically with no instrumentation required.
 
 | Event | When it fires | Key properties |
 |-------|--------------|----------------|
-| `page` | Every page load | UTMs, click IDs (`gclid`, `fbclid`, `ttclid`, `rdt_cid`, `msclkid`, `dclid`, `li_fat_id`), `referral_code`, `landing_page` |
+| `page` | Every page load | UTMs, click IDs (`gclid`, `fbclid`, `ttclid`, `rdt_cid`, `msclkid`, `dclid`, `li_fat_id`, `twclid`), `referral_code`, `landing_page` |
 | `session_start` | New session (no active `_imtbl_sid` cookie) | `session_id` |
 | `session_end` | Page unload (`visibilitychange` / `pagehide`) | `session_id`, `duration` (seconds) |
 | `form_submitted` | HTML form submission | `form_action`, `form_id`, `form_name`, `field_names`. `email_hash` at `full` consent only. |

--- a/packages/audience/sdk/src/index.ts
+++ b/packages/audience/sdk/src/index.ts
@@ -5,10 +5,16 @@ export {
   canTrack,
   canIdentify,
   AudienceError,
+  getAttributionNetwork,
+  isPaidMeta,
+  isPaidTikTok,
+  isPaidGoogle,
+  isPaidReddit,
+  isPaidX,
 } from '@imtbl/audience-core';
 export type { ImmutableAudienceGlobal } from './cdn';
 export type { AudienceConfig } from './types';
-export type { AudienceErrorCode, AutocaptureOptions } from '@imtbl/audience-core';
+export type { AudienceErrorCode, AutocaptureOptions, AttributionNetwork } from '@imtbl/audience-core';
 export type {
   AchievementType,
   AchievementUnlockedProperties,


### PR DESCRIPTION
https://linear.app/imtbl/issue/SDK-710/extract-metatiktok-paid-traffic-detection-into-ts-immutable-sdk

Extracts the hardcoded Meta/TikTok UTM and click-ID checks from play's pixel.ts into a shared getAttributionNetwork() classifier, plus isPaidMeta/isPaidTikTok/isPaidGoogle/isPaidReddit/isPaidX helpers. Mirrors platform-services' server-side attribution network taxonomy so client- and server-classified traffic agree on the same names. Also adds twclid to the tracked click-ID params, since X had no click-ID fallback (the same gap TikTok had before ttclid was already tracked).