### PR TITLE
fix(audience): require paid utm_medium alongside utm_source [SDK-710]

### DIFF
--- a/packages/audience/core/src/attribution.test.ts
+++ b/packages/audience/core/src/attribution.test.ts
@@ -203,10 +203,18 @@ describe('getAttributionNetwork', () => {
     ['reddit', 'reddit'],
     ['x', 'x'],
     ['twitter', 'x'],
-  ])('classifies utm_source=%s as %s', (source, expected) => {
-    setLocation(`https://example.com/?utm_source=${source}`);
+  ])('classifies utm_source=%s with a paid utm_medium as %s', (source, expected) => {
+    setLocation(`https://example.com/?utm_source=${source}&utm_medium=cpc`);
     expect(getAttributionNetwork()).toBe(expected);
   });
+
+  it.each(['cpc', 'ppc', 'paid', 'paid_social', 'paidsocial', 'CPC'])(
+    'treats utm_medium=%s as a paid medium',
+    (medium) => {
+      setLocation(`https://example.com/?utm_source=facebook&utm_medium=${medium}`);
+      expect(getAttributionNetwork()).toBe('meta');
+    },
+  );
 
   it.each([
     ['fbclid', 'meta'],
@@ -215,7 +223,7 @@ describe('getAttributionNetwork', () => {
     ['dclid', 'google'],
     ['rdt_cid', 'reddit'],
     ['twclid', 'x'],
-  ])('classifies %s presence as %s regardless of utm_source', (param, expected) => {
+  ])('classifies %s presence as %s regardless of utm_source or utm_medium', (param, expected) => {
     setLocation(`https://example.com/?${param}=123`);
     expect(getAttributionNetwork()).toBe(expected);
   });
@@ -231,16 +239,34 @@ describe('getAttributionNetwork', () => {
   });
 
   it('classifies an unrecognised utm_source as organic', () => {
-    setLocation('https://example.com/?utm_source=newsletter');
+    setLocation('https://example.com/?utm_source=newsletter&utm_medium=cpc');
     expect(getAttributionNetwork()).toBe('organic');
   });
+
+  it('classifies utm_source alone without utm_medium as organic', () => {
+    setLocation('https://example.com/?utm_source=facebook');
+    expect(getAttributionNetwork()).toBe('organic');
+  });
+
+  it.each(['organic', 'social', 'referral', 'email'])(
+    'classifies a matching utm_source with non-paid utm_medium=%s as organic',
+    (medium) => {
+      setLocation(`https://example.com/?utm_source=facebook&utm_medium=${medium}`);
+      expect(getAttributionNetwork()).toBe('organic');
+    },
+  );
 });
 
 describe('isPaid* helpers', () => {
   it('isPaidMeta reflects getAttributionNetwork', () => {
-    setLocation('https://example.com/?utm_source=facebook');
+    setLocation('https://example.com/?utm_source=facebook&utm_medium=paid_social');
     expect(isPaidMeta()).toBe(true);
     expect(isPaidTikTok()).toBe(false);
+  });
+
+  it('isPaidMeta is false for organic Meta-sourced traffic', () => {
+    setLocation('https://example.com/?utm_source=facebook&utm_medium=organic');
+    expect(isPaidMeta()).toBe(false);
   });
 
   it('isPaidTikTok reflects getAttributionNetwork', () => {
@@ -255,7 +281,7 @@ describe('isPaid* helpers', () => {
   });
 
   it('isPaidReddit reflects getAttributionNetwork', () => {
-    setLocation('https://example.com/?utm_source=reddit');
+    setLocation('https://example.com/?utm_source=reddit&utm_medium=paid');
     expect(isPaidReddit()).toBe(true);
   });
 

--- a/packages/audience/core/src/attribution.ts
+++ b/packages/audience/core/src/attribution.ts
@@ -134,10 +134,10 @@ export function clearAttribution(): void {
 }
 
 /**
- * The ad network a visit is attributed to, derived from `utm_source` and
- * ad-network click IDs on the current URL. Mirrors the network taxonomy
- * used by Immutable's server-side attribution pipeline so client- and
- * server-classified traffic agree on the same names.
+ * The ad network a visit is attributed to, derived from `utm_source` /
+ * `utm_medium` and ad-network click IDs on the current URL. Mirrors the
+ * network taxonomy used by Immutable's server-side attribution pipeline
+ * so client- and server-classified traffic agree on the same names.
  */
 export type AttributionNetwork = 'meta' | 'tiktok' | 'google' | 'reddit' | 'x' | 'organic' | 'other';
 
@@ -145,35 +145,58 @@ const META_SOURCES = ['facebook', 'instagram', 'meta', 'fb', 'ig'];
 const X_SOURCES = ['x', 'twitter'];
 
 /**
- * Classifies the current page load's traffic source from `utm_source` and
- * ad-network click IDs on the URL (e.g. `fbclid`, `ttclid`, `gclid`).
+ * `utm_medium` values that indicate paid traffic. A `utm_source` match
+ * alone isn't sufficient to call a visit "paid" — e.g. `utm_source=facebook`
+ * also covers an organic post shared on Facebook — so the medium must
+ * corroborate paid intent unless a network click ID is present.
+ */
+const PAID_MEDIUMS = ['cpc', 'ppc', 'paid', 'paid_social', 'paidsocial'];
+
+function isPaidSourceMatch(source: string | undefined, medium: string | undefined, sources: string[]): boolean {
+  return sources.includes(source ?? '') && PAID_MEDIUMS.includes(medium ?? '');
+}
+
+/**
+ * Classifies the current page load's traffic source from `utm_source` /
+ * `utm_medium` and ad-network click IDs on the URL (e.g. `fbclid`,
+ * `ttclid`, `gclid`). A network click ID is treated as paid on its own;
+ * a bare `utm_source` match additionally requires `utm_medium` to be a
+ * paid value (see {@link PAID_MEDIUMS}), so organic traffic tagged with
+ * e.g. `utm_source=facebook&utm_medium=organic` isn't misclassified as paid.
  *
  * @returns The matched network, `'organic'` when no UTM or click ID is
  * present, or `'other'` when a recognised click ID (e.g. `msclkid`,
  * `li_fat_id`) doesn't map to a named network.
  * @example
- * // https://example.com/?utm_source=facebook
+ * // https://example.com/?utm_source=facebook&utm_medium=paid_social
  * getAttributionNetwork(); // 'meta'
+ * @example
+ * // https://example.com/?utm_source=facebook&utm_medium=organic
+ * getAttributionNetwork(); // 'organic'
+ * @example
+ * // https://example.com/?fbclid=abc123
+ * getAttributionNetwork(); // 'meta' — click ID alone is a sufficient paid signal
  */
 export function getAttributionNetwork(): AttributionNetwork {
   if (typeof window === 'undefined' || !window.location) return 'organic';
 
   const params = new URLSearchParams(window.location.search);
   const source = params.get('utm_source')?.toLowerCase();
+  const medium = params.get('utm_medium')?.toLowerCase();
 
-  if (META_SOURCES.includes(source ?? '') || params.has('fbclid')) {
+  if (params.has('fbclid') || isPaidSourceMatch(source, medium, META_SOURCES)) {
     return 'meta';
   }
-  if (source === 'tiktok' || params.has('ttclid')) {
+  if (params.has('ttclid') || isPaidSourceMatch(source, medium, ['tiktok'])) {
     return 'tiktok';
   }
-  if (source === 'google' || params.has('gclid') || params.has('dclid')) {
+  if (params.has('gclid') || params.has('dclid') || isPaidSourceMatch(source, medium, ['google'])) {
     return 'google';
   }
-  if (source === 'reddit' || params.has('rdt_cid')) {
+  if (params.has('rdt_cid') || isPaidSourceMatch(source, medium, ['reddit'])) {
     return 'reddit';
   }
-  if (X_SOURCES.includes(source ?? '') || params.has('twclid')) {
+  if (params.has('twclid') || isPaidSourceMatch(source, medium, X_SOURCES)) {
     return 'x';
   }
   if (params.has('msclkid') || params.has('li_fat_id')) {


### PR DESCRIPTION
https://linear.app/imtbl/issue/SDK-710/extract-metatiktok-paid-traffic-detection-into-ts-immutable-sdk

getAttributionNetwork() previously classified any utm_source matching a known platform name (e.g. "facebook") as that paid network, even when utm_medium indicated organic traffic (e.g. a shared post). This meant isPaidMeta()/isPaidTikTok()/etc. could fire live ad-account conversions for non-paid visits.

Now a bare utm_source match additionally requires utm_medium to be a paid value (cpc, ppc, paid, paid_social, paidsocial), matching hub's existing resolveUtmChannel() convention. Ad-network click IDs (fbclid, ttclid, gclid, etc.) remain a sufficient paid signal on their own, regardless of utm_medium.