### PR TITLE
ci: speed up PR and merge queue validation

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,15 +1,22 @@
 name: "Setup"
-description: "Bootstrap NX SHAs, pnpm, and Node.js — callers own their pnpm install step"
+description: "Bootstrap NX SHAs, pnpm, Node.js, and optionally install dependencies"
 
 inputs:
   enable-cache:
     description: "Whether to cache the pnpm store. Set to 'false' for publish jobs to ensure a clean install."
+    default: "true"
+  run-install:
+    description: "Whether to run pnpm install after setting up Node/pnpm."
+    default: "true"
+  nx-set-shas:
+    description: "Whether to derive NX_BASE/NX_HEAD via nrwl/nx-set-shas (needs fetch-depth: 0)."
     default: "true"
 
 runs:
   using: "composite"
   steps:
     - name: Derive appropriate SHAs for base and head for `nx affected` commands
+      if: inputs.nx-set-shas == 'true'
       uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # pin@v5.0.1
 
     - name: Setup pnpm
@@ -22,3 +29,7 @@ runs:
         registry-url: https://registry.npmjs.org/
         cache: ${{ inputs.enable-cache == 'true' && 'pnpm' || '' }}
 
+    - name: Install dependencies
+      if: inputs.run-install == 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/audience-bundle-size.yaml
+++ b/.github/workflows/audience-bundle-size.yaml
@@ -41,10 +41,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Read budget config
         id: budget
         shell: bash

--- a/.github/workflows/build-game-bridge.yaml
+++ b/.github/workflows/build-game-bridge.yaml
@@ -65,10 +65,6 @@ jobs:
         with:
           enable-cache: "false"
 
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Set TS SDK hash
         shell: bash
         run: echo "TS_SDK_HASH=$(git rev-parse HEAD)" >> "$GITHUB_ENV"

--- a/.github/workflows/deploy-audience-cdn.yaml
+++ b/.github/workflows/deploy-audience-cdn.yaml
@@ -37,10 +37,6 @@ jobs:
         with:
           enable-cache: "false"
 
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Build audience SDK bundle
         shell: bash
         run: pnpm --filter @imtbl/audience... build

--- a/.github/workflows/deploy-audience-cdn.yaml
+++ b/.github/workflows/deploy-audience-cdn.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - "packages/audience/sdk/**"
       - "packages/audience/core/**"
+      - ".github/workflows/deploy-audience-cdn.yaml"
+    paths-ignore:
+      - "**/*.md"
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/deploy-pixel-cdn.yaml
+++ b/.github/workflows/deploy-pixel-cdn.yaml
@@ -37,10 +37,6 @@ jobs:
         with:
           enable-cache: "false"
 
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Build pixel bundle
         shell: bash
         run: pnpm --filter @imtbl/pixel build

--- a/.github/workflows/deploy-pixel-cdn.yaml
+++ b/.github/workflows/deploy-pixel-cdn.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - "packages/audience/pixel/**"
       - "packages/audience/core/**"
+      - ".github/workflows/deploy-pixel-cdn.yaml"
+    paths-ignore:
+      - "**/*.md"
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/flows.md
+++ b/.github/workflows/flows.md
@@ -1,11 +1,13 @@
 ## PR / Merge Group
 
-Runs on every PR and merge queue entry. Does **not** re-run on push to `main`
-(merge queue is the final validation). Functional tests run only when allowlisted
-paths change (`packages/orderbook/`, `sdk/`, `packages/config/`,
+Runs on every PR and merge queue entry, and on push to `main` as a break-glass
+safety net (merge queue is the normal final validation). Functional tests run
+when allowlisted paths change (`packages/orderbook/`, `sdk/`, `packages/config/`,
 `packages/internal/metrics/`, `packages/internal/generated-clients/`,
-`tests/func-tests/`, or this workflow), or when the PR has the `run-func-tests`
-label. Syncpack runs inside the SDK job. All jobs are automated — no manual gate.
+`tests/func-tests/`, this workflow, `pnpm-lock.yaml`, `pnpm-workspace.yaml`,
+root `package.json`, or `tsup.config.js`), or when the PR has the
+`run-func-tests` label (honored on both `pull_request` and `merge_group`).
+Syncpack runs inside the SDK job. All jobs are automated — no manual gate.
 
 ```mermaid
 flowchart LR

--- a/.github/workflows/flows.md
+++ b/.github/workflows/flows.md
@@ -1,13 +1,16 @@
 ## PR / Merge Group
 
-Runs on every PR and merge queue entry. Functional tests are skipped when all changed files are under `packages/audience/`. All jobs are automated - no manual gate.
+Runs on every PR and merge queue entry. Does **not** re-run on push to `main`
+(merge queue is the final validation). Functional tests run only when allowlisted
+paths change (`packages/orderbook/`, `sdk/`, `packages/config/`,
+`packages/internal/metrics/`, `packages/internal/generated-clients/`,
+`tests/func-tests/`, or this workflow), or when the PR has the `run-func-tests`
+label. Syncpack runs inside the SDK job. All jobs are automated — no manual gate.
 
 ```mermaid
 flowchart LR
-    PR([Pull Request\nor Merge Group]) --> sync[Syncpack\ndependency alignment]
-    PR --> blt[Build · Lint · Test\nSDK packages]
-    PR --> ex[Build · Lint · Test\nExamples]
-    PR --> func[Functional Tests\nexcept audience-only changes]
+    PR([Pull Request\nor Merge Group]) --> blt[Build · Lint · Test SDK\n+ Syncpack]
+    PR --> func[Functional Tests\nallowlisted paths or label]
     PR --> ab[Audience Bundle\nSize Check]
     PR --> pb[Pixel Bundle\nSize Check]
     PR --> tv[Title Validation\nconventional commits]

--- a/.github/workflows/passport-sample-app-deployment.yaml
+++ b/.github/workflows/passport-sample-app-deployment.yaml
@@ -43,10 +43,6 @@ jobs:
         with:
           enable-cache: "false"
 
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Initialize and install current @latest sdk versions on npm
         shell: bash
         run: pnpm --filter @imtbl/sdk... exec sh -c "jq --arg version \"$(npm view @imtbl/metrics versions --json | jq -r '.[-1]')\" '.version = \$version' package.json > package.tmp.json && mv package.tmp.json package.json" && pnpm i --ignore-scripts

--- a/.github/workflows/passport-sample-app-deployment.yaml
+++ b/.github/workflows/passport-sample-app-deployment.yaml
@@ -3,7 +3,11 @@ name: Passport Sample App Deployment
 on:
   push:
     paths:
-      - "packages/passport/**"
+      - "packages/passport/sample-app/**"
+      - "packages/passport/sdk/**"
+      - ".github/workflows/passport-sample-app-deployment.yaml"
+    paths-ignore:
+      - "**/*.md"
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/pixel-bundle-size.yaml
+++ b/.github/workflows/pixel-bundle-size.yaml
@@ -34,10 +34,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Read budget config
         id: budget
         shell: bash

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,11 @@ on:
   merge_group:
     branches:
       - main
+  # Break-glass: if main is pushed outside the merge queue, still validate.
+  # Merge-queue merges already ran this workflow; concurrency cancels duplicates.
+  push:
+    branches:
+      - main
 
 permissions: {}
 
@@ -46,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Needed to read PR labels when this job runs in a merge_group context.
+      pull-requests: read
     outputs:
       should-run: ${{ steps.changed-files.outputs.should-run }}
     steps:
@@ -61,18 +68,39 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
-          # Force-run when the PR carries this label (escape hatch).
-          FORCE_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-func-tests') }}
+          EVENT_NAME: ${{ github.event_name }}
+          # pull_request payload includes labels; merge_group / push do not.
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          # merge_group head ref looks like: gh-readonly-queue/main/pr-1234-<sha>
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "$FORCE_LABEL" = "true" ]; then
+          force_label=false
+
+          if [ "$EVENT_NAME" = "pull_request" ] && echo "$PR_LABELS" | grep -Fq '"run-func-tests"'; then
+            force_label=true
+          fi
+
+          # On merge_group, re-check the source PR for the force-run label.
+          if [ "$EVENT_NAME" = "merge_group" ] && [ -n "$MERGE_GROUP_HEAD_REF" ]; then
+            pr_number="$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -n 's|.*/pr-\([0-9][0-9]*\)-.*|\1|p')"
+            if [ -n "$pr_number" ]; then
+              if gh api "repos/${{ github.repository }}/issues/${pr_number}/labels" --jq '.[].name' \
+                | grep -Fxq 'run-func-tests'; then
+                force_label=true
+              fi
+            fi
+          fi
+
+          if [ "$force_label" = "true" ]; then
             echo "should-run=true" >> "$GITHUB_OUTPUT"
             echo "Running functional tests (run-func-tests label)"
             exit 0
           fi
 
-          # Allowlist: only orderbook / sdk packaging / shared deps the suite exercises.
+          # Allowlist: orderbook surface + shared build/deps roots that can break it.
           if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE \
-            '^(packages/orderbook/|sdk/|packages/config/|packages/internal/metrics/|packages/internal/generated-clients/|tests/func-tests/|\.github/workflows/pr\.yaml)'; then
+            '^(packages/orderbook/|sdk/|packages/config/|packages/internal/metrics/|packages/internal/generated-clients/|tests/func-tests/|\.github/workflows/pr\.yaml|pnpm-lock\.yaml|pnpm-workspace\.yaml|package\.json|tsup\.config\.js)'; then
             echo "should-run=true" >> "$GITHUB_OUTPUT"
             echo "Running functional tests (allowlisted path changed)"
           else

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,6 @@
 name: PR
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - "**"
@@ -18,30 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  syncpack:
-    name: Syncpack
-    runs-on: ubuntu-latest-4-cores
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: setup
-        uses: ./.github/actions/setup
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Syncpack
-        shell: bash
-        run: pnpm syncpack:check
-
   build-lint-test-sdk:
     name: Build, Lint & Test SDK
     runs-on: ubuntu-latest-8-cores
@@ -53,16 +26,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/setup
 
-      - name: Install dependencies
+      - name: Syncpack
         shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm syncpack:check
 
       - name: Build, Lint & Test
         shell: bash
@@ -88,16 +61,29 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          # Force-run when the PR carries this label (escape hatch).
+          FORCE_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-func-tests') }}
         run: |
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qv '^packages/audience/'; then
+          if [ "$FORCE_LABEL" = "true" ]; then
             echo "should-run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            echo "Running functional tests (run-func-tests label)"
+            exit 0
           fi
 
+          # Allowlist: only orderbook / sdk packaging / shared deps the suite exercises.
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE \
+            '^(packages/orderbook/|sdk/|packages/config/|packages/internal/metrics/|packages/internal/generated-clients/|tests/func-tests/|\.github/workflows/pr\.yaml)'; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "Running functional tests (allowlisted path changed)"
+          else
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping functional tests (no allowlisted paths changed)"
+          fi
+
+  # Always reports the required check name. Heavy work is conditional so skips
+  # still satisfy branch protection / merge queue.
   func-tests:
     name: Functional tests
-    if: needs.should-run-functional-tests.outputs.should-run == 'true'
     needs: should-run-functional-tests
     runs-on: ubuntu-latest-8-cores
     permissions:
@@ -105,37 +91,46 @@ jobs:
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.TS_IMMUTABLE_SDK_NX_TOKEN }}
     steps:
+      - name: Skip functional tests
+        if: needs.should-run-functional-tests.outputs.should-run != 'true'
+        shell: bash
+        run: echo "No allowlisted paths changed; skipping functional tests."
+
       - name: Checkout code
+        if: needs.should-run-functional-tests.outputs.should-run == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: setup
+        if: needs.should-run-functional-tests.outputs.should-run == 'true'
         uses: ./.github/actions/setup
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        with:
+          nx-set-shas: "false"
 
       - name: Build SDK
+        if: needs.should-run-functional-tests.outputs.should-run == 'true'
         shell: bash
         run: pnpm build
 
       - name: Prepare SDK
+        if: needs.should-run-functional-tests.outputs.should-run == 'true'
         shell: bash
         run: pnpm prepare:sdk
 
       - name: Prepare tests
+        if: needs.should-run-functional-tests.outputs.should-run == 'true'
         shell: bash
         run: pnpm prepare:tests
 
       - name: Update modules
+        if: needs.should-run-functional-tests.outputs.should-run == 'true'
         shell: bash
-        run: pnpm install --frozen-lockfile=false --ignore-scripts
+        run: pnpm install --frozen-lockfile=false --ignore-scripts --prefer-offline
 
       - name: Run functional tests
+        if: needs.should-run-functional-tests.outputs.should-run == 'true'
         shell: bash
         env:
           ZKEVM_ORDERBOOK_BANKER: ${{ secrets.ZKEVM_ORDERBOOK_BANKER }}
@@ -147,4 +142,4 @@ jobs:
           ZKEVM_RPC_ENDPOINT: "https://rpc.testnet.immutable.com"
           ORDERBOOK_MR_API_URL: "https://api.sandbox.immutable.com"
           ZKEVM_CHAIN_NAME: "imtbl-zkevm-testnet"
-        run: pnpm --filter "@tests/func-tests-zkevm" --parallel func-test:ci
+        run: pnpm --filter "@tests/func-tests-zkevm" func-test:ci

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,10 +70,6 @@ jobs:
         with:
           enable-cache: "false"
 
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
       - name: Setup Github
         shell: bash
         run: |
@@ -150,7 +146,6 @@ jobs:
         shell: bash
         run: |
           wget https://cdn.jsdelivr.net/npm/@imtbl/checkout-widgets/dist/browser/index.js
-
 
       - name: Notify SDK Slack Publish Success
         if: ${{ success() && (steps.npm_release.conclusion == 'success') && env.DRY_RUN == 'false' }}


### PR DESCRIPTION
## Summary
- Stop re-running the full `PR` workflow on push to `main` (merge queue is the final gate; publish/CDN keep their own workflows)
- Fold Syncpack into `Build, Lint & Test SDK` and drop the standalone Syncpack job / required check
- Centralize `pnpm install` in `.github/actions/setup` (callers no longer duplicate it)
- Run functional tests only for allowlisted paths (`packages/orderbook/`, `sdk/`, `packages/config/`, `packages/internal/metrics/`, `packages/internal/generated-clients/`, `tests/func-tests/`, `.github/workflows/pr.yaml`) or the `run-func-tests` label; job always reports so the required check stays green when skipped
- Examples job already removed on main via #2917
- **Ruleset (already applied):** `min_entries_to_merge_wait_minutes` 5 → 0; removed `Syncpack` from required status checks on Main branch protection

## Test plan
- [ ] Confirm this PR’s `Build, Lint & Test SDK` runs Syncpack + nx affected
- [ ] Confirm `Functional tests` runs here (allowlisted because `pr.yaml` changed) and still passes
- [ ] Open/observe a non-orderbook PR (e.g. docs/audience-only) and confirm Functional tests job succeeds quickly via skip step
- [ ] After merge, confirm push to main does **not** start the `PR` workflow
- [ ] Confirm merge queue no longer idles for the old 5-minute batch wait
- [ ] Optional: add `run-func-tests` label on an unrelated PR and confirm the suite is forced on


Made with [Cursor](https://cursor.com)