### PR TITLE
feat(audience): add trackConversion for pixel/CAPI dedup

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -68,7 +68,9 @@
       "!packages/game-bridge",
       "!@imtbl-alpha/**"
     ],
-    "releaseTagPattern": "{version}",
+    "releaseTag": {
+      "pattern": "{version}"
+    },
     "changelog": {
       "workspaceChangelog": {
         "file": false,

--- a/packages/audience/core/src/attribution.test.ts
+++ b/packages/audience/core/src/attribution.test.ts
@@ -3,11 +3,6 @@ import {
   collectPageAttribution,
   clearAttribution,
   getAttributionNetwork,
-  isPaidMeta,
-  isPaidTikTok,
-  isPaidGoogle,
-  isPaidReddit,
-  isPaidX,
 } from './attribution';
 
 const STORAGE_KEY = '__imtbl_attribution';
@@ -204,15 +199,13 @@ describe('getAttributionNetwork', () => {
     ['x', 'x'],
     ['twitter', 'x'],
   ])('classifies utm_source=%s with a paid utm_medium as %s', (source, expected) => {
-    setLocation(`https://example.com/?utm_source=${source}&utm_medium=cpc`);
-    expect(getAttributionNetwork()).toBe(expected);
+    expect(getAttributionNetwork({ utm_source: source, utm_medium: 'cpc' })).toBe(expected);
   });
 
   it.each(['cpc', 'ppc', 'paid', 'paid_social', 'paidsocial', 'CPC'])(
     'treats utm_medium=%s as a paid medium',
     (medium) => {
-      setLocation(`https://example.com/?utm_source=facebook&utm_medium=${medium}`);
-      expect(getAttributionNetwork()).toBe('meta');
+      expect(getAttributionNetwork({ utm_source: 'facebook', utm_medium: medium })).toBe('meta');
     },
   );
 
@@ -223,70 +216,75 @@ describe('getAttributionNetwork', () => {
     ['dclid', 'google'],
     ['rdt_cid', 'reddit'],
     ['twclid', 'x'],
-  ])('classifies %s presence as %s regardless of utm_source or utm_medium', (param, expected) => {
-    setLocation(`https://example.com/?${param}=123`);
-    expect(getAttributionNetwork()).toBe(expected);
+  ])('classifies %s presence as %s regardless of utm_source or utm_medium', (key, expected) => {
+    expect(getAttributionNetwork({ [key]: '123' })).toBe(expected);
   });
 
-  it.each(['msclkid', 'li_fat_id'])('classifies %s presence as other', (param) => {
-    setLocation(`https://example.com/?${param}=123`);
-    expect(getAttributionNetwork()).toBe('other');
+  it.each(['msclkid', 'li_fat_id'])('classifies %s presence as other', (key) => {
+    expect(getAttributionNetwork({ [key]: '123' })).toBe('other');
   });
 
-  it('classifies no params as organic', () => {
-    setLocation('https://example.com/');
-    expect(getAttributionNetwork()).toBe('organic');
+  it('classifies an empty snapshot as organic', () => {
+    expect(getAttributionNetwork({})).toBe('organic');
+  });
+
+  it('ignores empty-string click IDs', () => {
+    expect(getAttributionNetwork({ fbclid: '' })).toBe('organic');
   });
 
   it('classifies an unrecognised utm_source as organic', () => {
-    setLocation('https://example.com/?utm_source=newsletter&utm_medium=cpc');
-    expect(getAttributionNetwork()).toBe('organic');
+    expect(getAttributionNetwork({ utm_source: 'newsletter', utm_medium: 'cpc' })).toBe('organic');
   });
 
   it('classifies utm_source alone without utm_medium as organic', () => {
-    setLocation('https://example.com/?utm_source=facebook');
-    expect(getAttributionNetwork()).toBe('organic');
+    expect(getAttributionNetwork({ utm_source: 'facebook' })).toBe('organic');
   });
 
   it.each(['organic', 'social', 'referral', 'email'])(
     'classifies a matching utm_source with non-paid utm_medium=%s as organic',
     (medium) => {
-      setLocation(`https://example.com/?utm_source=facebook&utm_medium=${medium}`);
-      expect(getAttributionNetwork()).toBe('organic');
+      expect(getAttributionNetwork({ utm_source: 'facebook', utm_medium: medium })).toBe('organic');
     },
   );
+
+  it('classifies from the snapshot, independent of the current URL', () => {
+    // URL says Meta, but classification is driven solely by the snapshot.
+    setLocation('https://example.com/?fbclid=abc');
+    expect(getAttributionNetwork({ ttclid: 'xyz' })).toBe('tiktok');
+
+    // A clean URL still classifies from the snapshot's click ID.
+    setLocation('https://example.com/games/devilfish');
+    expect(getAttributionNetwork({ fbclid: 'abc' })).toBe('meta');
+  });
 });
 
-describe('isPaid* helpers', () => {
-  it('isPaidMeta reflects getAttributionNetwork', () => {
-    setLocation('https://example.com/?utm_source=facebook&utm_medium=paid_social');
-    expect(isPaidMeta()).toBe(true);
-    expect(isPaidTikTok()).toBe(false);
+describe('getAttributionNetwork from the current URL (no snapshot)', () => {
+  it.each([
+    ['fbclid', 'meta'],
+    ['ttclid', 'tiktok'],
+    ['gclid', 'google'],
+    ['rdt_cid', 'reddit'],
+    ['twclid', 'x'],
+  ])('classifies %s on the URL as %s', (param, expected) => {
+    setLocation(`https://example.com/?${param}=123`);
+    expect(getAttributionNetwork()).toBe(expected);
   });
 
-  it('isPaidMeta is false for organic Meta-sourced traffic', () => {
-    setLocation('https://example.com/?utm_source=facebook&utm_medium=organic');
-    expect(isPaidMeta()).toBe(false);
+  it('classifies a paid utm_source/medium on the URL', () => {
+    setLocation('https://example.com/?utm_source=facebook&utm_medium=cpc');
+    expect(getAttributionNetwork()).toBe('meta');
   });
 
-  it('isPaidTikTok reflects getAttributionNetwork', () => {
-    setLocation('https://example.com/?ttclid=abc');
-    expect(isPaidTikTok()).toBe(true);
-    expect(isPaidMeta()).toBe(false);
+  it('classifies no params on the URL as organic', () => {
+    setLocation('https://example.com/');
+    expect(getAttributionNetwork()).toBe('organic');
   });
 
-  it('isPaidGoogle reflects getAttributionNetwork', () => {
-    setLocation('https://example.com/?gclid=abc');
-    expect(isPaidGoogle()).toBe(true);
-  });
-
-  it('isPaidReddit reflects getAttributionNetwork', () => {
-    setLocation('https://example.com/?utm_source=reddit&utm_medium=paid');
-    expect(isPaidReddit()).toBe(true);
-  });
-
-  it('isPaidX reflects getAttributionNetwork', () => {
-    setLocation('https://example.com/?twclid=abc');
-    expect(isPaidX()).toBe(true);
+  it('returns organic when there is no window (SSR)', () => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    // @ts-expect-error simulate a non-browser runtime
+    delete globalThis.window;
+    expect(getAttributionNetwork()).toBe('organic');
+    if (original) Object.defineProperty(globalThis, 'window', original);
   });
 });

--- a/packages/audience/core/src/attribution.ts
+++ b/packages/audience/core/src/attribution.ts
@@ -157,75 +157,63 @@ function isPaidSourceMatch(source: string | undefined, medium: string | undefine
 }
 
 /**
- * Classifies the current page load's traffic source from `utm_source` /
- * `utm_medium` and ad-network click IDs on the URL (e.g. `fbclid`,
- * `ttclid`, `gclid`). A network click ID is treated as paid on its own;
- * a bare `utm_source` match additionally requires `utm_medium` to be a
- * paid value (see {@link PAID_MEDIUMS}), so organic traffic tagged with
- * e.g. `utm_source=facebook&utm_medium=organic` isn't misclassified as paid.
- *
- * @returns The matched network, `'organic'` when no UTM or click ID is
- * present, or `'other'` when a recognised click ID (e.g. `msclkid`,
- * `li_fat_id`) doesn't map to a named network.
- * @example
- * // https://example.com/?utm_source=facebook&utm_medium=paid_social
- * getAttributionNetwork(); // 'meta'
- * @example
- * // https://example.com/?utm_source=facebook&utm_medium=organic
- * getAttributionNetwork(); // 'organic'
- * @example
- * // https://example.com/?fbclid=abc123
- * getAttributionNetwork(); // 'meta' — click ID alone is a sufficient paid signal
+ * Shared classifier for {@link getAttributionNetwork}. `source` / `medium`
+ * are expected pre-lowercased; `hasParam` reports whether a given click-ID
+ * key is present, letting the same logic run against a URL or an
+ * {@link Attribution} snapshot.
  */
-export function getAttributionNetwork(): AttributionNetwork {
-  if (typeof window === 'undefined' || !window.location) return 'organic';
-
-  const params = new URLSearchParams(window.location.search);
-  const source = params.get('utm_source')?.toLowerCase();
-  const medium = params.get('utm_medium')?.toLowerCase();
-
-  if (params.has('fbclid') || isPaidSourceMatch(source, medium, META_SOURCES)) {
-    return 'meta';
-  }
-  if (params.has('ttclid') || isPaidSourceMatch(source, medium, ['tiktok'])) {
-    return 'tiktok';
-  }
-  if (params.has('gclid') || params.has('dclid') || isPaidSourceMatch(source, medium, ['google'])) {
-    return 'google';
-  }
-  if (params.has('rdt_cid') || isPaidSourceMatch(source, medium, ['reddit'])) {
-    return 'reddit';
-  }
-  if (params.has('twclid') || isPaidSourceMatch(source, medium, X_SOURCES)) {
-    return 'x';
-  }
-  if (params.has('msclkid') || params.has('li_fat_id')) {
-    return 'other';
-  }
+function classifyNetwork(
+  source: string | undefined,
+  medium: string | undefined,
+  hasParam: (key: AttributionKey) => boolean,
+): AttributionNetwork {
+  if (hasParam('fbclid') || isPaidSourceMatch(source, medium, META_SOURCES)) return 'meta';
+  if (hasParam('ttclid') || isPaidSourceMatch(source, medium, ['tiktok'])) return 'tiktok';
+  if (hasParam('gclid') || hasParam('dclid') || isPaidSourceMatch(source, medium, ['google'])) return 'google';
+  if (hasParam('rdt_cid') || isPaidSourceMatch(source, medium, ['reddit'])) return 'reddit';
+  if (hasParam('twclid') || isPaidSourceMatch(source, medium, X_SOURCES)) return 'x';
+  if (hasParam('msclkid') || hasParam('li_fat_id')) return 'other';
   return 'organic';
 }
 
-/** @returns Whether the current visit is attributed to paid Meta (Facebook/Instagram) traffic. */
-export function isPaidMeta(): boolean {
-  return getAttributionNetwork() === 'meta';
-}
+/**
+ * Classifies a visit's traffic source from `utm_source` / `utm_medium` and
+ * ad-network click IDs (e.g. `fbclid`, `ttclid`, `gclid`). A network click ID
+ * is treated as paid on its own; a bare `utm_source` match additionally
+ * requires `utm_medium` to be a paid value (see {@link PAID_MEDIUMS}), so
+ * organic traffic tagged with e.g. `utm_source=facebook&utm_medium=organic`
+ * isn't misclassified as paid.
+ *
+ * @param attribution When provided, classifies from this snapshot. Pass the
+ * session-cached first-touch attribution (the same signals that ride on
+ * `sign_up` events and drive server-side attribution) so client- and
+ * server-classified traffic agree, even after the landing URL's query params
+ * are gone. When omitted, reads the current `window.location` — use this
+ * standalone form only where no {@link Audience} instance exists (e.g. a page
+ * with just an ad pixel); when you have an instance, prefer
+ * `Audience.getAttributionNetwork()`, which classifies from its cached snapshot.
+ * @returns The matched network, `'organic'` when no UTM or click ID is
+ * present, or `'other'` when a recognised click ID (e.g. `msclkid`,
+ * `li_fat_id`) doesn't map to a named network.
+ */
+export function getAttributionNetwork(attribution?: Attribution): AttributionNetwork {
+  if (attribution) {
+    return classifyNetwork(
+      attribution.utm_source?.toLowerCase(),
+      attribution.utm_medium?.toLowerCase(),
+      (key) => {
+        const value = attribution[key];
+        return value != null && value !== '';
+      },
+    );
+  }
 
-/** @returns Whether the current visit is attributed to paid TikTok traffic. */
-export function isPaidTikTok(): boolean {
-  return getAttributionNetwork() === 'tiktok';
-}
+  if (typeof window === 'undefined' || !window.location) return 'organic';
 
-/** @returns Whether the current visit is attributed to paid Google traffic. */
-export function isPaidGoogle(): boolean {
-  return getAttributionNetwork() === 'google';
-}
-
-/** @returns Whether the current visit is attributed to paid Reddit traffic. */
-export function isPaidReddit(): boolean {
-  return getAttributionNetwork() === 'reddit';
-}
-
-/** @returns Whether the current visit is attributed to paid X (Twitter) traffic. */
-export function isPaidX(): boolean {
-  return getAttributionNetwork() === 'x';
+  const params = new URLSearchParams(window.location.search);
+  return classifyNetwork(
+    params.get('utm_source')?.toLowerCase(),
+    params.get('utm_medium')?.toLowerCase(),
+    (key) => params.has(key),
+  );
 }

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -53,11 +53,6 @@ export {
   collectSessionAttribution,
   collectPageAttribution,
   getAttributionNetwork,
-  isPaidMeta,
-  isPaidTikTok,
-  isPaidGoogle,
-  isPaidReddit,
-  isPaidX,
 } from './attribution';
 export type { Attribution, AttributionNetwork } from './attribution';
 

--- a/packages/audience/sdk/src/conversion.ts
+++ b/packages/audience/sdk/src/conversion.ts
@@ -1,0 +1,46 @@
+import type { AttributionNetwork } from '@imtbl/audience-core';
+
+/**
+ * Reserved event property carrying the shared conversion event id. The same
+ * value is passed to the ad-network browser pixel so the network can
+ * deduplicate the browser event against the server-side Conversions API event
+ * (which reads this property downstream). The leading underscore marks it as
+ * SDK-owned (callers must not set it by hand), matching the reserved `_imtbl_`
+ * identifier convention; snake_case keeps it BigQuery / Goal-filter friendly.
+ * This name is a cross-service contract with the postbacks builders - do not
+ * change it without updating them.
+ */
+export const CONVERSION_ID_PROPERTY = '_imtbl_conversion_id';
+
+/**
+ * Reserved event property naming the network the conversion id was minted for.
+ * Lets the server reuse the id only when dispatching to the same network the
+ * client fired a dedup pixel for. SDK-owned (see {@link CONVERSION_ID_PROPERTY});
+ * cross-service contract with postbacks.
+ */
+export const CONVERSION_NETWORK_PROPERTY = '_imtbl_conversion_network';
+
+/**
+ * Networks whose browser pixel and server Conversions API both support
+ * deduplicating on a shared event id. Google dedups on gclid + conversion
+ * action (not a shared id) and is intentionally excluded.
+ */
+export const DEDUP_CAPABLE_NETWORKS: ReadonlySet<AttributionNetwork> = new Set<AttributionNetwork>([
+  'meta',
+  'tiktok',
+  'reddit',
+]);
+
+/** Result of {@link Audience.trackConversion}. */
+export interface ConversionResult {
+  /**
+   * The shared id to pass to the ad-network browser pixel (e.g. Meta
+   * `eventID`, TikTok `event_id`, Reddit `conversionId`). `null` when the
+   * visit isn't attributed to a dedup-capable paid network, or when consent
+   * doesn't permit tracking — in both cases no dedup id is emitted and the
+   * caller should not fire a deduplicated pixel event.
+   */
+  eventId: string | null;
+  /** The network the visit was attributed to. */
+  network: AttributionNetwork;
+}

--- a/packages/audience/sdk/src/index.ts
+++ b/packages/audience/sdk/src/index.ts
@@ -1,16 +1,17 @@
 export { Audience } from './sdk';
 export { AudienceEvents } from './events';
 export {
+  CONVERSION_ID_PROPERTY,
+  CONVERSION_NETWORK_PROPERTY,
+  DEDUP_CAPABLE_NETWORKS,
+} from './conversion';
+export type { ConversionResult } from './conversion';
+export {
   IdentityType,
   canTrack,
   canIdentify,
   AudienceError,
   getAttributionNetwork,
-  isPaidMeta,
-  isPaidTikTok,
-  isPaidGoogle,
-  isPaidReddit,
-  isPaidX,
 } from '@imtbl/audience-core';
 export type { ImmutableAudienceGlobal } from './cdn';
 export type { AudienceConfig } from './types';

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -1815,4 +1815,180 @@ describe('Audience', () => {
       expect(sentMessages().filter((m: any) => m.eventName === 'link_clicked')).toHaveLength(0);
     });
   });
+
+  describe('trackConversion', () => {
+    function initWithLocation(search: string, overrides: Record<string, unknown> = {}) {
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search,
+          href: `https://studio.com/${search}`,
+          protocol: 'https:',
+          pathname: '/',
+        },
+        writable: true,
+        configurable: true,
+      });
+      sessionStorage.clear();
+      return createSDK(overrides);
+    }
+
+    it('mints a shared id and stamps reserved props for a dedup-capable network', async () => {
+      const sdk = initWithLocation('?fbclid=abc123');
+
+      const result = sdk.trackConversion('sign_up', { method: 'email' });
+
+      expect(result.network).toBe('meta');
+      expect(result.eventId).toEqual(expect.any(String));
+      expect(result.eventId).not.toBe('');
+
+      await sdk.flush();
+      const msg = sentMessages().find((m: any) => m.eventName === 'sign_up');
+      expect(msg).toBeDefined();
+      expect(msg.properties._imtbl_conversion_id).toBe(result.eventId);
+      expect(msg.properties._imtbl_conversion_network).toBe('meta');
+      expect(msg.properties.method).toBe('email');
+
+      sdk.shutdown();
+    });
+
+    it.each([
+      ['?fbclid=abc', 'meta'],
+      ['?ttclid=abc', 'tiktok'],
+      ['?rdt_cid=abc', 'reddit'],
+    ])('mints an id for the dedup-capable network from %s', (search, network) => {
+      const sdk = initWithLocation(search);
+
+      const result = sdk.trackConversion('sign_up', { method: 'email' });
+
+      expect(result.network).toBe(network);
+      expect(result.eventId).toEqual(expect.any(String));
+
+      sdk.shutdown();
+    });
+
+    it('does not mint an id for a non-dedup-capable network but still tracks the event', async () => {
+      const sdk = initWithLocation('?gclid=abc');
+
+      const result = sdk.trackConversion('sign_up', { method: 'email' });
+
+      expect(result.network).toBe('google');
+      expect(result.eventId).toBeNull();
+
+      await sdk.flush();
+      const msg = sentMessages().find((m: any) => m.eventName === 'sign_up');
+      expect(msg).toBeDefined();
+      expect(msg.properties._imtbl_conversion_id).toBeUndefined();
+      expect(msg.properties._imtbl_conversion_network).toBeUndefined();
+      expect(msg.properties.method).toBe('email');
+
+      sdk.shutdown();
+    });
+
+    it('does not mint an id for organic traffic but still tracks the event', async () => {
+      const sdk = initWithLocation('');
+
+      const result = sdk.trackConversion('sign_up', { method: 'email' });
+
+      expect(result.network).toBe('organic');
+      expect(result.eventId).toBeNull();
+
+      await sdk.flush();
+      const msg = sentMessages().find((m: any) => m.eventName === 'sign_up');
+      expect(msg).toBeDefined();
+      expect(msg.properties._imtbl_conversion_id).toBeUndefined();
+
+      sdk.shutdown();
+    });
+
+    it('classifies from session-cached attribution after the URL loses its params', async () => {
+      const sdk = initWithLocation('?fbclid=abc123');
+
+      // Simulate navigating to a later page whose URL has no click-ID params.
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search: '',
+          href: 'https://studio.com/games/devilfish',
+          protocol: 'https:',
+          pathname: '/games/devilfish',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const result = sdk.trackConversion('sign_up', { method: 'email' });
+
+      expect(result.network).toBe('meta');
+      expect(result.eventId).toEqual(expect.any(String));
+
+      await sdk.flush();
+      const msg = sentMessages().find((m: any) => m.eventName === 'sign_up');
+      expect(msg.properties._imtbl_conversion_id).toBe(result.eventId);
+
+      sdk.shutdown();
+    });
+
+    it('is a no-op at none consent and returns a null eventId', async () => {
+      const sdk = initWithLocation('?fbclid=abc123', { consent: 'none' });
+
+      const result = sdk.trackConversion('sign_up', { method: 'email' });
+
+      expect(result.eventId).toBeNull();
+
+      await sdk.flush();
+      expect(sentMessages()).toHaveLength(0);
+
+      sdk.shutdown();
+    });
+  });
+
+  describe('getAttributionNetwork', () => {
+    function initWithLocation(search: string) {
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search,
+          href: `https://studio.com/${search}`,
+          protocol: 'https:',
+          pathname: '/',
+        },
+        writable: true,
+        configurable: true,
+      });
+      sessionStorage.clear();
+      return createSDK();
+    }
+
+    it('classifies the network from the session-cached first-touch attribution', () => {
+      const sdk = initWithLocation('?fbclid=abc123');
+      expect(sdk.getAttributionNetwork()).toBe('meta');
+      sdk.shutdown();
+    });
+
+    it('returns organic when there is no paid signal', () => {
+      const sdk = initWithLocation('');
+      expect(sdk.getAttributionNetwork()).toBe('organic');
+      sdk.shutdown();
+    });
+
+    it('stays stable after the URL loses its query params', () => {
+      const sdk = initWithLocation('?ttclid=abc');
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          search: '',
+          href: 'https://studio.com/games/devilfish',
+          protocol: 'https:',
+          pathname: '/games/devilfish',
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      expect(sdk.getAttributionNetwork()).toBe('tiktok');
+      sdk.shutdown();
+    });
+  });
 });

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -1,5 +1,6 @@
 import type {
   Attribution,
+  AttributionNetwork,
   ConsentLevel,
   ConsentManager,
   Message,
@@ -26,6 +27,7 @@ import {
   collectContext,
   collectSessionAttribution,
   collectThirdPartyIds,
+  getAttributionNetwork as resolveAttributionNetwork,
   getOrCreateSessionId,
   createConsentManager,
   canTrack,
@@ -38,6 +40,12 @@ import { adoptAnonymousId, resolvePrivacySignal } from '@imtbl/audience-core/int
 import { track } from '@imtbl/metrics';
 import { DebugLogger } from './debug';
 import { REQUIRED_EVENT_PROPS, type AudienceEventName, type PropsFor } from './events';
+import {
+  CONVERSION_ID_PROPERTY,
+  CONVERSION_NETWORK_PROPERTY,
+  DEDUP_CAPABLE_NETWORKS,
+  type ConversionResult,
+} from './conversion';
 import type { AudienceConfig } from './types';
 import {
   LIBRARY_NAME, LIBRARY_VERSION, LOG_PREFIX, DEFAULT_CONSENT_SOURCE,
@@ -230,6 +238,18 @@ export class Audience {
     return this.anonymousId;
   }
 
+  /**
+   * The ad network this visit is attributed to, classified from the
+   * session-cached first-touch attribution captured when the SDK initialised
+   * (UTM params + ad-network click IDs). Returns `'organic'` when there's no
+   * paid signal, or `'other'` for a recognised but unnamed click ID. Stable
+   * for the session, so it agrees with server-side attribution even after the
+   * landing URL's query params are gone.
+   */
+  getAttributionNetwork(): AttributionNetwork {
+    return resolveAttributionNetwork(this.attribution);
+  }
+
   /** True when the current consent level does not permit tracking. */
   private isTrackingDisabled(): boolean {
     return !canTrack(this.consent.level);
@@ -320,17 +340,71 @@ export class Audience {
       ? [properties?: PropsFor<E>]
       : [properties: PropsFor<E>]
   ): void {
+    this.emitTrack(event, args[0] as Record<string, unknown> | undefined);
+  }
+
+  /**
+   * Like {@link track}, but mints a shared id for ad-network deduplication.
+   * Use for conversion events reported to ad networks, e.g. `sign_up` or
+   * `purchase`.
+   *
+   * Classifies the visit's network from the session-cached first-touch
+   * attribution (the same signals that drive server-side attribution). For a
+   * network that can dedupe on a shared id (Meta, TikTok, Reddit), it mints a
+   * conversion event id, stamps it onto the event under the reserved
+   * `_imtbl_conversion_id` / `_imtbl_conversion_network` properties, and returns
+   * it. Pass the returned `eventId` to that network's browser pixel (e.g. Meta
+   * `fbq('track', 'CompleteRegistration', {}, { eventID })`) so it deduplicates
+   * against the server-side event.
+   *
+   * `eventId` is null (and no dedup id is emitted) for a non-dedup-capable or
+   * organic visit, or when consent doesn't permit tracking; `network` is always
+   * returned for the caller's own routing. Same validation as {@link track}.
+   */
+  trackConversion<E extends AudienceEventName | string & {}>(
+    event: E,
+    ...args: {} extends PropsFor<E>
+      ? [properties?: PropsFor<E>]
+      : [properties: PropsFor<E>]
+  ): ConversionResult {
+    const network = this.getAttributionNetwork();
+
+    if (this.isTrackingDisabled()) return { eventId: null, network };
+
+    const eventId = DEDUP_CAPABLE_NETWORKS.has(network) ? generateId() : null;
+    const conversionProps = eventId
+      ? {
+        [CONVERSION_ID_PROPERTY]: eventId,
+        [CONVERSION_NETWORK_PROPERTY]: network,
+      }
+      : undefined;
+
+    this.emitTrack(event, args[0] as Record<string, unknown> | undefined, conversionProps);
+
+    return { eventId, network };
+  }
+
+  /**
+   * Shared implementation for {@link track} and {@link trackConversion}.
+   * `reserved` are SDK-owned properties (e.g. conversion ids) that take
+   * precedence over caller-supplied properties on collision.
+   */
+  private emitTrack(
+    event: string,
+    properties: Record<string, unknown> | undefined,
+    reserved?: Record<string, unknown>,
+  ): void {
     if (this.isTrackingDisabled()) return;
     if (!hasValue(event)) invalidCall('track() called with an empty event name.');
 
-    const [properties] = args;
-    validateRequiredProps(event, properties as Record<string, unknown> | undefined);
+    validateRequiredProps(event, properties);
 
     this.refreshSession();
 
     const mergedProps: Record<string, unknown> = {
       ...(UTM_EVENTS.has(event) ? this.attribution : {}),
-      ...properties as Record<string, unknown> | undefined,
+      ...properties,
+      ...reserved,
     };
 
     this.enqueue('track', {


### PR DESCRIPTION
## Summary

Adds a conversion event id primitive to `@imtbl/audience` so a browser pixel event and its server-side Conversions API (CAPI) counterpart can be deduplicated on a **shared id**. Today Game Page fires browser pixels client-side and postbacks fires CAPI events server-side for the same `sign_up`, with no common id, so ad networks double-count the conversion.

This is piece 1 of 3 (SDK-719). Follow-ups: SDK-720 (Play fires vendor pixels with the shared id) and SDK-721 (postbacks reads the shared id + event-name mapping).

## Changes

- **`Audience.trackConversion(event, properties?)`** - behaves like `track()`, and additionally: classifies the visit's network from the session-cached first-touch attribution (the same signals that drive server-side attribution), mints a shared id for dedup-capable networks (Meta, TikTok, Reddit), stamps it onto the event under the reserved `_imtbl_conversion_id` / `_imtbl_conversion_network` properties, and returns `{ eventId, network }`. The caller passes `eventId` to the browser pixel (e.g. Meta `fbq('track', 'CompleteRegistration', {}, { eventID })`).
- **`Audience.getAttributionNetwork()`** instance method - classifies from the client's cached snapshot so client- and server-side attribution agree even after the landing URL's query params are gone.
- **Standalone `getAttributionNetwork(attribution?)`** - retained and made optional-arg: classifies from a passed snapshot, else falls back to the live URL, for consumers that have a pixel but no SDK instance.
- **Reserved property contract** in `sdk/src/conversion.ts` (`_imtbl_conversion_id`, `_imtbl_conversion_network`, `DEDUP_CAPABLE_NETWORKS`). These are a cross-service contract with the postbacks builders (SDK-721).

### Breaking change

Removes `isPaidMeta` / `isPaidTikTok` / `isPaidGoogle` / `isPaidReddit` / `isPaidX`. The only consumer is Game Page (Play), which we control and which is updated in SDK-720 to use `getAttributionNetwork()`.

## Test plan

- [x] `packages/audience/core` unit tests pass (attribution classification, snapshot + live-URL paths)
- [x] `packages/audience/sdk` unit tests pass (trackConversion id minting, reserved props, consent gating, instance `getAttributionNetwork`)
- [x] Typecheck passes (incl. `sdk.test-d.ts` compile-time assertions)
- [ ] Validated end-to-end once SDK-720 (Play) consumes the prerelease alpha build