### PR TITLE
fix(audience): bundle core subpath + support X/Google dedup

### DIFF
--- a/packages/audience/sdk/src/conversion.ts
+++ b/packages/audience/sdk/src/conversion.ts
@@ -21,24 +21,30 @@ export const CONVERSION_ID_PROPERTY = '_imtbl_conversion_id';
 export const CONVERSION_NETWORK_PROPERTY = '_imtbl_conversion_network';
 
 /**
- * Networks whose browser pixel and server Conversions API both support
- * deduplicating on a shared event id. Google dedups on gclid + conversion
- * action (not a shared id) and is intentionally excluded.
+ * Networks whose browser pixel and server Conversions API can deduplicate on a
+ * shared, client-minted id passed to both legs. Each network names the field
+ * differently (Meta `eventID`, TikTok `event_id`, Reddit/X `conversion_id`,
+ * Google `transaction_id`/`order_id`) but the value is the same. Google dedup
+ * relies on the postbacks upload sending the id as `order_id`; the browser
+ * gtag must send it as `transaction_id`.
  */
 export const DEDUP_CAPABLE_NETWORKS: ReadonlySet<AttributionNetwork> = new Set<AttributionNetwork>([
   'meta',
   'tiktok',
   'reddit',
+  'x',
+  'google',
 ]);
 
 /** Result of {@link Audience.trackConversion}. */
 export interface ConversionResult {
   /**
    * The shared id to pass to the ad-network browser pixel (e.g. Meta
-   * `eventID`, TikTok `event_id`, Reddit `conversionId`). `null` when the
-   * visit isn't attributed to a dedup-capable paid network, or when consent
-   * doesn't permit tracking — in both cases no dedup id is emitted and the
-   * caller should not fire a deduplicated pixel event.
+   * `eventID`, TikTok `event_id`, Reddit/X `conversion_id`, Google gtag
+   * `transaction_id`). `null` when the visit isn't attributed to a
+   * dedup-capable paid network, or when consent doesn't permit tracking — in
+   * both cases no dedup id is emitted and the caller should not fire a
+   * deduplicated pixel event.
    */
   eventId: string | null;
   /** The network the visit was attributed to. */

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -1856,6 +1856,8 @@ describe('Audience', () => {
       ['?fbclid=abc', 'meta'],
       ['?ttclid=abc', 'tiktok'],
       ['?rdt_cid=abc', 'reddit'],
+      ['?twclid=abc', 'x'],
+      ['?gclid=abc', 'google'],
     ])('mints an id for the dedup-capable network from %s', (search, network) => {
       const sdk = initWithLocation(search);
 
@@ -1868,11 +1870,13 @@ describe('Audience', () => {
     });
 
     it('does not mint an id for a non-dedup-capable network but still tracks the event', async () => {
-      const sdk = initWithLocation('?gclid=abc');
+      // msclkid classifies as 'other' (Microsoft/LinkedIn) — a paid network we
+      // don't support server-side dedup for.
+      const sdk = initWithLocation('?msclkid=abc');
 
       const result = sdk.trackConversion('sign_up', { method: 'email' });
 
-      expect(result.network).toBe('google');
+      expect(result.network).toBe('other');
       expect(result.eventId).toBeNull();
 
       await sdk.flush();

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -350,8 +350,8 @@ export class Audience {
    *
    * Classifies the visit's network from the session-cached first-touch
    * attribution (the same signals that drive server-side attribution). For a
-   * network that can dedupe on a shared id (Meta, TikTok, Reddit), it mints a
-   * conversion event id, stamps it onto the event under the reserved
+   * network that can dedupe on a shared id (Meta, TikTok, Reddit, X, Google),
+   * it mints a conversion event id, stamps it onto the event under the reserved
    * `_imtbl_conversion_id` / `_imtbl_conversion_network` properties, and returns
    * it. Pass the returned `eventId` to that network's browser pixel (e.g. Meta
    * `fbq('track', 'CompleteRegistration', {}, { eventID })`) so it deduplicates

--- a/packages/audience/sdk/tsdown.config.js
+++ b/packages/audience/sdk/tsdown.config.js
@@ -13,6 +13,14 @@ import { BUNDLED_WORKSPACE_DEPS } from './scripts/bundled-workspace-deps.mjs';
 
 const localVersion = pkg.version === '0.0.0' ? '0.0.0-local' : pkg.version;
 
+// Match each bundled workspace dep and any of its subpath exports (e.g.
+// `@imtbl/audience-core/internal`). A bare-name string only matches the base
+// specifier, so tsdown would leave subpath imports external and break
+// `npm install` for consumers (the private core package is never published).
+const BUNDLE_MATCHERS = BUNDLED_WORKSPACE_DEPS.map(
+  (name) => new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(/.*)?$`),
+);
+
 export default defineConfig((options) => {
   if (options.watch) {
     return {
@@ -23,7 +31,7 @@ export default defineConfig((options) => {
       platform: 'browser',
       dts: false,
       deps: {
-        alwaysBundle: BUNDLED_WORKSPACE_DEPS,
+        alwaysBundle: BUNDLE_MATCHERS,
         onlyBundle: false,
       },
       plugins: [
@@ -45,7 +53,7 @@ export default defineConfig((options) => {
       treeshake: true,
       dts: false,
       deps: {
-        alwaysBundle: BUNDLED_WORKSPACE_DEPS,
+        alwaysBundle: BUNDLE_MATCHERS,
         onlyBundle: false,
       },
       plugins: [
@@ -66,7 +74,7 @@ export default defineConfig((options) => {
       dts: false,
       clean: true,
       deps: {
-        alwaysBundle: BUNDLED_WORKSPACE_DEPS,
+        alwaysBundle: BUNDLE_MATCHERS,
         onlyBundle: false,
       },
       plugins: [replacePlugin({ __SDK_VERSION__: pkg.version })],


### PR DESCRIPTION
## Summary

Two related audience-SDK changes.

### 1. `fix`: bundle workspace-dep subpaths into the published package

**Regression from #2928 (tsup → tsdown build migration, 2026-07-28).** The audience build previously used **tsup**, whose `noExternal` (fed the bare-name `BUNDLED_WORKSPACE_DEPS` list) inlined `@imtbl/audience-core` **and its subpaths**. #2928 migrated the build to **tsdown**, moving the same bare-name list to `deps.alwaysBundle` — but tsdown's matcher only matches the **bare package name**, not subpaths. So the `@imtbl/audience-core/internal` import (added harmlessly back in #2881, 2026-06-09) started leaking out as an **external** import.

Because `@imtbl/audience-core` is `private: true` (never published) and `prepack` strips it from `dependencies`, the published package throws `MODULE_NOT_FOUND` for `@imtbl/audience-core/internal` at runtime (jest, bundlers, any npm consumer).

**Affected releases:** only `2.24.0` and the `2.23.1-0` alpha (both published 2026-07-29, after the migration). `2.23.0` and earlier — built with tsup — resolve fine, which is why Play `main` (pinned to `2.23.0`) is green and this only surfaced on the branch that bumped past the migration.

**Fix:** derive `alwaysBundle` matchers from the dep list as regexes that also match subpaths (`^@imtbl/audience-core(/.*)?$`), restoring the tsup behavior. tsdown accepts regex matchers (the CDN build already uses `alwaysBundle: [/.*/]`).

### 2. `feat`: support X and Google in `trackConversion` dedup

Add `x` and `google` to `DEDUP_CAPABLE_NETWORKS` so `trackConversion` mints and stamps a shared conversion id for those visits. X dedups on `conversion_id`, Google on `transaction_id`/`order_id`, both keyed on the same client-minted value the postbacks builders reuse server-side. This lets Game Page add X/Google pixels later with no further SDK coordination.

> Note: Google server-side dedup also depends on the postbacks upload sending the id as `order_id` (separate platform-services migration PR).

## Test plan
- [ ] CI build + `@imtbl/audience` tests pass
- [ ] Packed tarball's `dist/{browser,node}/index.js` has no external `@imtbl/audience-core/internal` import (inlined)
- [ ] After release, Play bumps to the new version and CI goes green