### PR TITLE
fix(build): restore published engines.node to >=20.11.0

### DIFF
--- a/packages/audience/sample-app/package.json
+++ b/packages/audience/sample-app/package.json
@@ -7,7 +7,7 @@
     "@imtbl/audience": "workspace:*"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "private": true,
   "scripts": {

--- a/packages/audience/sdk/package.json
+++ b/packages/audience/sdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,7 +18,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {

--- a/packages/internal/bridge/sdk/package.json
+++ b/packages/internal/bridge/sdk/package.json
@@ -24,7 +24,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {

--- a/packages/internal/cryptofiat/package.json
+++ b/packages/internal/cryptofiat/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {

--- a/packages/internal/dex/sdk/package.json
+++ b/packages/internal/dex/sdk/package.json
@@ -25,7 +25,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {

--- a/packages/internal/generated-clients/package.json
+++ b/packages/internal/generated-clients/package.json
@@ -19,7 +19,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {

--- a/packages/internal/metrics/package.json
+++ b/packages/internal/metrics/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {

--- a/packages/internal/toolkit/package.json
+++ b/packages/internal/toolkit/package.json
@@ -24,7 +24,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {

--- a/packages/passport/sdk/package.json
+++ b/packages/passport/sdk/package.json
@@ -28,7 +28,7 @@
     "typescript": "catalog:toolchain"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=20.11.0"
   },
   "exports": {
     "development": {


### PR DESCRIPTION
## Summary

[#2928](https://github.com/immutable/ts-immutable-sdk/pull/2928) (dev toolchain upgrade) raised `engines.node` from `>=20.11.0` to `>=24` across the monorepo, including every **published** package. For consumers that is a **breaking change that shipped in a minor** (`2.24.0`):

- It drops Node 20/22 consumers.
- Under `engine-strict` it makes `npm ci` hard-fail - e.g. Play CI (Node 22) errors with `EBADENGINE ... @imtbl/audience@2.24.1 Required: {"node":">=24"}`.

The bundles target **`es2022`** (verified in each `tsdown.config.js`), which runs on Node 18+, so the runtime floor never needed Node 24. This restores the consumer-facing floor to the pre-#2928 value `>=20.11.0`.

Widening `engines` is backward-compatible, so this is safe to release as a **patch** (`2.24.2`) - it undoes a breaking change rather than introducing one.

## Scope

Reverts `engines.node` to `>=20.11.0` on the 10 packages #2928 bumped:
`audience/sdk`, `audience/sample-app`, `passport/sdk`, `config`, `internal/{toolkit,cryptofiat,dex/sdk,bridge/sdk,generated-clients,metrics}`.

**Intentionally unchanged:** the repo's dev/build Node - root `package.json` `engines` and `.nvmrc` (`24.18.0`) stay at Node 24, since the upgraded build toolchain (tsdown/pnpm) expects it. Build-time Node and consumer runtime Node are independent.

## Test plan

- [ ] CI green (build/test/lint on Node 24 dev env)
- [ ] Publish `2.24.2`; confirm `npm view @imtbl/audience@2.24.2 engines` = `{"node":">=20.11.0"}`
- [ ] Bump Play to `2.24.2`; `npm ci` on Node 22 succeeds