### PR TITLE
fix(checkout-widgets): stop stuck Loading overlays under React 19

### DIFF
--- a/packages/checkout/widgets-lib/src/components/Handover/Handover.tsx
+++ b/packages/checkout/widgets-lib/src/components/Handover/Handover.tsx
@@ -37,16 +37,19 @@ export function Handover({ id, children }: { id: string, children?: React.ReactN
   return (
     <>
       {children}
-      {loader && (
-        <LoadingOverlay visible>
-          <LoadingOverlay.Content>
-            <LoadingOverlay.Content.LoopingText
-              text={[...loader.text]}
-              textDuration={loader.duration}
-            />
-          </LoadingOverlay.Content>
-        </LoadingOverlay>
-      )}
+      {/*
+        Keep LoadingOverlay mounted and toggle `visible`. Conditionally mounting
+        `{loader && <LoadingOverlay visible>}` orphans the modal under React 19
+        (biom3 useControlledOverlay cleanup race).
+      */}
+      <LoadingOverlay visible={Boolean(loader)}>
+        <LoadingOverlay.Content>
+          <LoadingOverlay.Content.LoopingText
+            text={loader ? [...loader.text] : ['']}
+            textDuration={loader?.duration}
+          />
+        </LoadingOverlay.Content>
+      </LoadingOverlay>
       {handover && (renderChildren || handover.animationUrl) && (
         <Stack
           sx={{

--- a/packages/checkout/widgets-lib/src/components/Loading/InlineLoadingOverlay.tsx
+++ b/packages/checkout/widgets-lib/src/components/Loading/InlineLoadingOverlay.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import { Body, Box } from '@biom3/react';
+import { Fit, Layout, useRive } from '@rive-app/react-canvas-lite';
+
+export interface InlineLoadingOverlayProps {
+  loadingText: string | string[];
+  textDuration?: number;
+  testId?: string;
+}
+
+/**
+ * Self-contained loading UI that does not use biom3 LoadingOverlay/Modal.
+ *
+ * biom3's LoadingOverlay registers into an overlays store and does not reliably
+ * CLOSE_MODAL on unmount under React 19 (useControlledOverlay vs useIsMounted
+ * cleanup order). Unmounting a visible LoadingOverlay can leave a stuck modal.
+ */
+export function InlineLoadingOverlay({
+  loadingText,
+  textDuration = 2500,
+  testId = 'checkout-loading-view',
+}: InlineLoadingOverlayProps) {
+  const texts = Array.isArray(loadingText) ? loadingText : [loadingText];
+  const [textIndex, setTextIndex] = useState(0);
+
+  const { RiveComponent } = useRive({
+    src: 'https://biome.immutable.com/hosted-assets/rive/immutable_loader.riv',
+    autoplay: true,
+    layout: new Layout({ fit: Fit.Contain }),
+  });
+
+  useEffect(() => {
+    if (texts.length <= 1) return undefined;
+    const id = window.setInterval(() => {
+      setTextIndex((prev) => (prev + 1) % texts.length);
+    }, textDuration);
+    return () => window.clearInterval(id);
+  }, [texts.length, textDuration]);
+
+  return (
+    <Box
+      testId={testId}
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 1,
+        d: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'base.color.translucent.emphasis.300',
+      }}
+    >
+      <Box
+        testId={`${testId}__modalContent`}
+        sx={{
+          d: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 'base.spacing.x4',
+          px: 'base.spacing.x4',
+          py: 'base.spacing.x6',
+          brad: 'base.borderRadius.x6',
+          bg: 'base.color.neutral.500',
+          boxShadow: 'base.shadow.500',
+          minWidth: '220px',
+        }}
+      >
+        <Box
+          testId={`${testId}__riveBox`}
+          sx={{
+            width: '96px',
+            height: '96px',
+            flexShrink: 0,
+          }}
+        >
+          <RiveComponent />
+        </Box>
+        <Body
+          testId={`${testId}__loopingText`}
+          size="medium"
+          sx={{ textAlign: 'center' }}
+        >
+          {texts[textIndex]}
+        </Body>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/checkout/widgets-lib/src/views/loading/LoadingView.tsx
+++ b/packages/checkout/widgets-lib/src/views/loading/LoadingView.tsx
@@ -1,4 +1,5 @@
-import { BoxProps, LoadingOverlay } from '@biom3/react';
+import { BoxProps } from '@biom3/react';
+import { InlineLoadingOverlay } from '../../components/Loading/InlineLoadingOverlay';
 import { SimpleLayout } from '../../components/SimpleLayout/SimpleLayout';
 
 export interface LoadingViewProps {
@@ -6,20 +7,27 @@ export interface LoadingViewProps {
   textDuration?: number;
   containerSx?: BoxProps['sx'];
 }
-export function LoadingView({ loadingText, textDuration, containerSx = {} }: LoadingViewProps) {
-  const text = Array.isArray(loadingText) ? loadingText : [loadingText];
-  const duration = textDuration || 2500;
 
+/**
+ * Widget loading screen.
+ *
+ * Intentionally avoids biom3 LoadingOverlay/Modal: callers mount/unmount this
+ * view when the route changes (and Suspense fallbacks do the same). Under
+ * React 19, unmounting a visible LoadingOverlay orphans the modal in biom3's
+ * overlays store (still present in @biom3/react@0.32.11). An inline overlay
+ * tears down with the React tree.
+ */
+export function LoadingView({
+  loadingText,
+  textDuration,
+  containerSx = {},
+}: LoadingViewProps) {
   return (
     <SimpleLayout containerSx={containerSx}>
-      <LoadingOverlay visible testId="checkout-loading-view">
-        <LoadingOverlay.Content>
-          <LoadingOverlay.Content.LoopingText
-            text={[...text]}
-            textDuration={duration}
-          />
-        </LoadingOverlay.Content>
-      </LoadingOverlay>
+      <InlineLoadingOverlay
+        loadingText={loadingText}
+        textDuration={textDuration}
+      />
     </SimpleLayout>
   );
 }


### PR DESCRIPTION
## Summary
- After #2928 (React 19), Checkout widgets show a perpetual Loading modal over content.
- **Not fixed by bumping biom3**: catalog is `@biom3/react@^0.29.4` (~0.29.11); latest is `0.32.11` and still has the same `useControlledOverlay` unmount race.
- Surgical fix:
  - **`LoadingView`**: stop using `LoadingOverlay` (these views are conditionally mounted/unmounted across ~20 call sites + Suspense). Use an inline overlay that tears down with the tree.
  - **`Handover`**: keep biom3 `LoadingOverlay`, always mounted, `visible={Boolean(loader)}` instead of `{loader && <LoadingOverlay visible>}`.

## Test plan
- [ ] Connect mount: wallet list with **no** stuck Loading modal
- [ ] Control: CDN `2.24.3` still reproduces
- [ ] Handover loader flow (sale/purchase/add-tokens): loader shows and clears cleanly
- [ ] Smoke Swap / Bridge / Wallet mount