### PR TITLE
feat(audience): attach identityType to track()/page() events

### DIFF
--- a/packages/audience/core/src/types.ts
+++ b/packages/audience/core/src/types.ts
@@ -40,12 +40,14 @@ export interface TrackMessage extends BaseMessage {
   eventName: string;
   properties?: Record<string, unknown>;
   userId?: string;
+  identityType?: string;
 }
 
 export interface PageMessage extends BaseMessage {
   type: 'page';
   properties?: Record<string, unknown>;
   userId?: string;
+  identityType?: string;
 }
 
 export interface ScreenMessage extends BaseMessage {

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -358,6 +358,37 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
+    it('excludes identityType at anonymous consent', async () => {
+      const sdk = createSDK({ consent: 'anonymous' });
+
+      sdk.track('sign_in', { method: 'passport' });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'sign_in',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.identityType).toBeUndefined();
+
+      sdk.shutdown();
+    });
+
+    it('includes identityType at full consent after identify', async () => {
+      const sdk = createSDK({ consent: 'full' });
+
+      sdk.identify(TEST_USER.id, TEST_USER.identityType);
+      sdk.track('level_up', { level: 5 });
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'level_up',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.identityType).toBe(TEST_USER.identityType);
+
+      sdk.shutdown();
+    });
+
     it('enqueues sign_up with method property and sessionId', async () => {
       const sdk = createSDK();
 
@@ -907,6 +938,33 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
+    it('excludes identityType at anonymous consent', async () => {
+      const sdk = createSDK({ consent: 'anonymous' });
+
+      sdk.page({ section: 'shop' });
+      await sdk.flush();
+
+      const msg = sentMessages().find((m: any) => m.type === 'page');
+      expect(msg).toBeDefined();
+      expect(msg.identityType).toBeUndefined();
+
+      sdk.shutdown();
+    });
+
+    it('includes identityType at full consent after identify', async () => {
+      const sdk = createSDK({ consent: 'full' });
+
+      sdk.identify(TEST_USER.id, TEST_USER.identityType);
+      sdk.page({ section: 'shop' });
+      await sdk.flush();
+
+      const msg = sentMessages().find((m: any) => m.type === 'page');
+      expect(msg).toBeDefined();
+      expect(msg.identityType).toBe(TEST_USER.identityType);
+
+      sdk.shutdown();
+    });
+
     it('attaches attribution to the first page view only', async () => {
       Object.defineProperty(window, 'location', {
         value: {
@@ -1016,6 +1074,7 @@ describe('Audience', () => {
       const pageMsg = sentMessages().find((m: any) => m.type === 'page');
       expect(pageMsg.consentLevel).toBe('full');
       expect(pageMsg.userId).toBe(TEST_USER.id);
+      expect(pageMsg.identityType).toBe(TEST_USER.identityType);
 
       sdk.shutdown();
     });
@@ -1036,6 +1095,24 @@ describe('Audience', () => {
       expect(trackMsg).toBeDefined();
       expect(trackMsg.consentLevel).toBe('full');
       expect(trackMsg.userId).toBe(TEST_USER.id);
+      expect(trackMsg.identityType).toBe(TEST_USER.identityType);
+
+      sdk.shutdown();
+    });
+
+    it('drops identityType (like userId) from track events after downgrade from full', async () => {
+      const sdk = createSDK({ consent: 'full' });
+      sdk.identify(TEST_USER.id, TEST_USER.identityType);
+      sdk.setConsent('anonymous');
+      sdk.track('post_downgrade_event');
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'post_downgrade_event',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.userId).toBeUndefined();
+      expect(msg.identityType).toBeUndefined();
 
       sdk.shutdown();
     });
@@ -1492,6 +1569,25 @@ describe('Audience', () => {
       sdk.shutdown();
     });
 
+    it('clears userId and identityType on downgrade to none, so a later upgrade to full does not resurface them', async () => {
+      const sdk = createSDK({ consent: 'full' });
+      sdk.identify(TEST_USER.id, TEST_USER.identityType);
+
+      sdk.setConsent('none');
+      sdk.setConsent('full');
+      sdk.track('post_reidentify_event');
+      await sdk.flush();
+
+      const msg = sentMessages().find(
+        (m: any) => m.type === 'track' && m.eventName === 'post_reidentify_event',
+      );
+      expect(msg).toBeDefined();
+      expect(msg.userId).toBeUndefined();
+      expect(msg.identityType).toBeUndefined();
+
+      sdk.shutdown();
+    });
+
     it('stops queue and makes track no-op on anonymous to none downgrade', async () => {
       const sdk = createSDK({ consent: 'anonymous' });
 
@@ -1603,6 +1699,7 @@ describe('Audience', () => {
       );
       expect(msg).toBeDefined();
       expect(msg.userId).toBeUndefined();
+      expect(msg.identityType).toBeUndefined();
       expect(msg.anonymousId).toBeDefined();
       expect(msg.anonymousId).not.toBe(originalAnonId);
 

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -117,6 +117,8 @@ export class Audience {
 
   private userId: string | undefined;
 
+  private identityType: IdentityType | undefined;
+
   private isFirstPage = true;
 
   private destroyed = false;
@@ -260,6 +262,11 @@ export class Audience {
     return canIdentify(this.consent.level) ? this.userId : undefined;
   }
 
+  /** Returns identityType if consent is full, undefined otherwise. */
+  private effectiveIdentityType(): IdentityType | undefined {
+    return canIdentify(this.consent.level) ? this.identityType : undefined;
+  }
+
   /** Create or resume the rolling session and cache its ID. */
   private refreshSession(): void {
     this.sessionId = getOrCreateSessionId(this.cookieDomain);
@@ -314,6 +321,7 @@ export class Audience {
       type: 'page',
       properties: mergedProps,
       userId: this.effectiveUserId(),
+      identityType: this.effectiveIdentityType(),
     });
   }
 
@@ -413,6 +421,7 @@ export class Audience {
       eventName: truncate(event),
       properties: mergedProps,
       userId: this.effectiveUserId(),
+      identityType: this.effectiveIdentityType(),
     });
   }
 
@@ -445,6 +454,7 @@ export class Audience {
 
     const resolvedId = truncate(id.trim());
     this.userId = resolvedId;
+    this.identityType = identityType;
     this.enqueue('identify', {
       ...this.baseMessage(),
       type: 'identify',
@@ -550,8 +560,13 @@ export class Audience {
     if (!canTrack(effective)) {
       deleteCookie(COOKIE_NAME, this.cookieDomain);
       deleteCookie(SESSION_COOKIE, this.cookieDomain);
-    } else if (canIdentify(previous) && !canIdentify(effective)) {
+    }
+    if (!canIdentify(effective)) {
+      // Cleared on any downgrade out of full (not just to anonymous) so a
+      // later upgrade back to full can't resurface a stale identity without
+      // a fresh identify() call.
       this.userId = undefined;
+      this.identityType = undefined;
     }
 
     if (isUpgradeFromNone) {
@@ -570,6 +585,7 @@ export class Audience {
    */
   reset(): void {
     this.userId = undefined;
+    this.identityType = undefined;
     this.queue.clear();
     deleteCookie(COOKIE_NAME, this.cookieDomain);
     deleteCookie(SESSION_COOKIE, this.cookieDomain);


### PR DESCRIPTION
## Summary
userId already carries forward from the last identify() call onto every subsequent track()/page() event; identityType did not. This persists identityType alongside userId on the SDK instance and attaches it to track()/page() the same way, clearing both on reset()/consent downgrade.

## Test plan
- [x] `jest` (audience/sdk, audience/core) — 461 tests, 0 failed
- [x] `tsc --noEmit` — no type errors
- [x] `oxlint` (audience package tree) — no new warnings/errors