### PR TITLE
fix(sdk): promote three bug-catching lint rules to error and fix the fallout

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -66,6 +66,8 @@
       }
     ],
 
+    "eslint/preserve-caught-error": "error",
+
     "eslint/no-unused-vars": [
       "warn",
       {
@@ -80,7 +82,7 @@
     "typescript/restrict-template-expressions": "warn",
     "typescript/await-thenable": "warn",
     "typescript/no-redundant-type-constituents": "warn",
-    "typescript/no-non-null-asserted-optional-chain": "warn",
+    "typescript/no-non-null-asserted-optional-chain": "error",
     "typescript/no-duplicate-type-constituents": "warn",
     "typescript/no-unsafe-type-assertion": "off",
     "typescript/no-unnecessary-type-assertion": "off",
@@ -90,7 +92,7 @@
     "typescript/no-duplicate-enum-values": "warn",
     "typescript/no-unnecessary-parameter-property-assignment": "off",
     "typescript/no-this-alias": "warn",
-    "typescript/no-base-to-string": "warn",
+    "typescript/no-base-to-string": "error",
     "typescript/no-wrapper-object-types": "warn",
     "typescript/no-for-in-array": "warn",
 

--- a/packages/checkout/widgets-lib/src/lib/connectEIP6963Provider.ts
+++ b/packages/checkout/widgets-lib/src/lib/connectEIP6963Provider.ts
@@ -43,9 +43,10 @@ export const connectEIP6963Provider = async (
       case CheckoutErrorType.USER_REJECTED_REQUEST_ERROR:
         throw new Error(
           ConnectEIP6963ProviderError.USER_REJECTED_REQUEST_ERROR,
+          { cause: error },
         );
       default:
-        throw new Error(ConnectEIP6963ProviderError.CONNECT_ERROR);
+        throw new Error(ConnectEIP6963ProviderError.CONNECT_ERROR, { cause: error });
     }
   }
 };

--- a/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/bridge/components/BridgeReviewSummary.tsx
@@ -305,24 +305,28 @@ export function BridgeReviewSummary() {
   }, []);
 
   const handleNetworkSwitch = useCallback((provider: WrappedBrowserProvider) => {
+    // Both sides must already be selected — this only ever runs after the review
+    // screen has them. Bail rather than dispatching undefined into bridge state.
+    if (!from || !to) return;
+
     bridgeDispatch({
       payload: {
         type: BridgeActions.SET_WALLETS_AND_NETWORKS,
         from: {
           browserProvider: provider,
-          walletAddress: from?.walletAddress!,
-          walletProviderInfo: from?.walletProviderInfo!,
-          network: from?.network!,
+          walletAddress: from.walletAddress,
+          walletProviderInfo: from.walletProviderInfo,
+          network: from.network,
         },
         to: {
-          browserProvider: to?.browserProvider!,
-          walletAddress: to?.walletAddress!,
-          walletProviderInfo: to?.walletProviderInfo!,
-          network: to?.network!,
+          browserProvider: to.browserProvider,
+          walletAddress: to.walletAddress,
+          walletProviderInfo: to.walletProviderInfo,
+          network: to.network,
         },
       },
     });
-  }, [from?.browserProvider, from?.network, to?.browserProvider, to?.network]);
+  }, [from, to]);
 
   useEffect(() => {
     if (!from?.browserProvider) return;
@@ -627,14 +631,16 @@ export function BridgeReviewSummary() {
         </Button>
         )}
       </Box>
-      <NetworkSwitchDrawer
-        visible={showSwitchNetworkDrawer}
-        targetChainId={from?.network!}
-        provider={from?.browserProvider!}
-        checkout={checkout}
-        onCloseDrawer={() => setShowSwitchNetworkDrawer(false)}
-        onNetworkSwitch={handleNetworkSwitch}
-      />
+      {from && (
+        <NetworkSwitchDrawer
+          visible={showSwitchNetworkDrawer}
+          targetChainId={from.network}
+          provider={from.browserProvider}
+          checkout={checkout}
+          onCloseDrawer={() => setShowSwitchNetworkDrawer(false)}
+          onNetworkSwitch={handleNetworkSwitch}
+        />
+      )}
       <NotEnoughGas
         environment={checkout.config.environment}
         visible={showNotEnoughGasDrawer}

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidget.tsx
@@ -160,10 +160,12 @@ export default function SaleWidget(props: SaleWidgetProps) {
               errorType={viewState.view.data?.errorType}
               transactionHash={viewState.view.data?.transactionHash}
               vendorMessage={viewState.view.data?.vendorError?.message}
-              blockExplorerLink={BlockExplorerService.getTransactionLink(
-                chainId.current as ChainId,
-                viewState.view.data?.transactionHash!,
-              )}
+              blockExplorerLink={viewState.view.data?.transactionHash
+                ? BlockExplorerService.getTransactionLink(
+                  chainId.current as ChainId,
+                  viewState.view.data.transactionHash,
+                )
+                : undefined}
             />
           )}
           {viewState.view.type === SaleWidgetViews.ORDER_SUMMARY && (

--- a/packages/checkout/widgets-lib/src/widgets/sale/functions/fundingBalanceFees.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/functions/fundingBalanceFees.ts
@@ -87,8 +87,10 @@ export const getFundingBalanceFeeBreakDown = (
   }
 
   const addFee = (fee: Fee, label: string, prefix: string = '~ ') => {
-    if (fee.amount > 0) {
-      const formattedFee = formatUnits(fee.amount, fee?.token?.decimals);
+    // A fee without a token can't be rendered — FormattedFee.token is required
+    // and consumers read token.symbol, so skip rather than push a hole.
+    if (fee.amount > 0 && fee.token) {
+      const formattedFee = formatUnits(fee.amount, fee.token.decimals);
 
       feesBreakdown.push({
         label,
@@ -103,7 +105,7 @@ export const getFundingBalanceFeeBreakDown = (
         )}`,
         amount: `${tokenValueFormat(formattedFee)}`,
         prefix,
-        token: fee?.token!,
+        token: fee.token,
       });
     }
   };

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/OrderSummary.tsx
@@ -231,7 +231,9 @@ export function OrderSummary({ subView }: OrderSummaryProps) {
       // suggest to top up base currency balance
       const smartCheckoutResult = fundingBalancesResult.find(
         (result) => result.currency.base,
-      )?.smartCheckoutResult!;
+      )?.smartCheckoutResult;
+      if (!smartCheckoutResult) return;
+
       const data = getTopUpViewData(
         smartCheckoutResult.transactionRequirements,
       );

--- a/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/sale/views/PayWithCoins.tsx
@@ -89,7 +89,11 @@ export function PayWithCoins() {
       },
       (error, txns) => {
         const details = { transactionId: signResponse?.transactionId };
-        sendFailedEvent(error.toString(), error, txns, undefined, details); // checkoutPrimarySalePaymentMethods_FailEventFailed
+        // `error` is a SignOrderError ({ type, data }), not an Error. Its default
+        // toString is "[object Object]", so this event was reporting nothing
+        // useful — `type` is the field that identifies the failure.
+        const reason = error instanceof Error ? error.message : error.type;
+        sendFailedEvent(reason, error, txns, undefined, details); // checkoutPrimarySalePaymentMethods_FailEventFailed
         goToErrorView(error.type, error.data);
       },
       onTxnStepExecuteAll,

--- a/packages/checkout/widgets-lib/src/widgets/wallet/WalletWidgetRoot.tsx
+++ b/packages/checkout/widgets-lib/src/widgets/wallet/WalletWidgetRoot.tsx
@@ -96,8 +96,8 @@ export class Wallet extends Base<WidgetType.WALLET> {
                     config={this.strongConfig()}
                     walletConfig={{
                       showDisconnectButton:
-                        this.properties.config?.showDisconnectButton!,
-                      showNetworkMenu: this.properties.config?.showNetworkMenu!,
+                        this.properties.config?.showDisconnectButton ?? false,
+                      showNetworkMenu: this.properties.config?.showNetworkMenu ?? false,
                     }}
                   />
                 </Suspense>

--- a/packages/internal/bridge/sdk/src/lib/validation.test.ts
+++ b/packages/internal/bridge/sdk/src/lib/validation.test.ts
@@ -35,7 +35,7 @@ describe('Validation', () => {
       try {
         await validateChainConfiguration(bridgeConfig);
       } catch (error: any) {
-        throw new Error(`Should not have thrown an error, but threw ${error}`);
+        throw new Error(`Should not have thrown an error, but threw ${error}`, { cause: error });
       }
     });
 
@@ -107,7 +107,7 @@ describe('Validation', () => {
       try {
         await checkReceiver(tokenSent, destinationChainId, '0x123', config);
       } catch (error: any) {
-        throw new Error(`Should not have thrown an error, but threw ${error}`);
+        throw new Error(`Should not have thrown an error, but threw ${error}`, { cause: error });
       }
     });
 
@@ -125,7 +125,7 @@ describe('Validation', () => {
       try {
         await checkReceiver(tokenSent, destinationChainId, '0x123', config);
       } catch (error: any) {
-        throw new Error(`Should not have thrown an error, but threw ${error}`);
+        throw new Error(`Should not have thrown an error, but threw ${error}`, { cause: error });
       }
     });
 
@@ -147,7 +147,7 @@ describe('Validation', () => {
         await checkReceiver(tokenSent, destinationChainId, '0x123', config);
         expect(mockProvider.getCode).toHaveBeenCalledTimes(1);
       } catch (error: any) {
-        throw new Error(`Should not have thrown an error, but threw ${error}`);
+        throw new Error(`Should not have thrown an error, but threw ${error}`, { cause: error });
       }
     });
 

--- a/packages/internal/bridge/sdk/src/tokenBridge.ts
+++ b/packages/internal/bridge/sdk/src/tokenBridge.ts
@@ -158,11 +158,14 @@ export class TokenBridge {
   public async getFee(req: BridgeFeeRequest): Promise<BridgeFeeResponse> {
     const [, , res] = await Promise.all([
       this.initialise(),
-      async () => {
+      // Note the trailing `()`. This was previously passed as an uninvoked async
+      // function, so Promise.all resolved it to the function object and the
+      // chain-id validation never ran.
+      (async () => {
         if (req.action !== BridgeFeeActions.FINALISE_WITHDRAWAL) {
           await validateChainIds(req.sourceChainId, req.destinationChainId, this.config);
         }
-      },
+      })(),
       this.getFeePrivate(req),
     ]);
     return res;
@@ -702,7 +705,7 @@ export class TokenBridge {
     const [allowance, feeData, tenderlyRes] = await Promise.all([
       this.getAllowance(direction, token, sender),
       this.config.childProvider.getFeeData(),
-      await this.getDynamicWithdrawGasRootChain(
+      this.getDynamicWithdrawGasRootChain(
         direction.destinationChainId,
         sender,
         recipient,

--- a/packages/internal/dex/sdk/src/lib/utils.test.ts
+++ b/packages/internal/dex/sdk/src/lib/utils.test.ts
@@ -25,7 +25,7 @@ const provider = {
       if (payload.to === USDC_TEST_TOKEN.address) {
         return USDC_TEST_TOKEN.decimals.toString(16);
       }
-      throw new Error(`Unrecognized ERC20: ${payload.to}`);
+      throw new Error(`Unrecognized ERC20: ${JSON.stringify(payload.to)}`);
     }
     throw new Error(`Call not supported: ${payload.data}`);
   }),

--- a/packages/orderbook/src/orderbook.ts
+++ b/packages/orderbook/src/orderbook.ts
@@ -94,7 +94,7 @@ export class Orderbook {
 
     if (config.overrides?.jsonRpcProviderUrl) {
       finalConfig.provider = getConfiguredProvider(
-        config.overrides?.jsonRpcProviderUrl!,
+        config.overrides.jsonRpcProviderUrl,
         config.baseConfig.rateLimitingKey,
       );
     }
@@ -778,7 +778,7 @@ export class Orderbook {
 
     if (orderResult.status.name !== OrderStatusName.ACTIVE) {
       throw new Error(
-        `Cannot fulfil order that is not active. Current status: ${orderResult.status}`,
+        `Cannot fulfil order that is not active. Current status: ${orderResult.status.name}`,
       );
     }
 

--- a/packages/wallet/src/magic/magicTEESigner.ts
+++ b/packages/wallet/src/magic/magicTEESigner.ts
@@ -235,7 +235,7 @@ export default class MagicTEESigner implements WalletSigner {
           errorMessage += `: ${(error as Error).message}`;
         }
 
-        throw new Error(errorMessage);
+        throw new Error(errorMessage, { cause: error });
       }
     }, 'magicSignMessage');
   }

--- a/packages/wallet/src/zkEvm/relayerClient.ts
+++ b/packages/wallet/src/zkEvm/relayerClient.ts
@@ -155,7 +155,7 @@ export class RelayerClient {
     } catch (parseError) {
       const preview = RelayerClient.getResponsePreview(responseText);
       // eslint-disable-next-line max-len
-      throw new Error(`Relayer JSON parse error: ${parseError instanceof Error ? parseError.message : 'Unknown error'}. Content: "${preview}"`);
+      throw new Error(`Relayer JSON parse error: ${parseError instanceof Error ? parseError.message : 'Unknown error'}. Content: "${preview}"`, { cause: parseError });
     }
 
     if (jsonResponse.error) {


### PR DESCRIPTION
Follow-up to #2944.

## Why

#2944 shipped because the rule that would have caught it was set to `warn`, so nothing failed CI. This promotes three rules that catch **runtime defects** rather than style preferences, and clears the codebase so the gate stays green.

| Rule | Was | Now | Catches |
|---|---|---|---|
| `typescript/no-non-null-asserted-optional-chain` | warn | **error** | `a?.b!` — undefined at runtime, typed as present |
| `typescript/no-base-to-string` | warn | **error** | `"[object Object]"` in error messages and analytics |
| `eslint/preserve-caught-error` | — | **error** | rethrow without `cause`, discarding the original stack |

## Two real defects surfaced

**1. Bridge fee validation has been dead code.** `tokenBridge.getFee` passed an *uninvoked* async function to `Promise.all`, so it resolved the function object and `validateChainIds` never ran:

```diff
-      async () => {
+      (async () => {
         if (req.action !== BridgeFeeActions.FINALISE_WITHDRAWAL) {
           await validateChainIds(req.sourceChainId, req.destinationChainId, this.config);
         }
-      },
+      })(),
```

⚠️ **Behaviour change:** this restores validation that has not been running. Callers passing mismatched chain ids will now get the intended error instead of silently proceeding. Worth a look from someone who knows the bridge callers.

**2. Sale failure analytics reported nothing.** `PayWithCoins` called `error.toString()` on a `SignOrderError` (`{ type, data }`, not an `Error`), so every `checkoutPrimarySalePaymentMethods_FailEventFailed` event carried the literal string `"[object Object]"`. Now sends `error.type`.

## Also fixed

- An undefined provider could reach `NetworkSwitchDrawer` via `from?.browserProvider!` — the same component #2944 hardens
- `OrderSummary` dereferenced a possibly-missing `smartCheckoutResult`
- `SaleWidget` built block-explorer links containing `undefined`
- `fundingBalanceFees` pushed fees with a missing required `token`

## On `oxlint --fix`

**Not used. It is not safe on this repo.** A trial run produced:

- `.sort()` → `.toSorted()` in 11 places — ES2023 array methods (Chrome 110 / Safari 16.4 / Node 20), shipped unpolyfilled. Note this is **worse than a compile error**: `widgets-lib` sets `"lib": ["dom", "dom.iterable", "esnext"]`, so `toSorted` type-checks there and would have shipped silently. It only fails to compile in packages that inherit `target: ES2022` from `tsconfig.base.json` (orderbook, wallet, checkout/sdk, …). Verified both ways.
- Dropped entries from React dependency arrays (×2) — silent behaviour change
- Dead whitespace throughout `cancellablePromise.ts`

Which is the same failure mode as #2944: an autofix applied without review. Every change here is hand-written.

## Deferred, with counts

| Rule | Count | Why not here |
|---|---|---|
| `no-floating-promises` | 230 | Closest to #2944's root cause, but needs per-site judgment — `void` for genuine fire-and-forget, real handling for user-triggered actions. Blanket-`void`ing would silence the signal rather than fix it. Own PR. |
| `no-unsafe-enum-comparison` | 93 | Needs a canonical type chosen per comparison — a refactor, not a lint fix |
| `react-hooks/exhaustive-deps` | 235 | Every fix changes render behaviour and can cause infinite loops |

**Do not enable the `radix` rule.** It is currently off (`style` category), and its autofix is what caused #2944.

## Testing

- `pnpm typecheck` clean across widgets-lib, orderbook, wallet, bridge-sdk, dex-sdk
- widgets-lib: 39 suites / 265 tests pass
- bridge-sdk + dex-sdk: 297 tests pass
- `oxlint packages/` reports **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
