### PR TITLE
fix(auth): retry silent token refresh on transient failures

### DIFF
--- a/packages/auth/src/Auth.test.ts
+++ b/packages/auth/src/Auth.test.ts
@@ -268,6 +268,8 @@ describe('Auth', () => {
 
       await expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
 
+      // Definitive rejection: no retry, user removed immediately
+      expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(1);
       expect(mockEventEmitter.emit).toHaveBeenCalledWith(
         AuthEvents.USER_REMOVED,
         expect.objectContaining({
@@ -307,107 +309,170 @@ describe('Auth', () => {
       expect(mockUserManager.removeUser).toHaveBeenCalled();
     });
 
-    it('emits USER_REMOVED event for network errors', async () => {
-      const auth = Object.create(Auth.prototype) as Auth;
-      const mockEventEmitter = { emit: jest.fn() };
-      const mockUserManager = {
-        signinSilent: jest.fn().mockRejectedValue(new Error('Network error: Failed to fetch')),
-        removeUser: jest.fn().mockResolvedValue(undefined),
-      };
+    it('retries network errors and keeps the user when retries are exhausted', async () => {
+      jest.useFakeTimers();
+      try {
+        const auth = Object.create(Auth.prototype) as Auth;
+        const mockEventEmitter = { emit: jest.fn() };
+        const mockUserManager = {
+          signinSilent: jest.fn().mockRejectedValue(new Error('Network error: Failed to fetch')),
+          removeUser: jest.fn().mockResolvedValue(undefined),
+        };
 
-      (auth as any).eventEmitter = mockEventEmitter;
-      (auth as any).userManager = mockUserManager;
-      (auth as any).refreshingPromise = null;
+        (auth as any).eventEmitter = mockEventEmitter;
+        (auth as any).userManager = mockUserManager;
+        (auth as any).refreshingPromise = null;
 
-      await expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        await jest.advanceTimersByTimeAsync(6000); // both backoffs, generous for jitter
+        await assertion;
 
-      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
-        AuthEvents.USER_REMOVED,
-        expect.objectContaining({
-          reason: 'refresh_failed',
-        }),
-      );
-      expect(mockUserManager.removeUser).toHaveBeenCalled();
+        // Initial attempt + 2 retries, and the still-valid refresh token is kept
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(3);
+        expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+        expect(mockUserManager.removeUser).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
-    it('emits USER_REMOVED event for server_error OAuth error', async () => {
-      const auth = Object.create(Auth.prototype) as Auth;
-      const mockEventEmitter = { emit: jest.fn() };
-      const mockUserManager = {
-        signinSilent: jest.fn(),
-        removeUser: jest.fn().mockResolvedValue(undefined),
-      };
+    it('recovers when a transient failure is followed by success', async () => {
+      jest.useFakeTimers();
+      try {
+        const mockOidcUser = {
+          id_token: 'new-id',
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expired: false,
+          profile: { sub: 'user-123', email: 'test@example.com', nickname: 'tester' },
+        };
 
-      const { ErrorResponse } = jest.requireActual('oidc-client-ts');
-      const errorResponse = new ErrorResponse({
-        error: 'server_error',
-        error_description: 'Internal server error',
-      });
-      mockUserManager.signinSilent.mockRejectedValue(errorResponse);
+        (decodeJwtPayload as jest.Mock).mockReturnValue({
+          username: undefined,
+          passport: undefined,
+        });
 
-      (auth as any).eventEmitter = mockEventEmitter;
-      (auth as any).userManager = mockUserManager;
-      (auth as any).refreshingPromise = null;
+        const auth = Object.create(Auth.prototype) as Auth;
+        const mockEventEmitter = { emit: jest.fn() };
+        const mockUserManager = {
+          signinSilent: jest.fn()
+            .mockRejectedValueOnce(new Error('Network error: Failed to fetch'))
+            .mockResolvedValue(mockOidcUser),
+          removeUser: jest.fn().mockResolvedValue(undefined),
+        };
 
-      await expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        (auth as any).eventEmitter = mockEventEmitter;
+        (auth as any).userManager = mockUserManager;
+        (auth as any).refreshingPromise = null;
 
-      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
-        AuthEvents.USER_REMOVED,
-        expect.objectContaining({
-          reason: 'refresh_failed',
-        }),
-      );
-      expect(mockUserManager.removeUser).toHaveBeenCalled();
+        const refreshPromise = (auth as any).refreshTokenAndUpdatePromise();
+        await jest.advanceTimersByTimeAsync(2000); // backoff before the retry
+        const user = await refreshPromise;
+
+        expect(user.accessToken).toBe('new-access');
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(2);
+        expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+          AuthEvents.TOKEN_REFRESHED,
+          expect.objectContaining({ accessToken: 'new-access' }),
+        );
+        expect(mockUserManager.removeUser).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
-    it('emits USER_REMOVED event for unknown errors (safer default)', async () => {
-      const auth = Object.create(Auth.prototype) as Auth;
-      const mockEventEmitter = { emit: jest.fn() };
-      const mockUserManager = {
-        signinSilent: jest.fn().mockRejectedValue(new Error('Some unknown error')),
-        removeUser: jest.fn().mockResolvedValue(undefined),
-      };
+    it('retries server_error OAuth errors and keeps the user', async () => {
+      jest.useFakeTimers();
+      try {
+        const auth = Object.create(Auth.prototype) as Auth;
+        const mockEventEmitter = { emit: jest.fn() };
+        const mockUserManager = {
+          signinSilent: jest.fn(),
+          removeUser: jest.fn().mockResolvedValue(undefined),
+        };
 
-      (auth as any).eventEmitter = mockEventEmitter;
-      (auth as any).userManager = mockUserManager;
-      (auth as any).refreshingPromise = null;
+        const { ErrorResponse } = jest.requireActual('oidc-client-ts');
+        const errorResponse = new ErrorResponse({
+          error: 'server_error',
+          error_description: 'Internal server error',
+        });
+        mockUserManager.signinSilent.mockRejectedValue(errorResponse);
 
-      await expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        (auth as any).eventEmitter = mockEventEmitter;
+        (auth as any).userManager = mockUserManager;
+        (auth as any).refreshingPromise = null;
 
-      // Unknown errors should remove user (safer default)
-      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
-        AuthEvents.USER_REMOVED,
-        expect.objectContaining({
-          reason: 'refresh_failed',
-        }),
-      );
-      expect(mockUserManager.removeUser).toHaveBeenCalled();
+        const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        await jest.advanceTimersByTimeAsync(6000);
+        await assertion;
+
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(3);
+        expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+        expect(mockUserManager.removeUser).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('retries unknown errors and keeps the user', async () => {
+      jest.useFakeTimers();
+      try {
+        const auth = Object.create(Auth.prototype) as Auth;
+        const mockEventEmitter = { emit: jest.fn() };
+        const mockUserManager = {
+          signinSilent: jest.fn().mockRejectedValue(new Error('Some unknown error')),
+          removeUser: jest.fn().mockResolvedValue(undefined),
+        };
+
+        (auth as any).eventEmitter = mockEventEmitter;
+        (auth as any).userManager = mockUserManager;
+        (auth as any).refreshingPromise = null;
+
+        const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        await jest.advanceTimersByTimeAsync(6000);
+        await assertion;
+
+        // Unknown errors are treated as transient: the refresh token may still be
+        // valid, so the user is kept and the next call can try again
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(3);
+        expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+        expect(mockUserManager.removeUser).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('does not emit USER_REMOVED event for ErrorTimeout', async () => {
-      const auth = Object.create(Auth.prototype) as Auth;
-      const mockEventEmitter = { emit: jest.fn() };
-      const mockUserManager = {
-        signinSilent: jest.fn(),
-        removeUser: jest.fn().mockResolvedValue(undefined),
-      };
+      jest.useFakeTimers();
+      try {
+        const auth = Object.create(Auth.prototype) as Auth;
+        const mockEventEmitter = { emit: jest.fn() };
+        const mockUserManager = {
+          signinSilent: jest.fn(),
+          removeUser: jest.fn().mockResolvedValue(undefined),
+        };
 
-      // Mock ErrorTimeout
-      const { ErrorTimeout } = jest.requireActual('oidc-client-ts');
-      const timeoutError = new ErrorTimeout('Silent sign-in timed out');
-      mockUserManager.signinSilent.mockRejectedValue(timeoutError);
+        // Mock ErrorTimeout
+        const { ErrorTimeout } = jest.requireActual('oidc-client-ts');
+        const timeoutError = new ErrorTimeout('Silent sign-in timed out');
+        mockUserManager.signinSilent.mockRejectedValue(timeoutError);
 
-      (auth as any).eventEmitter = mockEventEmitter;
-      (auth as any).userManager = mockUserManager;
-      (auth as any).refreshingPromise = null;
+        (auth as any).eventEmitter = mockEventEmitter;
+        (auth as any).userManager = mockUserManager;
+        (auth as any).refreshingPromise = null;
 
-      await expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        await jest.advanceTimersByTimeAsync(6000); // timeouts are retried before rejecting
+        await assertion;
 
-      expect(mockEventEmitter.emit).not.toHaveBeenCalledWith(
-        AuthEvents.USER_REMOVED,
-        expect.anything(),
-      );
-      expect(mockUserManager.removeUser).not.toHaveBeenCalled();
+        expect(mockEventEmitter.emit).not.toHaveBeenCalledWith(
+          AuthEvents.USER_REMOVED,
+          expect.anything(),
+        );
+        expect(mockUserManager.removeUser).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/packages/auth/src/Auth.test.ts
+++ b/packages/auth/src/Auth.test.ts
@@ -324,11 +324,11 @@ describe('Auth', () => {
         (auth as any).refreshingPromise = null;
 
         const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
-        await jest.advanceTimersByTimeAsync(6000); // both backoffs, generous for jitter
+        await jest.advanceTimersByTimeAsync(10000); // both backoffs, generous for jitter
         await assertion;
 
-        // Initial attempt + 2 retries, and the still-valid refresh token is kept
-        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(3);
+        // Initial attempt + 3 retries, and the still-valid refresh token is kept
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(4);
         expect(mockEventEmitter.emit).not.toHaveBeenCalled();
         expect(mockUserManager.removeUser).not.toHaveBeenCalled();
       } finally {
@@ -403,10 +403,10 @@ describe('Auth', () => {
         (auth as any).refreshingPromise = null;
 
         const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
-        await jest.advanceTimersByTimeAsync(6000);
+        await jest.advanceTimersByTimeAsync(10000);
         await assertion;
 
-        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(3);
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(4);
         expect(mockEventEmitter.emit).not.toHaveBeenCalled();
         expect(mockUserManager.removeUser).not.toHaveBeenCalled();
       } finally {
@@ -438,10 +438,10 @@ describe('Auth', () => {
         (auth as any).refreshingPromise = null;
 
         const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
-        await jest.advanceTimersByTimeAsync(6000);
+        await jest.advanceTimersByTimeAsync(10000);
         await assertion;
 
-        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(3);
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(4);
         expect(mockEventEmitter.emit).not.toHaveBeenCalled();
         expect(mockUserManager.removeUser).not.toHaveBeenCalled();
       } finally {
@@ -464,12 +464,12 @@ describe('Auth', () => {
         (auth as any).refreshingPromise = null;
 
         const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
-        await jest.advanceTimersByTimeAsync(6000);
+        await jest.advanceTimersByTimeAsync(10000);
         await assertion;
 
         // Unknown errors are treated as transient: the refresh token may still be
         // valid, so the user is kept and the next call can try again
-        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(3);
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(4);
         expect(mockEventEmitter.emit).not.toHaveBeenCalled();
         expect(mockUserManager.removeUser).not.toHaveBeenCalled();
       } finally {
@@ -497,7 +497,7 @@ describe('Auth', () => {
         (auth as any).refreshingPromise = null;
 
         const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
-        await jest.advanceTimersByTimeAsync(6000); // timeouts are retried before rejecting
+        await jest.advanceTimersByTimeAsync(10000); // timeouts are retried before rejecting
         await assertion;
 
         expect(mockEventEmitter.emit).not.toHaveBeenCalledWith(

--- a/packages/auth/src/Auth.test.ts
+++ b/packages/auth/src/Auth.test.ts
@@ -414,6 +414,41 @@ describe('Auth', () => {
       }
     });
 
+    it('retries too_many_requests OAuth errors (rate limit) and keeps the user', async () => {
+      jest.useFakeTimers();
+      try {
+        const auth = Object.create(Auth.prototype) as Auth;
+        const mockEventEmitter = { emit: jest.fn() };
+        const mockUserManager = {
+          signinSilent: jest.fn(),
+          removeUser: jest.fn().mockResolvedValue(undefined),
+        };
+
+        // oidc-client-ts surfaces any non-OK response with an `error` body field as
+        // an ErrorResponse, including 429s — these must not destroy the session
+        const { ErrorResponse } = jest.requireActual('oidc-client-ts');
+        const errorResponse = new ErrorResponse({
+          error: 'too_many_requests',
+          error_description: 'Rate limit exceeded',
+        });
+        mockUserManager.signinSilent.mockRejectedValue(errorResponse);
+
+        (auth as any).eventEmitter = mockEventEmitter;
+        (auth as any).userManager = mockUserManager;
+        (auth as any).refreshingPromise = null;
+
+        const assertion = expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+        await jest.advanceTimersByTimeAsync(6000);
+        await assertion;
+
+        expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(3);
+        expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+        expect(mockUserManager.removeUser).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('retries unknown errors and keeps the user', async () => {
       jest.useFakeTimers();
       try {

--- a/packages/auth/src/Auth.test.ts
+++ b/packages/auth/src/Auth.test.ts
@@ -205,6 +205,7 @@ describe('Auth', () => {
       const mockEventEmitter = { emit: jest.fn() };
       const mockUserManager = {
         signinSilent: jest.fn().mockResolvedValue(mockOidcUser),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
       };
 
       (auth as any).eventEmitter = mockEventEmitter;
@@ -229,6 +230,7 @@ describe('Auth', () => {
       const mockEventEmitter = { emit: jest.fn() };
       const mockUserManager = {
         signinSilent: jest.fn().mockResolvedValue(null),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
       };
 
       (auth as any).eventEmitter = mockEventEmitter;
@@ -252,6 +254,7 @@ describe('Auth', () => {
           }),
         ),
         removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
       };
 
       // Make the error an instance of ErrorResponse
@@ -285,6 +288,7 @@ describe('Auth', () => {
       const mockUserManager = {
         signinSilent: jest.fn(),
         removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
       };
 
       const { ErrorResponse } = jest.requireActual('oidc-client-ts');
@@ -317,6 +321,7 @@ describe('Auth', () => {
         const mockUserManager = {
           signinSilent: jest.fn().mockRejectedValue(new Error('Network error: Failed to fetch')),
           removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
         };
 
         (auth as any).eventEmitter = mockEventEmitter;
@@ -359,6 +364,7 @@ describe('Auth', () => {
             .mockRejectedValueOnce(new Error('Network error: Failed to fetch'))
             .mockResolvedValue(mockOidcUser),
           removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
         };
 
         (auth as any).eventEmitter = mockEventEmitter;
@@ -389,6 +395,7 @@ describe('Auth', () => {
         const mockUserManager = {
           signinSilent: jest.fn(),
           removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
         };
 
         const { ErrorResponse } = jest.requireActual('oidc-client-ts');
@@ -422,6 +429,7 @@ describe('Auth', () => {
         const mockUserManager = {
           signinSilent: jest.fn(),
           removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
         };
 
         // oidc-client-ts surfaces any non-OK response with an `error` body field as
@@ -457,6 +465,7 @@ describe('Auth', () => {
         const mockUserManager = {
           signinSilent: jest.fn().mockRejectedValue(new Error('Some unknown error')),
           removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
         };
 
         (auth as any).eventEmitter = mockEventEmitter;
@@ -485,6 +494,7 @@ describe('Auth', () => {
         const mockUserManager = {
           signinSilent: jest.fn(),
           removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue({ refresh_token: 'stored-refresh-token' }),
         };
 
         // Mock ErrorTimeout
@@ -508,6 +518,26 @@ describe('Auth', () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+
+    it('fails fast without retrying when there is no stored refresh token', async () => {
+      const auth = Object.create(Auth.prototype) as Auth;
+      const mockEventEmitter = { emit: jest.fn() };
+      const mockUserManager = {
+        signinSilent: jest.fn().mockRejectedValue(new Error('No silent_redirect_uri configured')),
+        removeUser: jest.fn().mockResolvedValue(undefined),
+        getUser: jest.fn().mockResolvedValue(null),
+      };
+
+      (auth as any).eventEmitter = mockEventEmitter;
+      (auth as any).userManager = mockUserManager;
+      (auth as any).refreshingPromise = null;
+
+      await expect((auth as any).refreshTokenAndUpdatePromise()).rejects.toThrow();
+
+      // Deterministic failure (no session to refresh): single attempt, no backoff
+      expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(1);
+      expect(mockUserManager.removeUser).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -62,7 +62,12 @@ const parseJsonSafely = (text: string): unknown => {
 // from the token endpoint) would otherwise destroy a session backed by a still-valid
 // refresh token. Retry with jittered backoff, and only remove the stored user when the
 // authorization server definitively rejects the refresh token.
-const SILENT_REFRESH_MAX_RETRIES = 2;
+// 4 attempts spread over ~3-6s of jittered backoff. Kept deliberately short: the
+// refresh blocks getAccessToken callers, and rate-limit windows are per-second, so
+// ~1s spacing already lands retries in a fresh bucket. Outages longer than this are
+// covered across cycles — exhaustion keeps the user, so the next getAccessToken
+// call starts a new cycle.
+const SILENT_REFRESH_MAX_RETRIES = 3;
 const SILENT_REFRESH_RETRY_DELAY_MS = 1000;
 
 function refreshRetryDelay(ms: number): Promise<void> {

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -870,6 +870,13 @@ export class Auth {
             errorMessage = `${errorMessage}: ${err}`;
           }
 
+          // Terminal refresh failures were previously invisible (client-side
+          // logger.warn only), which made fleet-wide incidents impossible to see.
+          trackError('passport', 'silentRefresh', err instanceof Error ? err : new Error(errorMessage), {
+            userRemoved: removeUser,
+            ...(err instanceof ErrorResponse && err.error ? { oauthErrorCode: err.error } : {}),
+          });
+
           if (removeUser) {
             // Emit USER_REMOVED event BEFORE removing user so consumers can react
             // (e.g., auth-next-client can clear the NextAuth session)

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -58,6 +58,34 @@ const parseJsonSafely = (text: string): unknown => {
   }
 };
 
+// A transient failure on the silent refresh (network error, timeout, 5xx or rate limit
+// from the token endpoint) would otherwise destroy a session backed by a still-valid
+// refresh token. Retry with jittered backoff, and only remove the stored user when the
+// authorization server definitively rejects the refresh token.
+const SILENT_REFRESH_MAX_RETRIES = 2;
+const SILENT_REFRESH_RETRY_DELAY_MS = 1000;
+
+function refreshRetryDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+// Full jitter on the backoff so that when the token endpoint fails for many clients at
+// once (peak-hour rate limiting), their retries spread out instead of synchronising.
+function refreshBackoffWithJitter(attemptNumber: number): number {
+  const base = SILENT_REFRESH_RETRY_DELAY_MS * attemptNumber;
+  return base * (0.5 + Math.random() * 0.5);
+}
+
+// OAuth error codes that indicate a server-side fault rather than a verdict on the
+// refresh token itself. Any other ErrorResponse is a definitive rejection.
+const TRANSIENT_OAUTH_ERROR_CODES = new Set(['server_error', 'temporarily_unavailable']);
+
+const isPermanentRefreshError = (error: unknown): boolean => (
+  error instanceof ErrorResponse && !TRANSIENT_OAUTH_ERROR_CODES.has(error.error ?? '')
+);
+
 const extractTokenErrorMessage = (
   payload: unknown,
   fallbackText: string,
@@ -751,6 +779,26 @@ export class Auth {
     });
   }
 
+  private async signinSilentWithRetry(): Promise<OidcUser | null> {
+    const attempt = async (attemptNumber: number): Promise<OidcUser | null> => {
+      try {
+        const oidcUser = await this.userManager.signinSilent();
+        if (attemptNumber > 1) {
+          track('passport', 'silentRefreshRecovered', { attempt: attemptNumber });
+        }
+        return oidcUser;
+      } catch (error) {
+        if (isPermanentRefreshError(error) || attemptNumber > SILENT_REFRESH_MAX_RETRIES) {
+          throw error;
+        }
+        logger.warn(`Silent refresh attempt ${attemptNumber} failed, retrying`, error);
+        await refreshRetryDelay(refreshBackoffWithJitter(attemptNumber));
+        return attempt(attemptNumber + 1);
+      }
+    };
+    return attempt(1);
+  }
+
   private async refreshTokenAndUpdatePromise(): Promise<User | null> {
     if (this.refreshingPromise) {
       return this.refreshingPromise;
@@ -759,7 +807,7 @@ export class Auth {
     this.refreshingPromise = new Promise((resolve, reject) => {
       (async () => {
         try {
-          const newOidcUser = await this.userManager.signinSilent();
+          const newOidcUser = await this.signinSilentWithRetry();
           if (newOidcUser) {
             const user = Auth.mapOidcUserToDomainModel(newOidcUser);
             // Emit TOKEN_REFRESHED event so consumers (e.g., auth-next-client) can sync
@@ -773,13 +821,15 @@ export class Auth {
         } catch (err) {
           let passportErrorType = PassportErrorType.AUTHENTICATION_ERROR;
           let errorMessage = 'Failed to refresh token';
-          // Default to REMOVING user - safer to log out on unknown errors
-          // Only keep user logged in for explicitly known transient errors
-          let removeUser = true;
+          // Only remove the user when the authorization server definitively rejected
+          // the refresh token. Transient failures (network errors, timeouts, 5xx, rate
+          // limits) have already been retried by signinSilentWithRetry; if they still
+          // fail, keep the stored user so the next call can try again — the refresh
+          // token is still valid.
+          const removeUser = isPermanentRefreshError(err);
           if (err instanceof ErrorTimeout) {
             passportErrorType = PassportErrorType.SILENT_LOGIN_ERROR;
             errorMessage = `${errorMessage}: ${err.message}`;
-            removeUser = false;
           } else if (err instanceof ErrorResponse) {
             passportErrorType = PassportErrorType.NOT_LOGGED_IN_ERROR;
             errorMessage = `${errorMessage}: ${err.message || err.error_description}`;

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -39,6 +39,7 @@ import DeviceCredentialsManager from './storage/device_credentials_manager';
 import { PassportError, PassportErrorType, withPassportError } from './errors';
 import logger from './utils/logger';
 import { isAccessTokenExpiredOrExpiring } from './utils/token';
+import { delay, backoffWithJitter } from './utils/retry';
 import LoginPopupOverlay from './overlay/loginPopupOverlay';
 import { LocalForageAsyncStorage } from './storage/LocalForageAsyncStorage';
 import { buildLogoutUrl } from './logout';
@@ -69,19 +70,6 @@ const parseJsonSafely = (text: string): unknown => {
 // call starts a new cycle.
 const SILENT_REFRESH_MAX_RETRIES = 3;
 const SILENT_REFRESH_RETRY_DELAY_MS = 1000;
-
-function refreshRetryDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-// Full jitter on the backoff so that when the token endpoint fails for many clients at
-// once (peak-hour rate limiting), their retries spread out instead of synchronising.
-function refreshBackoffWithJitter(attemptNumber: number): number {
-  const base = SILENT_REFRESH_RETRY_DELAY_MS * attemptNumber;
-  return base * (0.5 + Math.random() * 0.5);
-}
 
 // OAuth error codes that are a definitive verdict on the refresh token or client —
 // the session cannot be recovered by retrying, so the stored user must be removed.
@@ -809,6 +797,13 @@ export class Auth {
   }
 
   private async signinSilentWithRetry(): Promise<OidcUser | null> {
+    // Retrying only helps when there is a refresh token to exchange — the failure
+    // modes worth absorbing (429s, 5xx, network blips) all live on that exchange.
+    // A silent login without one (no stored session, iframe flow) fails
+    // deterministically, so it gets a single attempt and fails fast.
+    const storedUser = await this.userManager.getUser();
+    const canRetry = !!storedUser?.refresh_token;
+
     const attempt = async (attemptNumber: number): Promise<OidcUser | null> => {
       try {
         const oidcUser = await this.userManager.signinSilent();
@@ -817,11 +812,11 @@ export class Auth {
         }
         return oidcUser;
       } catch (error) {
-        if (isPermanentRefreshError(error) || attemptNumber > SILENT_REFRESH_MAX_RETRIES) {
+        if (!canRetry || isPermanentRefreshError(error) || attemptNumber > SILENT_REFRESH_MAX_RETRIES) {
           throw error;
         }
         logger.warn(`Silent refresh attempt ${attemptNumber} failed, retrying`, error);
-        await refreshRetryDelay(refreshBackoffWithJitter(attemptNumber));
+        await delay(backoffWithJitter(SILENT_REFRESH_RETRY_DELAY_MS, attemptNumber));
         return attempt(attemptNumber + 1);
       }
     };

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -78,12 +78,36 @@ function refreshBackoffWithJitter(attemptNumber: number): number {
   return base * (0.5 + Math.random() * 0.5);
 }
 
-// OAuth error codes that indicate a server-side fault rather than a verdict on the
-// refresh token itself. Any other ErrorResponse is a definitive rejection.
-const TRANSIENT_OAUTH_ERROR_CODES = new Set(['server_error', 'temporarily_unavailable']);
+// OAuth error codes that are a definitive verdict on the refresh token or client —
+// the session cannot be recovered by retrying, so the stored user must be removed.
+// Sources:
+// - RFC 6749 §5.2 (token endpoint error codes, invalid_request..invalid_scope):
+//   https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+// - OIDC Core §3.1.2.6 (access_denied, login_required, consent_required,
+//   interaction_required, account_selection_required):
+//   https://openid.net/specs/openid-connect-core-1_0.html#AuthError
+// Anything else (RFC 6749's server_error / temporarily_unavailable, Auth0's
+// too_many_requests rate-limit code, unknown/custom codes) is treated as transient:
+// oidc-client-ts throws ErrorResponse for ANY non-OK response whose body has an
+// `error` field — including 429s and 5xxs — so an allowlist of fatal codes is the
+// only safe way to avoid destroying a still-valid session.
+// Auth0 rate limits: https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy
+const PERMANENT_OAUTH_ERROR_CODES = new Set([
+  'invalid_request',
+  'invalid_client',
+  'invalid_grant',
+  'unauthorized_client',
+  'unsupported_grant_type',
+  'invalid_scope',
+  'access_denied',
+  'login_required',
+  'consent_required',
+  'interaction_required',
+  'account_selection_required',
+]);
 
 const isPermanentRefreshError = (error: unknown): boolean => (
-  error instanceof ErrorResponse && !TRANSIENT_OAUTH_ERROR_CODES.has(error.error ?? '')
+  error instanceof ErrorResponse && PERMANENT_OAUTH_ERROR_CODES.has(error.error ?? '')
 );
 
 const extractTokenErrorMessage = (
@@ -831,7 +855,9 @@ export class Auth {
             passportErrorType = PassportErrorType.SILENT_LOGIN_ERROR;
             errorMessage = `${errorMessage}: ${err.message}`;
           } else if (err instanceof ErrorResponse) {
-            passportErrorType = PassportErrorType.NOT_LOGGED_IN_ERROR;
+            passportErrorType = removeUser
+              ? PassportErrorType.NOT_LOGGED_IN_ERROR
+              : PassportErrorType.AUTHENTICATION_ERROR;
             errorMessage = `${errorMessage}: ${err.message || err.error_description}`;
           } else if (err instanceof Error) {
             errorMessage = `${errorMessage}: ${err.message}`;

--- a/packages/auth/src/login/standalone.ts
+++ b/packages/auth/src/login/standalone.ts
@@ -6,6 +6,7 @@
 
 import { Detail, getDetail, track } from '@imtbl/metrics';
 import { decodeJwtPayload } from '../utils/jwt';
+import { delay, backoffWithJitter } from '../utils/retry';
 import type {
   DirectLoginOptions, IdTokenPayload, MarketingConsentStatus, ZkEvmInfo,
 } from '../types';
@@ -439,19 +440,6 @@ const TOKEN_EXCHANGE_RETRY_DELAY_MS = 1000;
 // indefinite hang (this path has no other timeout around it).
 const TOKEN_EXCHANGE_TIMEOUT_MS = 10000;
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-// Full jitter on the backoff so that when auth returns 5xx to many clients at once,
-// their retries spread out instead of synchronising into a thundering herd.
-function backoffWithJitter(attemptNumber: number): number {
-  const base = TOKEN_EXCHANGE_RETRY_DELAY_MS * attemptNumber;
-  return base * (0.5 + Math.random() * 0.5);
-}
-
 // Outcome of a single token-exchange attempt: transient failures are retried, permanent
 // ones (4xx) are thrown straight through.
 type TokenAttemptOutcome =
@@ -553,7 +541,7 @@ async function exchangeCodeForTokens(
     });
 
     if (retriesLeft > 0) {
-      await delay(backoffWithJitter(attemptNumber));
+      await delay(backoffWithJitter(TOKEN_EXCHANGE_RETRY_DELAY_MS, attemptNumber));
       return attempt(retriesLeft - 1);
     }
     throw outcome.error;

--- a/packages/auth/src/utils/retry.ts
+++ b/packages/auth/src/utils/retry.ts
@@ -1,0 +1,12 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+// Full jitter on the backoff so that when the token endpoint fails for many clients
+// at once, their retries spread out instead of synchronising into a thundering herd.
+export function backoffWithJitter(baseDelayMs: number, attemptNumber: number): number {
+  const base = baseDelayMs * attemptNumber;
+  return base * (0.5 + Math.random() * 0.5);
+}


### PR DESCRIPTION
**TL;DR:** Illuvium players getting 401s mid-session isn't a CORS or backend problem — it's the Passport SDK destroying valid sessions when a token refresh hiccups. Tracked in [BLOC-522](https://linear.app/imtbl/issue/BLOC-522/passport-silent-token-refresh-logs-players-out-on-transient-failures).

## Symptom

Logged-in players in Unreal games start getting 401 Unauthorized mid-session, clustered in EU afternoon (peak) hours. Client logs show a CORS error on `counterfactual-address` — that's a red herring: it's the re-login cascade after the session dies, not the cause. (`Origin: null` is normal for the Unreal SDK's embedded browser bridge, and the endpoint's CORS config is fine — verified it returns 204 + `allow-origin: *`.)

## Root cause

Since ts-immutable-sdk **v1.76.8** (#2479, Dec 2024), a failed silent token refresh against Auth0 **deletes the stored user by default** — only timeouts are exempt, no retry, no backoff. So one transient failure (429 rate limit, 5xx, network blip) mid-session = permanent logout, even though the player's refresh token is still valid. On Unreal this ships in the bundled game-bridge from **unreal-immutable-sdk v1.5.0** (Feb 2025) onward.

The EU-afternoon clustering fits peak concurrency pushing refresh volume into Auth0 tenant rate limits — each throttled refresh becomes a logout instead of a retry. (Confirmation pending: Auth0 tenant logs, `fertft`/`api_limit` events during that window.)

## Fix

Mirrors the retry treatment #2931 gave the login token exchange, applied to the silent-refresh path (`refreshTokenAndUpdatePromise`):

- `signinSilentWithRetry` retries transient failures up to 3 times (4 attempts over ~3–6s of jittered backoff) with full-jitter backoff; tracks `silentRefreshRecovered` when a retry saves a session
- The stored user is only removed on a definitive OAuth rejection — an allowlist of codes from [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) and [OIDC Core §3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) (`invalid_grant`, `login_required`, …). Those are removed immediately with no retry — unchanged semantics, so the invalid-refresh-token hammering #2479 guarded against stays fixed
- Everything else is transient and **keeps the user** on retry exhaustion, so the next `getAccessToken` call tries again and the session self-heals once the outage/rate limit clears. Notably this includes rate-limit responses (`too_many_requests`) — a subtlety because oidc-client-ts throws `ErrorResponse` for any non-OK token response with an `error` body field (429s and 5xxs included), so a transient-code denylist would have misclassified the suspected production trigger as permanent

## Test plan

- [x] `Auth.test.ts`: 21/21 passing — retry-then-recover; retry-exhaustion keeping the user for network / `server_error` / `too_many_requests` / unknown errors; no-retry + immediate removal for `invalid_grant` and `login_required`
- [ ] Rebuild game-bridge and verify on Unreal (follow-up: cut alpha for the affected customer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)