### PR TITLE
fix(audience): scope tracking state per publishable key

### DIFF
--- a/packages/audience/core/src/attribution.test.ts
+++ b/packages/audience/core/src/attribution.test.ts
@@ -2,10 +2,13 @@ import {
   collectSessionAttribution,
   collectPageAttribution,
   clearAttribution,
+  clearLegacyAttribution,
   getAttributionNetwork,
 } from './attribution';
 
-const STORAGE_KEY = '__imtbl_attribution';
+const PK = 'pk_imapik-test-local';
+const OTHER_PK = 'pk_imapik-other-tenant';
+const STORAGE_KEY = `__imtbl_attribution:${PK}`;
 
 beforeEach(() => {
   sessionStorage.clear();
@@ -26,7 +29,7 @@ describe('collectSessionAttribution', () => {
       'https://example.com/?utm_source=google&utm_medium=cpc&utm_campaign=spring&utm_content=banner&utm_term=nft',
     );
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.utm_source).toBe('google');
     expect(result.utm_medium).toBe('cpc');
     expect(result.utm_campaign).toBe('spring');
@@ -40,7 +43,7 @@ describe('collectSessionAttribution', () => {
       + '&rdt_cid=rdt4&msclkid=ms5&li_fat_id=li6&twclid=tw7',
     );
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.gclid).toBe('abc');
     expect(result.dclid).toBe('dc1');
     expect(result.fbclid).toBe('fb2');
@@ -58,7 +61,7 @@ describe('collectSessionAttribution', () => {
       configurable: true,
     });
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.referrer).toBe('https://google.com/search?q=nft');
     expect(result.landing_page).toBe('https://game.example.com/landing');
   });
@@ -66,33 +69,33 @@ describe('collectSessionAttribution', () => {
   it('caches in sessionStorage and returns cached on second call', () => {
     setLocation('https://example.com/?utm_source=google');
 
-    const first = collectSessionAttribution();
+    const first = collectSessionAttribution(PK);
     expect(first.utm_source).toBe('google');
 
     // Change URL — should still return cached value
     setLocation('https://example.com/?utm_source=facebook');
-    const second = collectSessionAttribution();
+    const second = collectSessionAttribution(PK);
     expect(second.utm_source).toBe('google');
   });
 
   it('parses referral_code from the URL', () => {
     setLocation('https://example.com/?referral_code=PARTNER42');
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.referral_code).toBe('PARTNER42');
   });
 
   it('sets touchpoint_type to click when UTMs are present', () => {
     setLocation('https://example.com/?utm_source=google');
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.touchpoint_type).toBe('click');
   });
 
   it('sets touchpoint_type to click when a click ID is present', () => {
     setLocation('https://example.com/?gclid=abc123');
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.touchpoint_type).toBe('click');
   });
 
@@ -100,7 +103,7 @@ describe('collectSessionAttribution', () => {
     setLocation('https://example.com/');
     Object.defineProperty(document, 'referrer', { value: 'https://other.com', configurable: true });
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.touchpoint_type).toBeUndefined();
   });
 
@@ -108,7 +111,7 @@ describe('collectSessionAttribution', () => {
     setLocation('https://example.com/');
     Object.defineProperty(document, 'referrer', { value: '', configurable: true });
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.utm_source).toBeUndefined();
     expect(result.gclid).toBeUndefined();
     expect(result.referrer).toBeUndefined();
@@ -123,7 +126,7 @@ describe('collectSessionAttribution', () => {
       throw new Error('storage disabled');
     });
 
-    const result = collectSessionAttribution();
+    const result = collectSessionAttribution(PK);
     expect(result.utm_source).toBe('twitter');
   });
 });
@@ -131,7 +134,7 @@ describe('collectSessionAttribution', () => {
 describe('collectPageAttribution', () => {
   it('always parses from the current URL, ignoring sessionStorage', () => {
     setLocation('https://example.com/?utm_source=google');
-    collectSessionAttribution(); // seeds sessionStorage
+    collectSessionAttribution(PK); // seeds sessionStorage
 
     // Change URL — collectSessionAttribution would return cached 'google',
     // but collectPageAttribution reads the new URL.
@@ -177,11 +180,65 @@ describe('collectPageAttribution', () => {
 describe('clearAttribution', () => {
   it('removes cached attribution from sessionStorage', () => {
     setLocation('https://example.com/?utm_source=google');
-    collectSessionAttribution();
+    collectSessionAttribution(PK);
     expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
 
-    clearAttribution();
+    clearAttribution(PK);
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('leaves another publishable key\'s cache intact', () => {
+    setLocation('https://example.com/?utm_source=google');
+    collectSessionAttribution(PK);
+    collectSessionAttribution(OTHER_PK);
+
+    clearAttribution(PK);
+
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(sessionStorage.getItem(`__imtbl_attribution:${OTHER_PK}`)).not.toBeNull();
+  });
+});
+
+describe('per-publishable-key scoping', () => {
+  it('captures fresh attribution for a second key instead of replaying the first', () => {
+    // The leak this prevents: a portal serving many tenants from one origin
+    // runs one session across many keys. A session-wide cache is read before it
+    // is written, so tenant A's landing UTM would ride on tenant B's events.
+    setLocation('https://example.com/game-a?utm_source=meta&utm_medium=cpc');
+    const first = collectSessionAttribution(PK);
+    expect(first.utm_source).toBe('meta');
+    expect(first.landing_page).toBe('https://example.com/game-a?utm_source=meta&utm_medium=cpc');
+
+    setLocation('https://example.com/game-b');
+    const second = collectSessionAttribution(OTHER_PK);
+
+    expect(second.utm_source).toBeUndefined();
+    expect(second.landing_page).toBe('https://example.com/game-b');
+  });
+
+  it('still reuses the cached first touch for the same key', () => {
+    setLocation('https://example.com/game-a?utm_source=meta&utm_medium=cpc');
+    collectSessionAttribution(PK);
+
+    // Same tenant, later page in the journey — first touch must survive.
+    setLocation('https://example.com/game-a/press-kit');
+    const later = collectSessionAttribution(PK);
+
+    expect(later.utm_source).toBe('meta');
+    expect(later.landing_page).toBe('https://example.com/game-a?utm_source=meta&utm_medium=cpc');
+  });
+});
+
+describe('clearLegacyAttribution', () => {
+  it('removes the un-namespaced cache and leaves namespaced ones alone', () => {
+    setLocation('https://example.com/?utm_source=google');
+    sessionStorage.setItem('__imtbl_attribution', JSON.stringify({ utm_source: 'legacy' }));
+    collectSessionAttribution(PK);
+
+    clearLegacyAttribution();
+
+    expect(sessionStorage.getItem('__imtbl_attribution')).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
   });
 });
 

--- a/packages/audience/core/src/attribution.ts
+++ b/packages/audience/core/src/attribution.ts
@@ -19,6 +19,23 @@ const CLICK_ID_PARAMS = [
 
 const STORAGE_KEY = '__imtbl_attribution';
 
+/**
+ * Attribution is cached per publishable key, not per browser session.
+ *
+ * A host serving several tenants from one origin (e.g. a games portal with a
+ * page per studio) runs one browser session across many publishable keys.
+ * A session-wide cache is read before it is written, so it is never recaptured
+ * and the first landing's UTM params and click IDs get replayed onto every
+ * later tenant's events. Keying by publishable key scopes first-touch to the
+ * tenant it belongs to.
+ *
+ * Single-tenant consumers only ever have one key, so the key is stable and
+ * behaviour is unchanged.
+ */
+function storageKeyFor(publishableKey: string): string {
+  return `${STORAGE_KEY}:${publishableKey}`;
+}
+
 export interface Attribution {
   utm_source?: string;
   utm_medium?: string;
@@ -65,18 +82,18 @@ function parseParams(url: string): Attribution {
   return result;
 }
 
-function loadFromStorage(): Attribution | null {
+function loadFromStorage(publishableKey: string): Attribution | null {
   try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
+    const raw = sessionStorage.getItem(storageKeyFor(publishableKey));
     return raw ? (JSON.parse(raw) as Attribution) : null;
   } catch {
     return null;
   }
 }
 
-function saveToStorage(attribution: Attribution): void {
+function saveToStorage(publishableKey: string, attribution: Attribution): void {
   try {
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(attribution));
+    sessionStorage.setItem(storageKeyFor(publishableKey), JSON.stringify(attribution));
   } catch {
     // sessionStorage may be unavailable (private browsing, storage full)
   }
@@ -99,8 +116,12 @@ function buildAttribution(): Attribution {
   };
 }
 
-export function collectSessionAttribution(): Attribution {
-  const cached = loadFromStorage();
+/**
+ * First-touch attribution for `publishableKey`, captured on first call and
+ * reused for the rest of the session. Scoped per key — see {@link storageKeyFor}.
+ */
+export function collectSessionAttribution(publishableKey: string): Attribution {
+  const cached = loadFromStorage(publishableKey);
   if (cached) return cached;
 
   const landingPage = typeof window !== 'undefined' && window.location
@@ -112,7 +133,7 @@ export function collectSessionAttribution(): Attribution {
     landing_page: landingPage,
   };
 
-  saveToStorage(attribution);
+  saveToStorage(publishableKey, attribution);
   return attribution;
 }
 
@@ -125,7 +146,26 @@ export function collectPageAttribution(): Attribution {
   return buildAttribution();
 }
 
-export function clearAttribution(): void {
+/** Drop the cached first-touch attribution for `publishableKey`. */
+export function clearAttribution(publishableKey: string): void {
+  try {
+    sessionStorage.removeItem(storageKeyFor(publishableKey));
+  } catch {
+    // noop
+  }
+}
+
+/**
+ * Remove the pre-namespacing attribution cache.
+ *
+ * The old key was shared by every tenant on the origin, so its contents cannot
+ * be attributed to one. It is dropped rather than migrated: carrying it into a
+ * namespaced key would preserve exactly the cross-tenant replay the namespacing
+ * exists to stop. Attribution recaptures on the next `collectSessionAttribution`
+ * call, so the only cost is losing first-touch for sessions already in flight
+ * at upgrade time.
+ */
+export function clearLegacyAttribution(): void {
   try {
     sessionStorage.removeItem(STORAGE_KEY);
   } catch {

--- a/packages/audience/core/src/autocapture.test.ts
+++ b/packages/audience/core/src/autocapture.test.ts
@@ -55,6 +55,7 @@ describe('autocapture', () => {
       },
       enqueue,
       () => consent,
+      'pk_imapik-test-local',
     );
     teardown = result.teardown;
   }
@@ -837,7 +838,7 @@ describe('autocapture', () => {
 
   describe('config defaults', () => {
     it('enables both listeners when no options specified', () => {
-      teardown = setupAutocapture({}, enqueue, () => consent).teardown;
+      teardown = setupAutocapture({}, enqueue, () => consent, 'pk_imapik-test-local').teardown;
 
       const form = document.createElement('form');
       form.action = '/signup';
@@ -1103,7 +1104,7 @@ describe('autocapture', () => {
 
       it('enables scroll tracking by default', () => {
         // Call setupAutocapture directly to verify production defaults
-        teardown = setupAutocapture({}, enqueue, () => consent).teardown;
+        teardown = setupAutocapture({}, enqueue, () => consent, 'pk_imapik-test-local').teardown;
 
         (window as Record<string, unknown>).scrollY = 375;
         document.dispatchEvent(new Event('scroll'));
@@ -1249,7 +1250,7 @@ describe('autocapture', () => {
       });
 
       it('allows milestones to re-fire after resetScroll() (SPA route change)', () => {
-        const result = setupAutocapture({ scroll: true }, enqueue, () => consent);
+        const result = setupAutocapture({ scroll: true }, enqueue, () => consent, 'pk_imapik-test-local');
         teardown = result.teardown;
 
         // Fire 25 milestone.
@@ -1272,7 +1273,7 @@ describe('autocapture', () => {
       });
 
       it('cancels pending rAF so stale scroll position cannot fire against new page', () => {
-        const result = setupAutocapture({ scroll: true }, enqueue, () => consent);
+        const result = setupAutocapture({ scroll: true }, enqueue, () => consent, 'pk_imapik-test-local');
         teardown = result.teardown;
 
         // User has scrolled to 50% — rAF is scheduled but has not yet fired.

--- a/packages/audience/core/src/autocapture.ts
+++ b/packages/audience/core/src/autocapture.ts
@@ -167,6 +167,7 @@ export function setupAutocapture(
   options: AutocaptureOptions,
   enqueue: EnqueueFn,
   getConsent: ConsentFn,
+  publishableKey: string,
 ): { teardown: () => void; resetScroll: () => void } {
   const teardowns: Array<() => void> = [];
   let scrollReset: () => void = () => undefined;
@@ -255,7 +256,7 @@ export function setupAutocapture(
 
         if (isOutbound && options.clicks !== false) {
           enqueue('link_clicked', {
-            ...collectSessionAttribution(),
+            ...collectSessionAttribution(publishableKey),
             url: anchor.href,
             label: (anchor.textContent || '').trim().slice(0, 256),
             element_id: anchor.id || undefined,
@@ -263,7 +264,7 @@ export function setupAutocapture(
           });
         } else if (!isOutbound && options.internalClicks === true) {
           enqueue('link_clicked', {
-            ...collectSessionAttribution(),
+            ...collectSessionAttribution(publishableKey),
             url: anchor.href,
             label: (anchor.textContent || '').trim().slice(0, 256),
             element_id: anchor.id || undefined,

--- a/packages/audience/core/src/errors.ts
+++ b/packages/audience/core/src/errors.ts
@@ -80,13 +80,19 @@ export interface TransportResult {
  * - `'RATE_LIMITED'`:server returned 429. The batch is retained and will
  *                       be retried after the backoff window (honoring
  *                       `Retry-After` when present).
+ * - `'MULTIPLE_INSTANCES'`:`Audience.init()` was called while another instance
+ *                       was still live. Both instances stay running and will
+ *                       emit duplicate events until the earlier one is shut
+ *                       down. Not a transport failure — nothing was dropped —
+ *                       but it usually means a `shutdown()` call is missing.
  */
 export type AudienceErrorCode =
   | 'FLUSH_FAILED'
   | 'CONSENT_SYNC_FAILED'
   | 'NETWORK_ERROR'
   | 'VALIDATION_REJECTED'
-  | 'RATE_LIMITED';
+  | 'RATE_LIMITED'
+  | 'MULTIPLE_INSTANCES';
 
 /** One validation failure the backend reported for a single message. */
 export interface RejectionError {

--- a/packages/audience/core/src/index.ts
+++ b/packages/audience/core/src/index.ts
@@ -34,8 +34,8 @@ export { httpSend } from './transport';
 export type {
   TransportResult, AudienceErrorCode, RejectionError, MessageRejection,
 } from './errors';
-export { TransportError, AudienceError } from './errors';
-export { MessageQueue } from './queue';
+export { TransportError, AudienceError, invokeOnError } from './errors';
+export { MessageQueue, clearLegacyQueue } from './queue';
 export { collectContext } from './context';
 export {
   isTimestampValid,
@@ -52,6 +52,8 @@ export { getOrCreateSessionId } from './session';
 export {
   collectSessionAttribution,
   collectPageAttribution,
+  clearAttribution,
+  clearLegacyAttribution,
   getAttributionNetwork,
 } from './attribution';
 export type { Attribution, AttributionNetwork } from './attribution';

--- a/packages/audience/core/src/queue.test.ts
+++ b/packages/audience/core/src/queue.test.ts
@@ -35,13 +35,15 @@ interface QueueOpts {
   logPrefix?: string;
 }
 
+const TEST_KEY = 'pk_imapik-test-local';
+
 function createQueue(
   send: HttpSend,
   opts: QueueOpts = {},
 ) {
   return new MessageQueue(
     send,
-    'pk_imapik-test-local',
+    TEST_KEY,
     {
       flushIntervalMs: opts.flushIntervalMs,
       flushSize: opts.flushSize,
@@ -122,12 +124,13 @@ describe('MessageQueue', () => {
     queue.enqueue(makeMessage('1'));
 
     const stored = JSON.parse(localStorage.getItem('__imtbl_audience_queue')!);
-    expect(stored).toHaveLength(1);
-    expect(stored[0].messageId).toBe('1');
+    expect(stored.publishableKey).toBe(TEST_KEY);
+    expect(stored.messages).toHaveLength(1);
+    expect(stored.messages[0].messageId).toBe('1');
   });
 
   it('restores messages from localStorage on construction', () => {
-    storage.setItem('queue', [makeMessage('restored')]);
+    storage.setItem('queue', { publishableKey: TEST_KEY, messages: [makeMessage('restored')] });
 
     const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue(okResult);
     const queue = createQueue(send);
@@ -136,7 +139,10 @@ describe('MessageQueue', () => {
   });
 
   it('filters stale messages on restore', () => {
-    storage.setItem('queue', [makeMessage('stale'), makeMessage('fresh')]);
+    storage.setItem('queue', {
+      publishableKey: TEST_KEY,
+      messages: [makeMessage('stale'), makeMessage('fresh')],
+    });
 
     const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue(okResult);
     const queue = createQueue(send, {
@@ -144,6 +150,30 @@ describe('MessageQueue', () => {
     });
 
     expect(queue.length).toBe(1);
+  });
+
+  it('drops a persisted queue belonging to a different publishable key', () => {
+    // A message carries no tenant of its own — the key is only applied as a
+    // header at send time. Restoring another key's batch would re-send it under
+    // ours, delivering one tenant's events into another's project.
+    storage.setItem('queue', {
+      publishableKey: 'pk_imapik-other-tenant',
+      messages: [makeMessage('other-tenant')],
+    });
+
+    const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue(okResult);
+    const queue = createQueue(send);
+
+    expect(queue.length).toBe(0);
+  });
+
+  it('drops a legacy bare-array queue that carries no publishable key', () => {
+    storage.setItem('queue', [makeMessage('legacy')]);
+
+    const send = jest.fn<ReturnType<HttpSend>, Parameters<HttpSend>>().mockResolvedValue(okResult);
+    const queue = createQueue(send);
+
+    expect(queue.length).toBe(0);
   });
 
   it('filters stale messages before a flush attempt, not just on restore', async () => {

--- a/packages/audience/core/src/queue.ts
+++ b/packages/audience/core/src/queue.ts
@@ -12,6 +12,23 @@ import { isBrowser } from './utils';
 const STORAGE_KEY = 'queue';
 const MAX_BATCH_SIZE = 100; // Backend maxItems limit per OAS
 
+/** Pre-namespacing localStorage prefix used by the web SDK's queue. */
+const LEGACY_WEB_PREFIX = '__imtbl_web_';
+
+/**
+ * Persisted queue envelope.
+ *
+ * The publishable key is stored alongside the messages because a message
+ * carries no tenant of its own — the key is only applied as a header at send
+ * time. Without it a restored batch cannot be attributed, and on a host serving
+ * several tenants from one origin it would be re-sent under whichever key
+ * happens to be active, delivering one tenant's events to another.
+ */
+interface PersistedQueue {
+  publishableKey: string;
+  messages: Message[];
+}
+
 export interface MessageQueueOptions {
   /** Override the default API base URL for the ingest endpoint. */
   baseUrl?: string;
@@ -109,10 +126,26 @@ export class MessageQueue {
     this.storagePrefix = options?.storagePrefix;
     this.logPrefix = options?.logPrefix ?? '[audience]';
 
-    const restored = (storage.getItem(STORAGE_KEY, this.storagePrefix) as Message[] | undefined) ?? [];
-    this.messages = this.staleFilter
-      ? restored.filter(this.staleFilter)
-      : restored;
+    this.messages = this.restore();
+  }
+
+  /**
+   * Reload persisted messages, dropping anything that cannot be proven to
+   * belong to this queue's publishable key.
+   *
+   * Two shapes are rejected: a bare array (the pre-namespacing format, which
+   * carries no key at all) and an envelope whose key differs from ours. Both
+   * would otherwise be re-sent under this instance's credential.
+   */
+  private restore(): Message[] {
+    const raw = storage.getItem(STORAGE_KEY, this.storagePrefix);
+    if (!raw || Array.isArray(raw)) return [];
+
+    const persisted = raw as PersistedQueue;
+    if (persisted.publishableKey !== this.publishableKey) return [];
+
+    const messages = persisted.messages ?? [];
+    return this.staleFilter ? messages.filter(this.staleFilter) : messages;
   }
 
   start(): void {
@@ -331,6 +364,23 @@ export class MessageQueue {
   }
 
   private persist(): void {
-    storage.setItem(STORAGE_KEY, this.messages, this.storagePrefix);
+    const envelope: PersistedQueue = {
+      publishableKey: this.publishableKey,
+      messages: this.messages,
+    };
+    storage.setItem(STORAGE_KEY, envelope, this.storagePrefix);
   }
+}
+
+/**
+ * Remove the pre-namespacing web SDK queue.
+ *
+ * Its messages carry no publishable key, so they cannot be re-homed into a
+ * namespaced queue without guessing which tenant they belong to — and guessing
+ * wrong sends one tenant's events to another. Dropped instead. The old key is
+ * only non-empty when the unload flush failed to drain it, so this loses at
+ * most a small number of events, once, per browser.
+ */
+export function clearLegacyQueue(): void {
+  storage.removeItem(STORAGE_KEY, LEGACY_WEB_PREFIX);
 }

--- a/packages/audience/pixel/src/pixel.test.ts
+++ b/packages/audience/pixel/src/pixel.test.ts
@@ -478,6 +478,7 @@ describe('Pixel', () => {
         { forms: undefined, clicks: undefined },
         expect.any(Function),
         expect.any(Function),
+        expect.any(String),
       );
     });
 
@@ -494,6 +495,7 @@ describe('Pixel', () => {
         { forms: false, clicks: true },
         expect.any(Function),
         expect.any(Function),
+        expect.any(String),
       );
     });
 
@@ -510,6 +512,7 @@ describe('Pixel', () => {
         expect.objectContaining({ scroll: false }),
         expect.any(Function),
         expect.any(Function),
+        expect.any(String),
       );
     });
 

--- a/packages/audience/pixel/src/pixel.ts
+++ b/packages/audience/pixel/src/pixel.ts
@@ -123,6 +123,7 @@ export class Pixel {
       { forms: autocapture?.forms, clicks: autocapture?.clicks, scroll: autocapture?.scroll },
       (eventName, properties) => this.track(eventName, properties),
       () => this.consent!.level,
+      this.publishableKey,
     );
     this.teardownAutocapture = autocaptureResult.teardown;
     this.resetScrollDepth = autocaptureResult.resetScroll;
@@ -135,7 +136,7 @@ export class Pixel {
     this.resetScrollDepth?.();
 
     this.sessionId = getOrCreateSessionId(this.domain);
-    const attribution = collectSessionAttribution();
+    const attribution = collectSessionAttribution(this.publishableKey);
     const thirdPartyIds = collectThirdPartyIds();
 
     const message: PageMessage = {

--- a/packages/audience/sdk/src/index.ts
+++ b/packages/audience/sdk/src/index.ts
@@ -12,10 +12,14 @@ export {
   canIdentify,
   AudienceError,
   getAttributionNetwork,
+  collectPageAttribution,
+  clearAttribution,
 } from '@imtbl/audience-core';
 export type { ImmutableAudienceGlobal } from './cdn';
 export type { AudienceConfig } from './types';
-export type { AudienceErrorCode, AutocaptureOptions, AttributionNetwork } from '@imtbl/audience-core';
+export type {
+  Attribution, AudienceErrorCode, AutocaptureOptions, AttributionNetwork,
+} from '@imtbl/audience-core';
 export type {
   AchievementType,
   AchievementUnlockedProperties,

--- a/packages/audience/sdk/src/sdk.test.ts
+++ b/packages/audience/sdk/src/sdk.test.ts
@@ -129,6 +129,97 @@ describe('Audience', () => {
       second.shutdown();
     });
 
+    it('reports MULTIPLE_INSTANCES through onError', () => {
+      // The console warning alone never reaches production monitoring, so
+      // double-initialisation goes unnoticed. onError is the monitorable path.
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const onError = jest.fn();
+
+      const first = createSDK();
+      const second = Audience.init({
+        publishableKey: 'pk_imapik-test-other',
+        consent: 'none',
+        onError,
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'MULTIPLE_INSTANCES' }),
+      );
+
+      warnSpy.mockRestore();
+      first.shutdown();
+      second.shutdown();
+    });
+
+    it('does not report MULTIPLE_INSTANCES for a lone instance', () => {
+      const onError = jest.fn();
+      const sdk = Audience.init({
+        publishableKey: 'pk_imapik-test-local',
+        consent: 'none',
+        onError,
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      sdk.shutdown();
+    });
+
+    it('clears the pre-namespacing storage keys on init', () => {
+      // Legacy entries carry no publishable key, so they cannot be attributed
+      // to a tenant. Dropped rather than migrated — carrying them into a
+      // namespaced key would preserve the cross-tenant replay we are fixing.
+      localStorage.setItem('__imtbl_web_queue', JSON.stringify([{ messageId: 'legacy' }]));
+      sessionStorage.setItem('__imtbl_attribution', JSON.stringify({ utm_source: 'legacy' }));
+
+      const sdk = createSDK();
+
+      expect(localStorage.getItem('__imtbl_web_queue')).toBeNull();
+      expect(sessionStorage.getItem('__imtbl_attribution')).toBeNull();
+      sdk.shutdown();
+    });
+
+    it('scopes the queue storage key to the publishable key', () => {
+      const sdk = createSDK();
+      sdk.track('custom_event', { foo: 'bar' });
+
+      expect(localStorage.getItem('__imtbl_web_pk_imapik-test-local_queue')).not.toBeNull();
+      expect(localStorage.getItem('__imtbl_web_queue')).toBeNull();
+      sdk.shutdown();
+    });
+
+    it('does not replay a previous tenant\'s attribution onto a new key', async () => {
+      // The reported bug: two publishable keys on one origin share a browser
+      // session, and the session-wide attribution cache is read before it is
+      // written, so the first landing's UTMs ride on the second tenant's events.
+      Object.defineProperty(window, 'location', {
+        value: new URL('https://portal.example.com/game-a?utm_source=meta&utm_medium=cpc'),
+        writable: true,
+        configurable: true,
+      });
+      const first = createSDK();
+      first.shutdown();
+
+      Object.defineProperty(window, 'location', {
+        value: new URL('https://portal.example.com/game-b'),
+        writable: true,
+        configurable: true,
+      });
+      const second = Audience.init({
+        publishableKey: 'pk_imapik-test-other',
+        consent: 'full',
+      });
+
+      fetchCalls.length = 0;
+      second.page();
+      await second.flush();
+
+      const pageMessage = sentMessages().find((m) => m.type === 'page');
+      expect(pageMessage).toBeDefined();
+      expect(pageMessage?.properties?.utm_source).toBeUndefined();
+      expect(pageMessage?.properties?.landing_page).toBe('https://portal.example.com/game-b');
+
+      second.shutdown();
+    });
+
     it('adopts imtbl_aid from URL and uses it as the anonymous ID', () => {
       Object.defineProperty(window, 'location', {
         value: {

--- a/packages/audience/sdk/src/sdk.ts
+++ b/packages/audience/sdk/src/sdk.ts
@@ -26,7 +26,11 @@ import {
   truncate,
   collectContext,
   collectSessionAttribution,
+  clearLegacyAttribution,
+  clearLegacyQueue,
   collectThirdPartyIds,
+  AudienceError,
+  invokeOnError,
   getAttributionNetwork as resolveAttributionNetwork,
   getOrCreateSessionId,
   createConsentManager,
@@ -185,7 +189,10 @@ export class Audience {
         onFlush: (ok, count) => this.debug.logFlush(ok, count),
         onError: config.onError,
         staleFilter: (m) => isTimestampValid(m.eventTimestamp),
-        storagePrefix: '__imtbl_web_',
+        // Namespaced per tenant: a host serving several publishable keys from
+        // one origin would otherwise share a single queue, and a restore could
+        // re-send one tenant's persisted events under another's credential.
+        storagePrefix: `__imtbl_web_${publishableKey}_`,
         logPrefix: LOG_PREFIX,
       },
     );
@@ -200,7 +207,7 @@ export class Audience {
       config.baseUrl,
     );
 
-    this.attribution = collectSessionAttribution();
+    this.attribution = collectSessionAttribution(publishableKey);
 
     if (!this.isTrackingDisabled()) this.queue.start();
 
@@ -209,26 +216,43 @@ export class Audience {
       config.autocapture ?? {},
       (eventName, properties) => this.track(eventName, properties),
       () => this.consent.level,
+      publishableKey,
     );
     this.teardownAutocapture = autocaptureResult.teardown;
     this.resetScrollDepth = autocaptureResult.resetScroll;
   }
 
   /**
-   * Create and start the SDK. Warns if another instance is already active —
-   * call `shutdown()` on the previous one first.
+   * Create and start the SDK. Reports `MULTIPLE_INSTANCES` via `onError` if
+   * another instance is already active — call `shutdown()` on the previous one
+   * first.
    */
   static init(config: AudienceConfig): Audience {
     if (!config.publishableKey?.trim()) {
       throw new Error(`${LOG_PREFIX} publishableKey is required`);
     }
     if (Audience.liveInstances > 0) {
+      const message = `${LOG_PREFIX} Multiple SDK instances detected.`
+        + ' Ensure previous instances are shut down to avoid duplicate events.';
       // eslint-disable-next-line no-console
-      console.warn(
-        `${LOG_PREFIX} Multiple SDK instances detected.`
-        + ' Ensure previous instances are shut down to avoid duplicate events.',
-      );
+      console.warn(message);
+      // Also surfaced through onError: the console warning alone never reaches
+      // production monitoring, so double-initialisation goes unnoticed.
+      // Not a transport failure, so there is no status or endpoint to report.
+      invokeOnError(config.onError, new AudienceError({
+        code: 'MULTIPLE_INSTANCES',
+        message,
+        status: 0,
+        endpoint: '',
+      }));
     }
+
+    // One-time cleanup of the pre-namespacing storage keys. Their contents
+    // carry no publishable key, so they cannot be re-homed without guessing
+    // which tenant they belong to — see clearLegacyQueue / clearLegacyAttribution.
+    clearLegacyQueue();
+    clearLegacyAttribution();
+
     Audience.liveInstances += 1;
     return new Audience(config);
   }


### PR DESCRIPTION
# Summary

Scopes the audience SDK's persistent state per publishable key, so a host serving several tenants from one origin no longer leaks tracking state between them.

Linear: [SDK-850](https://linear.app/imtbl/issue/SDK-850/audience-web-sdk-leaks-tracking-state-across-games-on-playimmutablecom)

# Detail and impact of the change

`play.immutable.com` serves a page per studio, so one browser session spans many publishable keys. None of the SDK's persistent state was keyed by publishable key — the key is only applied as a header at send time — so state crossed tenant boundaries.

## Fixed

**Attribution replay (fires on every tenant switch).** `collectSessionAttribution` cached under a single `__imtbl_attribution` sessionStorage key and is read before it is written, so it was never recaptured. The first landing's `landing_page`, `utm_*` and click IDs were merged onto every later tenant's first `page` event. Now cached per publishable key.

**Cross-tenant event disclosure via the queue (rare).** `MessageQueue` restored whatever was persisted under one `__imtbl_web_queue` localStorage key and applied the publishable key only when sending, so a batch left behind by one tenant could be re-sent under another's credential. The queue is now namespaced per key, and the persisted record carries the key it belongs to so a mismatched restore is dropped rather than guessed at. Needs the ~5s flush window to be missed (in-flight flush at unload, >100 backlog, or a failed flush), so it is much rarer than the attribution replay.

## Changed

`collectSessionAttribution`, `clearAttribution` and `setupAutocapture` now take the publishable key. Internal to the monorepo — the only call sites are `sdk` and `pixel`, both updated here.

`Audience.init` now reports `MULTIPLE_INSTANCES` through the existing `onError` callback alongside the console warning. The condition was already detected, but only via `console.warn`, which never reaches production monitoring. Deliberately not escalated to a throw: an analytics SDK should not be able to take down its host app, and it would break any consumer currently double-initialising quietly.

## Added

`clearAttribution` and `collectPageAttribution` are now exported from `@imtbl/audience`. Both already existed in core — `clearAttribution` had no callers and was unexported, `collectPageAttribution` was unreachable from the public surface.

## Removed

Pre-namespacing storage keys are deleted on init rather than migrated. Their contents carry no publishable key, so re-homing them would preserve exactly the cross-tenant replay this fixes. The old queue key is only non-empty when the unload flush failed to drain it, so the cost is a small one-time loss per browser.

# Anything else worth calling out?

**No behaviour change for single-tenant consumers.** A studio site only ever has one publishable key, so the namespaced key is stable and behaviour is byte-identical to today. This is the main reason namespacing was chosen over having consumers call `clearAttribution` imperatively — it is correct by construction and needs no coordination from the consuming app.

**Draining the legacy queue was considered and rejected.** Persisted messages carry no key (`baseMessage` stamps `messageId`, `eventTimestamp`, `anonymousId`, `surface`, `context`, `consentLevel`, `sessionId`), so a drain is necessarily blind and would re-send one tenant's events under whichever key is active — reintroducing the bug once per affected user, via the migration meant to fix it. The persisted record now carries the key so a future migration is not blind.

**One known behaviour change worth a second opinion:** a campaign landing on a portal's homepage and funnelling into a tenant page no longer passes attribution through, because no instance exists on the homepage to capture it. Today that works only as a side effect of the shared cache.

**Testing.** 351 core + 137 sdk + 51 pixel tests pass; typecheck clean across all three packages; `oxlint` clean (pre-existing warnings only). New coverage: per-key attribution scoping, legacy-key clearing, queue key-mismatch and bare-array rejection, `MULTIPLE_INSTANCES` via `onError`, and an end-to-end assertion that a second key's first `page` event carries its own landing page rather than the first key's.

`packages/audience/sdk/test/cdn-artifact.test.ts` fails in this environment (`_imtbl_audience_core is not defined`), but fails identically on a clean checkout of `main` — pre-existing and unrelated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQSGu6ukLTCTA1SgjFp1Bt)_