### PR TITLE
feat(auth): send OIDC login_hint for direct email login (PLT-1666)

### DIFF
--- a/packages/auth/src/Auth.test.ts
+++ b/packages/auth/src/Auth.test.ts
@@ -504,6 +504,45 @@ describe('Auth', () => {
       );
     });
 
+    it('forwards the email as login_hint for direct email login (PLT-1666)', async () => {
+      const mockOidcUser = {
+        id_token: 'token',
+        access_token: 'access',
+        refresh_token: 'refresh',
+        expired: false,
+        profile: { sub: 'user-123', email: 'test@example.com', nickname: 'tester' },
+      };
+
+      (decodeJwtPayload as jest.Mock).mockReturnValue({
+        username: 'username123',
+        passport: undefined,
+      });
+
+      mockUserManager.signinPopup.mockResolvedValue(mockOidcUser);
+
+      const auth = Object.create(Auth.prototype) as Auth;
+      (auth as any).userManager = mockUserManager;
+      (auth as any).config = {
+        popupOverlayOptions: { disableHeadlessLoginPromptOverlay: true },
+      };
+      getDetailMock.mockReturnValue('runtime-id-value');
+
+      await (auth as any).loginWithPopup({
+        directLoginMethod: 'email',
+        email: 'test@example.com',
+      });
+
+      expect(mockUserManager.signinPopup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extraQueryParams: expect.objectContaining({
+            direct: 'email',
+            email: 'test@example.com',
+            login_hint: 'test@example.com',
+          }),
+        }),
+      );
+    });
+
     it('rejects when signinPopup rejects', async () => {
       const error = new Error('Authentication failed');
       mockUserManager.signinPopup.mockRejectedValue(error);

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -454,6 +454,12 @@ export class Auth {
         if (emailValue) {
           params.direct = directLoginOptions.directLoginMethod;
           params.email = emailValue;
+          // Standard OIDC login_hint so the hosted (Ory/Hydra) login path also
+          // receives the email: Hydra does not relay the custom `email` param to
+          // the login UI, but it does relay login_hint onto the login request, so
+          // the branded page can resume at the OTP screen (PLT-1666). The Auth0
+          // path keeps using `email` above and is unaffected.
+          params.login_hint = emailValue;
         }
       } else {
         params.direct = directLoginOptions.directLoginMethod;

--- a/packages/auth/src/login/standalone.ts
+++ b/packages/auth/src/login/standalone.ts
@@ -414,6 +414,11 @@ async function buildAuthorizationUrl(
       if (directLoginOptions.email) {
         url.searchParams.set('direct', 'email');
         url.searchParams.set('email', directLoginOptions.email);
+        // Standard OIDC login_hint so the hosted (Ory/Hydra) login path receives the
+        // email too — Hydra relays login_hint onto the login request (the custom
+        // `email` param is dropped), letting the branded page resume at the OTP
+        // screen (PLT-1666). The Auth0 path keeps using `email` and is unaffected.
+        url.searchParams.set('login_hint', directLoginOptions.email);
       }
     } else {
       url.searchParams.set('direct', directLoginOptions.directLoginMethod);


### PR DESCRIPTION
## What
On the hosted Ory login popup, after the user enters their email in the embedded prompt the popup **restarts at step 0** instead of resuming at the OTP screen (Auth0 opened straight on the code screen). [PLT-1666](https://linear.app/imtbl/issue/PLT-1666).

Root cause: the SDK forwards the email as the **custom** `email` query param on `/authorize`. On the Ory/Hydra path Hydra does not relay custom params to the login UI, so the branded page only ever sees `login_challenge` and starts over.

## Change
Additionally set the **standard OIDC `login_hint`** (= the email) on the popup `/authorize`, alongside the existing `email`/`direct` params. Hydra **does** relay `login_hint` onto the login request, and Kratos surfaces it on the login flow, so the branded page can pre-fill + auto-send the code. Mirrored in the standalone/NextAuth popup builder.

- `Auth.ts` `buildExtraQueryParams` (main popup path)
- `login/standalone.ts` `buildAuthorizationUrl` (standalone path)

Additive and Auth0-safe: the Auth0 path still consumes `email`; `login_hint` is just an extra standard param it ignores/pre-fills harmlessly.

## Paired change
Consumed by the branded page in passport-login (reads `oauth2_login_request.oidc_context.login_hint` off the flow and auto-sends the code). This SDK change is a no-op until that lands, and vice-versa.

## Scope
Email one-time-code method only. Social method resume (no OIDC-standard method hint through Hydra) is a separate follow-up.

## Tests
`Auth.test.ts` — new case asserts `login_hint` is forwarded for direct email login. Full suite green (20/20); `tsc`/eslint clean.