### PR TITLE
fix(checkout): surface Transak order status on sale SALE_SUCCESS event

### DIFF
--- a/packages/checkout/sdk/src/widgets/definitions/events/sale.ts
+++ b/packages/checkout/sdk/src/widgets/definitions/events/sale.ts
@@ -33,6 +33,15 @@ export type SaleSuccess = {
   }[];
   /** The order reference id, use it to trace order throughout flow */
   transactionId: string;
+  /**
+   * Settlement status of the order. For card payments this mirrors the Transak
+   * order status: `'PROCESSING'` while the payment is captured but the mint is
+   * not yet settled (typically a couple of minutes), and `'COMPLETED'` once
+   * settled. Undefined for crypto payments, which settle on-chain synchronously.
+   * Do not treat the sale as final until settlement is confirmed — reconcile
+   * server-side using `transactionId`.
+   */
+  status?: string;
   [key: string]: unknown;
 };
 

--- a/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/SaleWidgetEvents.ts
@@ -28,6 +28,7 @@ export const sendSaleSuccessEvent = (
   transactions: ExecutedTransaction[] = [],
   tokenIds: string[] = [],
   transactionId: string = '',
+  status?: string,
 ) => {
   const event = new CustomEvent<
   WidgetEvent<WidgetType.SALE, SaleEventType.SUCCESS>
@@ -39,6 +40,7 @@ export const sendSaleSuccessEvent = (
         transactions,
         tokenIds,
         transactionId,
+        status,
       },
     },
   });

--- a/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
+++ b/packages/checkout/widgets-lib/src/widgets/sale/hooks/useSaleEvents.ts
@@ -90,6 +90,7 @@ export const useSaleEvent = () => {
       transactions,
       tokenIds,
       details.transactionId,
+      details.orderStatus,
     );
   };
 


### PR DESCRIPTION
## Problem

The sale widget's **card path** emits `SALE_SUCCESS` as soon as Transak reports **PROCESSING** — the card payment is captured but the mint has **not** settled yet (settlement takes ~2–3 min). The host payload is `{ paymentMethod, transactions, tokenIds, transactionId }` with **no field to distinguish PROCESSING from COMPLETED**, so integrators are told "success" while the order is still processing and can't tell the two apart.

Root cause in `widgets/sale/views/PayWithCard.tsx`:
- `onOrderCompleted` is wired to the **same handler** as `onOrderProcessing`, so the success path fires on `TRANSAK_ORDER_SUCCESSFUL` + status `PROCESSING`.
- The handler builds a `details` object that already contains `orderStatus`, but only `details.transactionId` is forwarded — `orderStatus` is dropped before the event.

## Change (additive, non-breaking)

- Add an optional **`status`** field to the public `SaleSuccess` event type (`checkout-sdk`).
- Thread the real Transak order status through `useSaleEvents.sendSuccessEvent` → `SaleWidgetEvents.sendSaleSuccessEvent` → the host `SALE_SUCCESS` payload.

Integrators can branch on `status` (`'PROCESSING'` vs `'COMPLETED'`) and reconcile settlement server-side via `transactionId`. Crypto payments (synchronous) leave `status` undefined, so existing consumers are unaffected.

## Not in scope (separate, breaking)

Does **not** change *when* success fires or the auto-close-on-PROCESSING behaviour — those alter existing semantics and need their own breaking change / product decision. This PR is the minimal, backward-compatible unblock.

## Impact

The premature-success behaviour affects **every live card-checkout integrator**, not just one — e.g. Ubisoft/Fates, Chess Universe, Gods Unchained, TokenTrove, Striker Manager (per checkout analytics).

## Tests

`checkout-sdk` typecheck passes; `checkout-widgets` typecheck clean. No behavioural change to existing flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)